### PR TITLE
fix: CLI version reporting for v0.3.0

### DIFF
--- a/src/octave_mcp/cli/main.py
+++ b/src/octave_mcp/cli/main.py
@@ -5,9 +5,11 @@ Aligned with MCP tools per Issue #51.
 
 import click
 
+from octave_mcp import __version__
+
 
 @click.group()
-@click.version_option(version="0.1.0")
+@click.version_option(version=__version__)
 def cli():
     """OCTAVE command-line tools."""
     pass


### PR DESCRIPTION
## Summary
- Fixed CLI version reporting to use package version instead of hardcoded value

## Problem
The `octave --version` command was reporting v0.1.0 instead of the actual package version v0.3.0.

## Solution
Updated `src/octave_mcp/cli/main.py` to import and use `__version__` from the package instead of a hardcoded string.

## Test plan
- [x] Verified CLI reports correct version: `octave --version` → 0.3.0
- [x] Package builds successfully
- [x] Package installs successfully from wheel
- [x] PyPI release workflow completed successfully
- [x] Package is available on PyPI: `pip install octave-mcp==0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)