### PR TITLE
docs: update all remaining references to new tool names

### DIFF
--- a/specs/octave-mcp-architecture.oct.md
+++ b/specs/octave-mcp-architecture.oct.md
@@ -177,7 +177,7 @@ REQUIREMENTS::[
 // Two primitives. Pipeline exposed via verbose option.
 
 TOOL_INGEST:
-  NAME::octave.ingest
+  NAME::octave_ingest
   PURPOSE::bring_information_into_system_safely
 
   PARAMETERS:
@@ -196,7 +196,7 @@ TOOL_INGEST:
   PIPELINE::[PREPARSE→PARSE→NORMALIZE→VALIDATE→REPAIR(if_fix)→VALIDATE]
 
 TOOL_EJECT:
-  NAME::octave.eject
+  NAME::octave_eject
   PURPOSE::present_information_out_of_system_appropriately
 
   PARAMETERS:
@@ -297,8 +297,8 @@ PHASE_1[core_library]:
 PHASE_2[mcp_server]:
   COMPONENTS::[
     wrap_library_as_MCP_tools,
-    octave.ingest_tool,
-    octave.eject_tool,
+    octave_ingest_tool,
+    octave_eject_tool,
     schema_repository[builtin+custom]
   ]
   DELIVERABLE::MCP_server_package
@@ -397,7 +397,7 @@ ALIGNMENT::[
 ]
 
 MAPPING::[
-  OCTAVE_MCP::octave.ingest|octave.eject,
+  OCTAVE_MCP::octave_ingest|octave_eject,
   HESTAI_MCP::document_submit|context_update
 ]
 

--- a/src/octave_mcp/mcp/base_tool.py
+++ b/src/octave_mcp/mcp/base_tool.py
@@ -84,7 +84,7 @@ class BaseTool(ABC):
         """Get the tool name.
 
         Returns:
-            Tool name (e.g., "octave.ingest")
+            Tool name (e.g., "octave_ingest")
         """
         pass
 

--- a/src/octave_mcp/mcp/eject.py
+++ b/src/octave_mcp/mcp/eject.py
@@ -1,6 +1,6 @@
 """MCP tool for OCTAVE eject (P2.3).
 
-Implements octave.eject tool with projection modes:
+Implements octave_eject tool with projection modes:
 - canonical: Full document, lossy=false
 - authoring: Lenient format, lossy=false
 - executive: STATUS,RISKS,DECISIONS only, lossy=true
@@ -15,7 +15,7 @@ from octave_mcp.mcp.base_tool import BaseTool, SchemaBuilder
 
 
 class EjectTool(BaseTool):
-    """MCP tool for octave.eject - projection and formatting."""
+    """MCP tool for octave_eject - projection and formatting."""
 
     def get_name(self) -> str:
         """Get tool name."""

--- a/src/octave_mcp/mcp/ingest.py
+++ b/src/octave_mcp/mcp/ingest.py
@@ -1,6 +1,6 @@
 """MCP tool for OCTAVE ingest (P2.2).
 
-Implements octave.ingest tool with pipeline:
+Implements octave_ingest tool with pipeline:
 PREPARSE→PARSE→NORMALIZE→VALIDATE→REPAIR(if fix)→VALIDATE
 """
 
@@ -15,7 +15,7 @@ from octave_mcp.mcp.base_tool import BaseTool, SchemaBuilder
 
 
 class IngestTool(BaseTool):
-    """MCP tool for octave.ingest - lenient to canonical pipeline."""
+    """MCP tool for octave_ingest - lenient to canonical pipeline."""
 
     def get_name(self) -> str:
         """Get tool name."""

--- a/src/octave_mcp/mcp/server.py
+++ b/src/octave_mcp/mcp/server.py
@@ -1,6 +1,6 @@
 """MCP server entry point (P2.4).
 
-Provides the MCP server with octave.ingest and octave.eject tools.
+Provides the MCP server with octave_ingest and octave_eject tools.
 """
 
 import asyncio
@@ -48,7 +48,7 @@ def create_server() -> Server:
         """Route tool calls to appropriate handler.
 
         Args:
-            name: Tool name (octave.ingest or octave.eject)
+            name: Tool name (octave_ingest or octave_eject)
             arguments: Tool arguments
 
         Returns:

--- a/tests/integration/test_e2e.py
+++ b/tests/integration/test_e2e.py
@@ -408,7 +408,7 @@ DATA::value
 
         request = CallToolRequest(
             method="tools/call",
-            params={"name": "octave.ingest", "arguments": {"content": invalid_content, "schema": "TEST"}},
+            params={"name": "octave_ingest", "arguments": {"content": invalid_content, "schema": "TEST"}},
         )
 
         from mcp.types import CallToolRequest as CallToolRequestType

--- a/tests/integration/test_server.py
+++ b/tests/integration/test_server.py
@@ -76,7 +76,7 @@ class TestMCPServer:
 
     @pytest.mark.asyncio
     async def test_call_ingest_tool_succeeds(self, server):
-        """Can call octave.ingest tool."""
+        """Can call octave_ingest tool."""
         from mcp.types import CallToolRequest
 
         content = """===TEST===
@@ -103,7 +103,7 @@ STATUS::active
 
     @pytest.mark.asyncio
     async def test_call_eject_tool_succeeds(self, server):
-        """Can call octave.eject tool."""
+        """Can call octave_eject tool."""
         from mcp.types import CallToolRequest
 
         content = """===TEST===

--- a/tests/unit/test_eject_tool.py
+++ b/tests/unit/test_eject_tool.py
@@ -1,4 +1,4 @@
-"""Test cases for octave.eject MCP tool (P2.3).
+"""Test cases for octave_eject MCP tool (P2.3).
 
 Tests projection modes:
 - canonical: Full document, lossy=false

--- a/tests/unit/test_ingest_tool.py
+++ b/tests/unit/test_ingest_tool.py
@@ -1,4 +1,4 @@
-"""Tests for octave.ingest MCP tool (P2.2).
+"""Tests for octave_ingest MCP tool (P2.2).
 
 Tests the ingest tool pipeline: PREPARSE→PARSE→NORMALIZE→VALIDATE→REPAIR→VALIDATE
 """


### PR DESCRIPTION
## Summary
Updates all remaining references from `octave.ingest`/`octave.eject` to `octave_ingest`/`octave_eject` throughout codebase and documentation.

This is a follow-up to PR #16 which renamed the actual tool names, ensuring complete consistency across all documentation, comments, and specifications.

## Changes
### Source Code Documentation
- `src/octave_mcp/mcp/ingest.py` - Update docstrings and class docs
- `src/octave_mcp/mcp/eject.py` - Update docstrings and class docs
- `src/octave_mcp/mcp/server.py` - Update module docstring and parameter docs
- `src/octave_mcp/mcp/base_tool.py` - Update example in `get_name()` docstring

### Test Documentation
- `tests/unit/test_ingest_tool.py` - Update module docstring
- `tests/unit/test_eject_tool.py` - Update module docstring
- `tests/integration/test_server.py` - Update test docstrings
- `tests/integration/test_e2e.py` - Update final tool call reference

### Specifications
- `specs/octave-mcp-architecture.oct.md` - Update all tool name references (4 locations)

## Quality Gates
✅ **Lint:** `ruff check src tests` → All checks passed!  
✅ **Typecheck:** `mypy src` → Success: no issues found in 22 source files  
✅ **Pre-commit hooks:** All passed

## Verification
No old tool name references remain outside of archived files:
```bash
grep -r "octave\.ingest\|octave\.eject" --include="*.py" --include="*.md" . | grep -v "_archive/" | wc -l
# Output: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)