### PR TITLE
fix(parser): consume bracket annotations after values to preserve indentation tracking

### DIFF
--- a/src/octave_mcp/core/parser.py
+++ b/src/octave_mcp/core/parser.py
@@ -541,6 +541,18 @@ class Parser:
 
             # If we consumed colons, return as colon-joined path
             if len(parts) > 1:
+                # GH#85: Consume bracket annotation if present after colon-path value
+                # Examples: HERMES:API_TIMEOUT[note], MODULE:SUB[annotation]
+                # Must consume before returning so indentation tracking sees NEWLINE
+                if self.current().type == TokenType.LIST_START:
+                    bracket_depth = 1
+                    self.advance()  # Consume [
+                    while bracket_depth > 0 and self.current().type != TokenType.EOF:
+                        if self.current().type == TokenType.LIST_START:
+                            bracket_depth += 1
+                        elif self.current().type == TokenType.LIST_END:
+                            bracket_depth -= 1
+                        self.advance()
                 return ":".join(parts)
 
             # GH#66: Continue capturing consecutive identifiers as multi-word value


### PR DESCRIPTION
## Summary

- Fix bracket annotations breaking indentation tracking for subsequent lines
- When parsing values with bracket annotations like `DONE[annotation]`, the parser now correctly consumes the entire bracket annotation before returning
- This ensures the parser ends at NEWLINE instead of LIST_START, preserving the indentation tracking introduced in #81

## Root Cause

`parse_value()` in the IDENTIFIER branch didn't consume bracket annotations `[...]` after values. The parser ended at `LIST_START` instead of `NEWLINE`, causing the GH#81 indentation tracking logic to incorrectly detect a dedent and break out of block parsing prematurely.

## Changes

- **src/octave_mcp/core/parser.py**: Added bracket consumption logic after value parsing (lines 615-629), using the same pattern as `parse_section_marker()`
- **tests/unit/test_parser_assignment_brackets.py**: 5 new test cases covering sibling preservation, nested brackets, multi-level nesting, empty brackets, and complex content

## Test plan

- [x] New tests in `test_parser_assignment_brackets.py` pass
- [x] All 561 existing tests pass
- [x] mypy clean
- [x] ruff clean
- [x] CRS review (Codex): APPROVED
- [x] CE review (Gemini): APPROVED

Fixes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)