### PR TITLE
Mythology registry + tier-0 taxonomy in agents spec

### DIFF
--- a/docs/reference/octave-mythology-registry.oct.md
+++ b/docs/reference/octave-mythology-registry.oct.md
@@ -1,0 +1,280 @@
+===OCTAVE_MYTHOLOGY_REGISTRY===
+// Canonical registry for mythological semantic compression tokens used in OCTAVE
+// This is a living vocabulary document. Specs should point here rather than embedding exhaustive lists.
+
+META:
+  TYPE::REGISTRY
+  VERSION::"1.0"
+  STATUS::DRAFT
+  PURPOSE::"Provide a stable, extensible, test-gated vocabulary for mythological semantic compression"
+  SCOPE::"Mythology tokens only (Domains, Patterns, Forces, Relationships)"
+  GOVERNANCE::"Promotion via validation; avoid synonym drift"
+  SOURCES::[
+    _archive/specs/octave-semantics-v1.oct.md.archive,
+    skills/octave-mastery/SKILL.md,
+    skills/octave-mythology/SKILL.md
+  ]
+
+§1::TAXONOMY
+  // Categories must not be mixed inside a single list without labeling
+  CATEGORIES::[
+    DOMAIN_ARCHETYPE::"Technical responsibility layers / persistent strengths",
+    PATTERN_TOKEN::"Situations and narrative trajectories (state/trajectory compression)",
+    FORCE::"System dynamics (time pressure, entropy, opportunity)",
+    RELATIONSHIP::"Interaction dynamics between components/actors"
+  ]
+
+§2::TIER_0_CORE_VALIDATED
+  // Tier 0 is intentionally small and stable.
+  // These entries are consistent across the repo’s existing canonical docs (see META::SOURCES).
+
+  DOMAIN_ARCHETYPES::
+    ZEUS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Executive function, authority, strategic direction, final arbitration"
+      BEST_FOR::[escalation,final_decision,conflict_arbitration]
+      NOT_FOR::[implementation_details]
+    ATHENA::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Strategic wisdom, planning, elegant solutions, deliberate action"
+      BEST_FOR::[architecture,governance,design_decisions,risk_assessment]
+      NOT_FOR::[raw_debug_spam]
+    APOLLO::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Analytics, clarity, insight, diagnosis, revealing truth"
+      BEST_FOR::[analysis,root_cause,hypothesis_testing,metrics]
+      NOT_FOR::[handwavy_storytelling]
+    HERMES::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Communication, translation, APIs, networking, messaging"
+      BEST_FOR::[integration,contracts,interfaces,coordination]
+      NOT_FOR::[security_policy]
+    HEPHAESTUS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Infrastructure, tooling, engineering craft, automation, build systems"
+      BEST_FOR::[implementation,tooling,reliability_engineering]
+      NOT_FOR::[high_level_governance_only]
+    ARES::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Security, defense, stress testing, adversarial analysis"
+      BEST_FOR::[threat_modeling,hardening,attack_simulation]
+      NOT_FOR::[UX_polish]
+    ARTEMIS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Monitoring, observation, logging, alerting, precision targeting"
+      BEST_FOR::[observability,signal_design,detection]
+      NOT_FOR::[broad_strategy]
+    POSEIDON::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Data stores, databases, persistence, large data pools"
+      BEST_FOR::[storage,querying,data_modeling]
+      NOT_FOR::[frontend_interactions]
+    DEMETER::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Resources, capacity, budgeting, scaling, growth"
+      BEST_FOR::[capacity_planning,performance_budgeting,cost_controls]
+      NOT_FOR::[one_off_bugfixes]
+    DIONYSUS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"UX, creativity, experimentation, transformation, productive chaos"
+      BEST_FOR::[ideation,product_exploration,refactor_reframes]
+      NOT_FOR::[strict_compliance]
+
+  PATTERN_TOKENS::
+    ODYSSEAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Long, difficult, transformative journey with a clear goal"
+      BEST_FOR::[multi_phase_projects,migrations,roadmaps]
+      NOT_FOR::[small_tickets]
+    SISYPHEAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Repetitive, endless maintenance or cyclical failure"
+      BEST_FOR::[toil,recurring_incidents,tech_debt_loops]
+      NOT_FOR::[novel_one_time_issues]
+    PROMETHEAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Breakthrough innovation that challenges constraints (with tradeoffs)"
+      BEST_FOR::[new_architecture,novel_solutions]
+      NOT_FOR::[routine_refactors]
+    ICARIAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Overreach from early success → increased risk of collapse"
+      BEST_FOR::[scope_creep_warnings,ambition_checks]
+      NOT_FOR::[steady_incremental_work]
+    PANDORAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Cascading unforeseen consequences / expanding blast radius"
+      BEST_FOR::[incident_analysis,change_risk]
+      NOT_FOR::[contained_changes]
+    TROJAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Hidden payload/change-from-within (stealth coupling, supply chain risk)"
+      BEST_FOR::[dependency_risk,review_focus]
+      NOT_FOR::[transparent_changes]
+    GORDIAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Decisive cut-through-complexity solution"
+      BEST_FOR::[simplification,hard_tradeoffs,unblocking]
+      NOT_FOR::[over-optimization]
+    ACHILLEAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Single critical weakness in an otherwise strong system"
+      BEST_FOR::[risk_registers,single_points_of_failure]
+      NOT_FOR::[distributed_failures]
+    PHOENICIAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Destruction and rebirth (refactor, redesign, deprecate/rebuild)"
+      BEST_FOR::[major_refactors,platform_replacement]
+      NOT_FOR::[quick_patches]
+    ORPHEAN::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Deep dive into internals to retrieve something valuable (rescue mission)"
+      BEST_FOR::[legacy_archeology,hard_debugging]
+      NOT_FOR::[surface_level_tasks]
+
+  FORCES::
+    HUBRIS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Dangerous overconfidence"
+      BEST_FOR::[risk_calls,guardrails]
+    NEMESIS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Corrective consequence / backlash"
+      BEST_FOR::[postmortems,tradeoff_realism]
+    KAIROS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Critical fleeting window; timing matters"
+      BEST_FOR::[release_windows,opportunity_cost]
+    CHRONOS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Relentless time pressure / deadlines"
+      BEST_FOR::[planning_under_time,scope_triage]
+    CHAOS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Entropy and disorder"
+      BEST_FOR::[stability_work,incident_states]
+    COSMOS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Order emerging from chaos"
+      BEST_FOR::[stabilization,hardening]
+    MOIRA::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Hard non-negotiables; fated constraints"
+      BEST_FOR::[platform_limits,legal_or_physical_constraints]
+    TYCHE::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Chance / randomness / external unpredictability"
+      BEST_FOR::[uncertainty,stochastic_failures]
+
+  RELATIONSHIPS::
+    HARMONIA::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Balanced synergy; stable integration"
+      BEST_FOR::[integration_design,coherence]
+    ERIS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Productive conflict; competition that drives improvement"
+      BEST_FOR::[design_reviews,red_team]
+    EROS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Binding attraction; coupling"
+      BEST_FOR::[dependency_discussion,coupling_management]
+    THANATOS::
+      STATUS::CORE_VALIDATED
+      WISDOM::"Unbinding dissolution; fragmentation"
+      BEST_FOR::[decoupling,decomposition,sunsets]
+
+§3::TIER_1_CANDIDATES_UNVALIDATED
+  // Candidates are allowed only when you can tolerate lower semantic binding.
+  // Promotion requires a comprehension/usage test and at least one stable usage example.
+
+  DOMAIN_ARCHETYPES::
+    THEMIS::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Policy, rules, governance-as-law, consistency"
+      BEST_FOR::[compliance,policy_enforcement]
+    METIS::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Cunning pragmatism; strategy under uncertainty"
+      BEST_FOR::[tactical_planning,ambiguity]
+    HESTIA::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Stability, baseline reliability, operational calm"
+      BEST_FOR::[ops_sanity,keep_it_simple]
+    HERA::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Stakeholders, power dynamics, organizational reality"
+      BEST_FOR::[stakeholder_alignment,org_constraints]
+    IRIS::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Routing/dispatch; status propagation"
+      BEST_FOR::[handoffs,routing,queues]
+    MNEMOSYNE::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Memory, lineage, audit trails, documentation continuity"
+      BEST_FOR::[knowledge_mgmt,traceability]
+
+  PATTERN_TOKENS::
+    CASSANDRAN::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Accurate warning ignored until disaster"
+      BEST_FOR::[risk_communication,ignored_signals]
+    DAMOCLEAN::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Constant looming risk"
+      BEST_FOR::[latent_risk,tech_debt_interest]
+    HYDRAN::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Fix one head, two grow back"
+      BEST_FOR::[regressions,bug_classes]
+    TANTALIAN::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Perpetually-near goal; chronic near-miss"
+      BEST_FOR::[flaky_tests,almost_fixed_issues]
+    LABYRINTHINE::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Complexity maze; navigation dominates"
+      BEST_FOR::[onboarding_cost,sprawling_systems]
+    SCYLLA_CHARYBDIS::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Forced tradeoff between two bad outcomes"
+      BEST_FOR::[hard_tradeoffs]
+
+  FORCES::
+    ANANKE::
+      STATUS::CANDIDATE_UNVALIDATED
+      WISDOM::"Necessity; must-satisfy constraints"
+      BEST_FOR::[non_negotiables,hard_requirements]
+
+§4::SELECTION_GUIDELINES
+  // Keep usage small; the point is compression + semantic binding.
+  RULES::[
+    prefer_TIER_0_for_specs_and_agent_profiles,
+    max_domain_archetypes::3,
+    max_pattern_tokens::2,
+    forces_and_relationships::"use only when they add non-obvious structure",
+    do_not_roleplay::"No ceremonial prose (functional shorthand only)",
+    do_not_invent_tokens_in_flight::"Add to registry first, then use"
+  ]
+
+§5::VALIDATION_AND_PROMOTION_PROTOCOL
+  // Minimal, test-gated growth process
+  PROMOTION::
+    CANDIDATE→CORE_VALIDATED::[
+      add_entry_with_STATUS::CANDIDATE_UNVALIDATED,
+      add_1_line_definition_and_NOT_FOR,
+      add_2_usage_examples[minimal,realistic],
+      run_comprehension_test_across_models[min_3_models],
+      record_results_as_EVIDENCE::[test_id,date],
+      if_comprehension≥0.9_and_no_overlap→promote_to_CORE_VALIDATED
+    ]
+
+§6::CHANGE_CONTROL
+  STABILITY_PRINCIPLE::"Prefer fewer, sharper meanings over exhaustive coverage"
+  DRIFT_PREVENTION::[
+    avoid_near_synonyms,
+    require_NOT_FOR_clauses,
+    deprecate_instead_of_redefining
+  ]
+
+===END===

--- a/specs/octave-5-llm-agents.oct.md
+++ b/specs/octave-5-llm-agents.oct.md
@@ -241,55 +241,51 @@ DECISION_MATRIX::[
 
 §8::ARCHETYPE_REFERENCE
 
-AVAILABLE_MYTHOLOGICAL_PATTERNS:
+// This section is intentionally NOT exhaustive.
+// It provides a small, stable Tier-0 vocabulary plus usage rules.
+// Full definitions and any extensions live in the registry:
+//   docs/reference/octave-mythology-registry.oct.md
 
-ATHENA::
-  WISDOM::"Strategic wisdom, architectural thinking, protective boundaries"
-  BEST_FOR::[governance_roles,design_decisions,risk_assessment]
+MYTHOLOGY_REGISTRY::docs/reference/octave-mythology-registry.oct.md
 
-APOLLO::
-  WISDOM::"Clarity, illumination, prophecy, order from chaos"
-  BEST_FOR::[analysis,pattern_recognition,optimization]
+TAXONOMY::[
+  DOMAIN_ARCHETYPES::"Technical responsibility layers / persistent strengths",
+  PATTERN_TOKENS::"Situations and narrative trajectories",
+  FORCES::"System dynamics (time pressure, entropy, opportunity)",
+  RELATIONSHIPS::"Interaction dynamics"
+]
 
-PROMETHEUS::
-  WISDOM::"Third-way creation, fire-bringing, rule-breaking for progress"
-  BEST_FOR::[innovation,creative_synthesis,constraint_breaking]
+SELECTION_RULES::[
+  prefer_TIER_0::"Use Tier-0 in specs and agent profiles unless you have a validated reason not to",
+  max_domain_archetypes::3,
+  max_pattern_tokens::2,
+  avoid_category_mixing::"Do not treat domain archetypes as pattern tokens (and vice versa)",
+  no_roleplay_prose::"Mythology is compression shorthand, not narrative theater",
+  extensions::"Add/validate in registry first; do not invent tokens in-flight"
+]
 
-HEPHAESTUS::
-  WISDOM::"Craft, implementation, practical mastery, refining details"
-  BEST_FOR::[implementation,code_quality,engineering_excellence]
+TIER_0_DOMAIN_ARCHETYPES::[
+  ZEUS,ATHENA,APOLLO,HERMES,HEPHAESTUS,ARES,ARTEMIS,POSEIDON,DEMETER,DIONYSUS
+]
 
-HERMES::
-  WISDOM::"Communication, interfaces, contracts, translation"
-  BEST_FOR::[API_design,documentation,integration,messaging]
+TIER_0_PATTERN_TOKENS::[
+  ODYSSEAN,SISYPHEAN,PROMETHEAN,ICARIAN,PANDORAN,TROJAN,GORDIAN,ACHILLEAN,PHOENICIAN,ORPHEAN
+]
 
-ARGUS::
-  WISDOM::"Vigilance, pattern recognition, comprehensive observation"
-  BEST_FOR::[monitoring,quality_assurance,detection,coverage]
+TIER_0_FORCES::[
+  HUBRIS,NEMESIS,KAIROS,CHRONOS,CHAOS,COSMOS,MOIRA,TYCHE
+]
 
-ATLAS::
-  WISDOM::"Foundational strength, bearing weight, system stability"
-  BEST_FOR::[infrastructure,core_systems,reliability,foundations]
+TIER_0_RELATIONSHIPS::[
+  HARMONIA,ERIS,EROS,THANATOS
+]
 
-ARTEMIS::
-  WISDOM::"Focus, clarity, boundary drawing, precision"
-  BEST_FOR::[specification,requirements,precision_work,focus]
-
-ARES::
-  WISDOM::"Direct action, conflict resolution, decisive force"
-  BEST_FOR::[conflict_resolution,bug_elimination,direct_fixing]
-
-APHRODITE::
-  WISDOM::"Connection, harmony, relationship, integration"
-  BEST_FOR::[coordination,integration,relationship_building]
-
-DIONYSUS::
-  WISDOM::"Transformation, emergence, flexibility, acceptance"
-  BEST_FOR::[transformation_work,flexibility,emergence_patterns]
-
-HADES::
-  WISDOM::"Deep knowledge, underworld mastery, hidden truths"
-  BEST_FOR::[deep_analysis,root_cause,hidden_dependencies,archeology]
+EXAMPLE_COMPOSITION::
+  // Keep usage sparse: 2-3 domains; 0-2 patterns; add forces/relationships only if they add structure
+  ARCHETYPES::[ATHENA⊕APOLLO]
+  PATTERN::SISYPHEAN
+  FORCE::CHRONOS
+  RELATIONSHIP::EROS
 
 §9::EXAMPLE_AGENT_ARCHITECTURES
 


### PR DESCRIPTION
Adds a dedicated mythology registry and refactors the agents spec archetype reference into a taxonomy + Tier-0 lists, with selection rules and a pointer to the registry.

Co-Authored-By: Warp <agent@warp.dev>