### PR TITLE
docs: align README CLI documentation with actual commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,11 @@ The CLI mirrors the MCP tools for use in shell pipelines, CI/CD, and local workf
 - **`octave write`** - write OCTAVE files with validation (content mode or delta changes mode).
 - **`octave eject`** - project OCTAVE into views (canonical, authoring, executive, developer) and formats (OCTAVE, JSON, YAML, Markdown).
 
-### Available via MCP (4 tools)
+### Available via MCP (3 tools)
 
 - **`octave_validate`** - schema validation and parsing of OCTAVE content
 - **`octave_write`** - unified file creation and modification (content mode OR changes mode with optional hash-based consistency checking)
 - **`octave_eject`** - format projection (octave, json, yaml, markdown) with declared loss tiers
-- **`octave_debate_to_octave`** - convert debate-hall-mcp JSON transcripts to OCTAVE format
 
 These tools make it easy for LLMs to emit minimal intent while relying on deterministic mechanics for structure and safety. If the LLM were replaced by a plain text emitter, OCTAVE would still provide value.
 


### PR DESCRIPTION
## Summary

- Remove references to nonexistent `octave ingest` command
- Document actual CLI commands that mirror MCP tools: `validate`, `write`, `eject`
- Remove `octave_debate_to_octave` from MCP tools list (tool being removed)
- Update quick-start examples to use correct commands

## Changes

| Before | After |
|--------|-------|
| `octave ingest` (nonexistent) | `octave validate` |
| 4 MCP tools | 3 MCP tools |
| Outdated CLI examples | Current command examples |

## Context

Per Issue #51, CLI was aligned with MCP tools but README was not updated. This PR corrects the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)