### PR TITLE
chore: add .hestai infrastructure for session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,14 @@ htmlcov/
 # Claude Code
 CLAUDE.md
 
-# HestAI session files
-.hestai/
+# HestAI report scratch area
+.hestai/reports/scratch/
+
+# Active Sessions (Ephemeral)
+.hestai/sessions/active/
+
+# Operational timestamps (session-specific state)
+.hestai/last_cleanup
 
 # Git worktrees
 worktrees/

--- a/.hestai
+++ b/.hestai
@@ -1,0 +1,1 @@
+/Volumes/OCTAVE/.hestai-state-wt-octave-f44817b


### PR DESCRIPTION
## Summary

Updates .gitignore to properly track .hestai infrastructure while ignoring ephemeral session files.

### Changes
- Update .gitignore patterns for .hestai directory
- Track .hestai symlink (points to worktree-specific state directory)
- Exclude ephemeral files: `reports/scratch/`, `sessions/active/`, `last_cleanup`

### Why
Enables session archives and governance files to be committed while keeping active session state out of version control.

## Test plan
- [x] Pre-commit hooks pass
- [x] No sensitive session data exposed

🤖 Generated with [Claude Code](https://claude.com/claude-code)