### PR TITLE
docs: Integrate OCTAVE skills and document architectural layers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,9 +188,20 @@ octave-mastery      # For advanced design
 
 For Claude Code users, these skills integrate into your workspace and activate via keyword triggers automatically.
 
+## Architectural Layers & Ownership
+
+The system is organized into three layers with clear responsibility boundaries:
+
+- **L1 (OCTAVE Repository)**: Owns language specification, syntax, operators, and profiles
+- **L2 (Orchestration Layer)**: Owns governance tooling, prompt assembly, context injection (e.g., HestAI-MCP)
+- **L3 (Project Layer)**: Owns role definitions, local policies, success criteria
+
+See **`specs/octave-5-llm-agents.oct.md` (§0::OWNERSHIP_AND_BOUNDARIES)** for the complete architectural breakdown and responsibility allocation.
+
 ## Resources
 
 - **Quick Reference**: `guides/llm-octave-quick-reference.oct.md`
 - **Core Spec**: `specs/octave-5-llm-core.oct.md`
+- **Architecture**: `specs/octave-5-llm-agents.oct.md` (layer ownership and boundaries)
 - **API Docs**: `docs/api.md`
 - **MCP Setup**: `docs/mcp-configuration.md`

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,70 @@
+# OCTAVE Claude Code Skills
+
+This directory contains three specialized Claude Code skills that enhance LLM and agent capabilities for working with OCTAVE documents.
+
+## Quick Start
+
+Three skills form a progression:
+
+1. **octave-literacy** – Foundation skill for core OCTAVE syntax
+2. **octave-compression** – Specialized workflow for prose-to-OCTAVE transformation
+3. **octave-mastery** – Advanced semantic vocabulary and architectural patterns
+
+Load them in this order (octave-compression and octave-mastery require octave-literacy first).
+
+## Skill Overview
+
+### octave-literacy
+**Purpose**: Fundamental reading and writing capability for the OCTAVE format.
+
+Provides core syntax rules, critical operators, and structural competence for working with OCTAVE documents.
+
+**Triggers**: `octave format`, `write octave`, `octave syntax`, `structured output`
+
+### octave-compression
+**Purpose**: Transform verbose prose into semantic OCTAVE structures.
+
+Provides a 4-phase workflow (Read → Extract → Compress → Validate) with rules for achieving 60-80% token reduction while preserving decision logic fidelity.
+
+**Requires**: octave-literacy
+
+**Triggers**: `compress to octave`, `semantic compression`, `documentation refactoring`
+
+### octave-mastery
+**Purpose**: Advanced semantic vocabulary and architectural patterns.
+
+Provides the Semantic Pantheon (mythological vocabulary for complex concepts), narrative dynamics, system forces, and advanced syntax patterns for high-density specifications and agent design.
+
+**Requires**: octave-literacy
+
+**Triggers**: `octave architecture`, `agent design`, `semantic pantheon`, `advanced octave`
+
+## Installation
+
+For Claude Code users:
+
+1. Skills in this directory are automatically discoverable
+2. Activate via keyword triggers in your prompts (see "Triggers" above)
+3. Or explicitly load: `/load octave-literacy`
+
+For other systems supporting YAML frontmatter skills (Codex, Gemini):
+
+1. Each skill is in `skill-name/SKILL.md` format
+2. Copy the SKILL.md file to your system's skills directory
+3. Register in your platform's configuration
+
+## For Developers
+
+Each skill follows the OCTAVE skills specification (`specs/octave-5-llm-skills.oct.md`):
+
+- **Name**: `octave-[literacy|compression|mastery]`
+- **Description**: Includes triggers and use cases
+- **Format**: YAML frontmatter + OCTAVE body
+- **Tools**: Read-only (no modifications)
+- **Size**: All under 500 lines (skill constraint)
+
+## See Also
+
+- **Guides**: `guides/` for usage documentation and compression rules
+- **Specs**: `specs/octave-5-llm-core.oct.md` for complete OCTAVE specification
+- **AGENTS.md**: Agent guidance with skills documentation and architectural overview

--- a/skills/octave-compression/SKILL.md
+++ b/skills/octave-compression/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: octave-compression
+description: Specialized workflow for transforming verbose natural language into semantic OCTAVE structures. REQUIRES octave-literacy to be loaded first. Use when refactoring documentation, generating knowledge artifacts, or compressing context. Triggers on: compress to octave, semantic compression, documentation refactoring.
+allowed-tools: Read
+---
+
+# OCTAVE Compression Skill
+
+===OCTAVE_COMPRESSION===
+META:
+  TYPE::SKILL
+  VERSION::"2.1"
+  PURPOSE::"Workflow for transforming prose into semantic density"
+  REQUIRES::octave-literacy
+  TIER::LOSSLESS
+
+§1::COMPRESSION_MANDATE
+  TARGET::"60-80% token reduction with 100% decision-logic fidelity"
+  PRINCIPLE::"Semantics > Syntax Rigidity"
+  TRUTH::"Dense ≠ Obscure. Preserve the causal chain."
+
+§2::TRANSFORMATION_WORKFLOW
+  PHASE_1_READ::[
+    ANALYZE::"Understand before compressing",
+    IDENTIFY::[Redundancy, Verbosity, Causal_Chains],
+    MAP::"Logic flow (A leads to B)"
+  ]
+
+  PHASE_2_EXTRACT::[
+    CORE_PATTERNS::"Essential decision logic",
+    REASONING::"BECAUSE statements (preserve the 'why')",
+    EVIDENCE::"Metrics and concrete examples",
+    TRANSFER::"HOW-to mechanics"
+  ]
+
+  PHASE_3_COMPRESS::[
+    APPLICATION::"Apply operators defined in octave-literacy",
+    HIERARCHY::"Group related concepts under parent keys",
+    ARRAYS::"Convert repetitive lists to [item1, item2]",
+    MYTHOLOGY::"If complex pattern, load octave-mastery for archetypes"
+  ]
+
+  PHASE_4_VALIDATE::[
+    FIDELITY::"Is the logic intact?",
+    GROUNDING::"Is there at least 1 concrete example?",
+    NAVIGABILITY::"Can a human scan it?"
+  ]
+
+§3::COMPRESSION_RULES
+  RULE_1::"Preserve CAUSALITY (X→Y because Z)"
+  RULE_2::"Drop stopwords (the, is, a, of)"
+  RULE_3::"One example per 200 tokens of abstraction"
+  RULE_4::"Explicit Tradeoffs (GAIN _VERSUS_ LOSS)"
+  RULE_5::"Use Mythological Encoding if complexity demands it"
+
+§4::ANTI_PATTERNS
+  AVOID::[
+    "Markdown inside OCTAVE blocks",
+    "JSON/YAML syntax (no curly braces, no trailing commas)",
+    "Deep nesting (>3 levels)",
+    "Loss of numbers or IDs"
+  ]
+
+===END===

--- a/skills/octave-literacy/SKILL.md
+++ b/skills/octave-literacy/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: octave-literacy
+description: Fundamental reading and writing capability for the OCTAVE format. Inject this to give an agent basic structural competence without the overhead of full architectural specifications. Triggers on: octave format, write octave, octave syntax, structured output.
+allowed-tools: Read
+---
+
+# OCTAVE Literacy Skill
+
+===OCTAVE_LITERACY===
+META:
+  TYPE::SKILL
+  VERSION::"1.0"
+  PURPOSE::"Essential syntax and operators for basic OCTAVE competence"
+  TIER::LOSSLESS
+
+§1::CORE_SYNTAX
+  ASSIGNMENT::KEY::value   // Double colon is MANDATORY for data
+  BLOCK::KEY:[indent_2]    // Single colon + newline + 2 spaces starts a block
+  LIST::[a,b,c]            // Brackets for collections
+  STRING::"value"          // Quotes required if contains spaces or special chars
+  COMMENT:://              // Standard comment syntax
+
+§2::OPERATORS
+  →::Flow (Step 1 → Step 2 → Step 3)
+  ⊕::Synthesis (Component A ⊕ Component B = New Whole)
+  ⇌::Tension (Speed ⇌ Quality)
+  ⧺::Concatenation (Prefix ~ Suffix)
+  §::Target (→§DECISION_LOG)
+
+§3::CRITICAL_RULES
+  1::No spaces around assignment :: (KEY::value, not KEY :: value)
+  2::Indent exactly 2 spaces per level (NO TABS)
+  3::All keys must be [A-Z, a-z, 0-9, _]
+  4::Envelopes are ===NAME=== at start and ===END=== at finish
+
+§4::EXAMPLE_BLOCK
+  ===EXAMPLE===
+  STATUS::ACTIVE
+  PHASES:
+    PLAN::[Research → Design]
+    BUILD::[Code ⊕ Test]
+  METRICS:
+    SPEED::"High"
+    QUALITY::"Verified"
+  ===END===
+
+===END===

--- a/skills/octave-mastery/SKILL.md
+++ b/skills/octave-mastery/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: octave-mastery
+description: Advanced semantic vocabulary and architectural patterns for the OCTAVE format. REQUIRES octave-literacy to be loaded first. Use for designing agents, crafting high-density specifications, or system architecture. Provides access to the Semantic Pantheon (Archetypes) and holographic patterns. Triggers on: octave architecture, agent design, semantic pantheon, advanced octave.
+allowed-tools: Read
+---
+
+# OCTAVE Mastery Skill
+
+===OCTAVE_MASTERY===
+META:
+  TYPE::SKILL
+  VERSION::"2.0"
+  PURPOSE::"Expert-level OCTAVE application: Archetypes, Advanced Syntax, Strategy"
+  REQUIRES::octave-literacy
+  TIER::LOSSLESS
+
+§1::SEMANTIC_PANTHEON
+  // The complete vocabulary for semantic compression
+  DOMAINS:
+    ZEUS::"Executive function, authority, strategic direction, final arbitration"
+    ATHENA::"Strategic wisdom, planning, elegant solutions, deliberate action"
+    APOLLO::"Analytics, data, insight, clarity, prediction, revealing truth"
+    HERMES::"Communication, translation, APIs, networking, messaging, speed"
+    HEPHAESTUS::"Infrastructure, tooling, engineering, automation, system architecture"
+    ARES::"Security, defense, stress testing, conflict simulation, adversarial analysis"
+    ARTEMIS::"Monitoring, observation, logging, alerting, precision targeting of issues"
+    POSEIDON::"Data lakes, storage, databases, unstructured data pools"
+    DEMETER::"Resource allocation, budgeting, system growth, scaling"
+    DIONYSUS::"User experience, engagement, creativity, chaotic innovation"
+
+§2::NARRATIVE_DYNAMICS
+  PATTERNS:
+    ODYSSEAN::"Long, transformative journey with a clear goal"
+    SISYPHEAN::"Repetitive, endless maintenance (e.g., tech debt)"
+    PROMETHEAN::"Breakthrough innovation challenging the status quo"
+    ICARIAN::"Overreach due to early success leading to failure"
+    PANDORAN::"Action unleashing complex, unforeseen problems"
+    TROJAN::"Hidden payload changing system from within"
+    GORDIAN::"Unconventional solution to impossible problem"
+    ACHILLEAN::"Single critical point of failure"
+    PHOENICIAN::"Necessary destruction and rebirth (refactoring)"
+
+§3::SYSTEM_FORCES
+  DYNAMICS:
+    HUBRIS::"Dangerous overconfidence"
+    NEMESIS::"Inevitable corrective consequence"
+    KAIROS::"Critical, fleeting window of opportunity"
+    CHRONOS::"Constant linear time pressure"
+    CHAOS::"Entropy and disorder"
+    COSMOS::"Emergence of order"
+
+§4::ADVANCED_SYNTAX
+  // Extends octave-literacy with holographic and type patterns
+  HOLOGRAPHIC::KEY::["value"∧CONSTRAINT→§TARGET]
+  INLINE_OBJECT::{{key:value, key2:value2}}
+  TYPE_DISAMBIGUATION::[
+    STRING::"42",
+    NUMBER::42,
+    BOOL::true
+  ]
+
+§5::ANTI_PATTERNS
+  SMELLS::[
+    "Isolated Lists (no relationships)",
+    "Flat Hierarchies (lack of grouping)",
+    "Buried Networks (relationships hidden in prose)",
+    "Operator Soup (A+B->C~D all in one line)"
+  ]
+
+===END===


### PR DESCRIPTION
## Summary

This PR completes the documentation tidyup by:
1. Integrating the three OCTAVE Claude Code skills into the repository
2. Adding architectural layers and ownership documentation
3. Making skills discoverable and usable from the repository itself

## Changes

### New: skills/ Directory
Created a dedicated skills directory with three Claude Code skills:

- **skills/octave-literacy/SKILL.md** – Foundation skill for core OCTAVE syntax and operators
- **skills/octave-compression/SKILL.md** – Workflow skill for transforming prose into OCTAVE (60-80% token reduction)
- **skills/octave-mastery/SKILL.md** – Advanced skill for semantic vocabulary and architectural patterns
- **skills/README.md** – Installation guidance and skill overview

### Updated: AGENTS.md
- Added comprehensive "Claude Code Skills" section documenting all three skills with triggers and usage patterns
- Added "Architectural Layers & Ownership" section:
  - L1: OCTAVE Repository (language specification)
  - L2: Orchestration Layer (governance tooling)
  - L3: Project Layer (roles and policies)
- Added reference to `specs/octave-5-llm-agents.oct.md (§0::OWNERSHIP_AND_BOUNDARIES)`

### Updated: guides/README.md
- Added quick reference table for Claude Code skills
- Links to full documentation in AGENTS.md

## Benefits

- ✅ Skills are now part of the repository (not just local ~/.claude/skills/)
- ✅ Multi-platform support (Claude Code, Codex, Gemini)
- ✅ Clear progression path: literacy → compression → mastery
- ✅ Architectural ownership boundaries documented and discoverable
- ✅ All skills follow OCTAVE skills specification format

## Testing

All pre-push quality checks passed:
- Ruff linting
- MyPy type checking
- Pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)