### PR TITLE
fix: v0.4.1 Hermetic Write + Type Hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.4.1] - 2026-01-07
+
+### Fixed
+- Hermetic schema resolution in `octave_write` tool - now uses `resolve_hermetic_standard` for `frozen@` and `latest` schema references (Issue #150)
+
+### Added
+- Type hints and improved documentation in write tool hermetic resolution path
+
 ## [0.4.0] - 2026-01-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/octave_mcp/__init__.py
+++ b/src/octave_mcp/__init__.py
@@ -39,7 +39,7 @@ from octave_mcp.core.schema_extractor import FieldDefinition, SchemaDefinition, 
 from octave_mcp.core.sealer import SealVerificationResult, seal_document, verify_seal
 from octave_mcp.core.validator import ValidationError, Validator
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 # Canonical OCTAVE operators (per specs/octave-5-llm-core.oct.md §2)
 # These are the Unicode canonical forms. ASCII aliases are also accepted by the lexer.


### PR DESCRIPTION
## Release v0.4.1\n\nFixes tech debt from v0.4.0 and includes type hints.\n\n### Changes\n- **Fix**:  now uses  for schema loading, enabling hermetic resolution of frozen/latest standards.\n- **Fix**: Added  marker for PEP 561 compliance (via rebase).\n- **Docs**: Updated CHANGELOG for v0.4.1.\n\n### Verification\n- Added .\n- All tests passing.