### PR TITLE
feat: add DISABLED_TOOLS environment variable support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# OCTAVE MCP Server Environment Configuration
+# Copy this file to .env and customize as needed
+
+# Optional: Tool Selection
+# Comma-separated list of tools to disable. If not set, all tools are enabled.
+# Available tools: octave_validate, octave_write, octave_eject, octave_debate_to_octave
+#
+# Example: Disable the debate-hall converter if not using debate-hall-mcp
+# DISABLED_TOOLS=octave_debate_to_octave
+#
+# Example: Only enable validate and write tools
+# DISABLED_TOOLS=octave_eject,octave_debate_to_octave


### PR DESCRIPTION
## Summary

- Add `DISABLED_TOOLS` environment variable to selectively disable MCP tools
- Useful for users who don't need all tools (e.g., `octave_debate_to_octave` when not using debate-hall-mcp)
- Follows the same pattern as pal-mcp-server for consistency

## Changes

- **`src/octave_mcp/mcp/server.py`**: Add tool filtering logic with `parse_disabled_tools()` and `filter_tools()` functions
- **`.env.example`**: Document the configuration option
- **`tests/unit/test_server_integration.py`**: Add 10 comprehensive tests for the new functionality

## Usage

```bash
# In .env file or environment:
DISABLED_TOOLS=octave_debate_to_octave

# Or disable multiple tools:
DISABLED_TOOLS=octave_eject,octave_debate_to_octave
```

## Test plan

- [x] All 829 tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff, black)
- [x] New tests cover parsing, filtering, and server integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)