### PR TITLE
feat: enhance skills with explicit v6 spec visibility

### DIFF
--- a/skills/octave-compression/SKILL.md
+++ b/skills/octave-compression/SKILL.md
@@ -3,18 +3,19 @@ name: octave-compression
 description: Specialized workflow for transforming verbose natural language into semantic OCTAVE structures. REQUIRES octave-literacy to be loaded first
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["compress to octave", "semantic compression", "documentation refactoring", "octave compression", "compress documentation", "knowledge artifact", "semantic density", "OCTAVE format conversion"]
-version: "2.3.0"
+version: "2.4.0"
 ---
 
 ===OCTAVE_COMPRESSION===
 META:
   TYPE::SKILL
-  VERSION::"2.3.0"
+  VERSION::"2.4.0"
   STATUS::ACTIVE
   PURPOSE::"Workflow for transforming prose into semantic density"
   REQUIRES::octave-literacy
   TIER::LOSSLESS
   SPEC_REFERENCE::octave-6-llm-data.oct.md[§1b::COMPRESSION_TIERS]
+  V6_FEATURES::"Loss accounting system, tier metadata tracking, fidelity guarantees"
 
 §1::COMPRESSION_MANDATE
   TARGET::"60-80% token reduction with 100% decision-logic fidelity"
@@ -36,6 +37,14 @@ META:
       LOSS::~50%[almost_all_explanatory_content,some_nuance,tradeoff_reasoning]
 
     TIER_METADATA::include_in_META_block[COMPRESSION_TIER,LOSS_PROFILE,NARRATIVE_DEPTH]
+
+    V6_LOSS_ACCOUNTING::[
+      PRINCIPLE::"OCTAVE-MCP is a loss accounting system for LLM communication",
+      TRACKING::"Every transformation must log what was preserved vs dropped",
+      METADATA::"Documents carry their compression tier and loss profile",
+      AUDIT::I4_TRANSFORM_AUDITABILITY[stable_ids,loss_receipts],
+      FIDELITY::I1_SYNTACTIC_FIDELITY[syntax_changes_ok,semantics_preserved]
+    ]
 
 §2::TRANSFORMATION_WORKFLOW
   PHASE_1_READ::[

--- a/skills/octave-literacy/SKILL.md
+++ b/skills/octave-literacy/SKILL.md
@@ -3,17 +3,18 @@ name: octave-literacy
 description: Fundamental reading and writing capability for the OCTAVE format. Basic structural competence without full architectural specifications
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["octave format", "write octave", "octave syntax", "structured output", "OCTAVE basics", "OCTAVE literacy", "OCTAVE structure", "semantic format", "key::value", "OCTAVE notation"]
-version: "1.2.0"
+version: "1.3.0"
 ---
 
 ===OCTAVE_LITERACY===
 META:
   TYPE::SKILL
-  VERSION::"1.2.0"
+  VERSION::"1.3.0"
   STATUS::ACTIVE
   PURPOSE::"Essential syntax and operators for basic OCTAVE competence"
   TIER::LOSSLESS
   SPEC_REFERENCE::octave-6-llm-core.oct.md
+  V6_FEATURES::"Adds CONTRACT/GRAMMAR blocks, assembly rules, .oct.md extension"
 
 §1::CORE_SYNTAX
   ASSIGNMENT::KEY::value   // Double colon is MANDATORY for data
@@ -56,15 +57,24 @@ META:
   1::No spaces around assignment :: (KEY::value, not KEY :: value)
   2::Indent exactly 2 spaces per level (NO TABS)
   3::All keys must be [A-Z, a-z, 0-9, _] and start with letter or underscore
-  4::Envelopes are ===NAME=== at start and ===END=== at finish
+  4::Envelopes are ===NAME=== at start and ===END=== at finish (NAME must be [A-Z_][A-Z0-9_]*)
   5::Use lowercase for true, false, null (NOT True, False, NULL)
   6::∧ only appears inside brackets, never bare: [A∧B∧C] is valid, A∧B is not
   7::⇌ is binary only (A⇌B), not chained (A⇌B⇌C is invalid)
+  8::File extension .oct.md is canonical (v6), .octave.txt deprecated
 
-  §3b::ASSEMBLY_RULES
+  §3b::V6_ENVELOPE_STRUCTURE
+    FILE_STRUCTURE::[===NAME===,META_BLOCK,SEPARATOR_OPTIONAL,BODY,===END===]
+    META_REQUIRED::[TYPE,VERSION]
+    META_V6_OPTIONAL::[CONTRACT,GRAMMAR]  // New in v6 for holographic contracts
+    CONTRACT::HOLOGRAPHIC[validation_law_in_document]
+    GRAMMAR::GBNF_COMPILER[generate_constrained_output]
+
+  §3c::ASSEMBLY_RULES
     WHEN_CONCATENATING_PROFILES::omit_intermediate_===END===[only_final_===END===_terminates]
     USE_CASES::[agent_context_injection,specification_layering,multi_part_documents]
     EXAMPLE::core_profile⊕schema_profile→single_===END===_at_finish
+    V6_PATTERN::multiple_profiles_one_document[no_intermediate_terminators]
 
 §4::EXAMPLE_BLOCK
   ===EXAMPLE===

--- a/skills/octave-mastery/SKILL.md
+++ b/skills/octave-mastery/SKILL.md
@@ -3,18 +3,19 @@ name: octave-mastery
 description: Advanced semantic vocabulary and architectural patterns for the OCTAVE format. REQUIRES octave-literacy to be loaded first
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["octave architecture", "agent design", "semantic pantheon", "advanced octave", "OCTAVE mastery", "holographic patterns", "archetypes", "high-density specifications", "system architecture", "OCTAVE patterns"]
-version: "2.2.0"
+version: "2.3.0"
 ---
 
 ===OCTAVE_MASTERY===
 META:
   TYPE::SKILL
-  VERSION::"2.2.0"
+  VERSION::"2.3.0"
   STATUS::ACTIVE
   PURPOSE::"Expert-level OCTAVE application: Archetypes, Advanced Syntax, Strategy"
   REQUIRES::octave-literacy
   TIER::LOSSLESS
   SPEC_REFERENCE::octave-6-llm-core.oct.md
+  V6_FEATURES::"Holographic contracts, JIT grammar compilation, constraint validation"
 
 §1::SEMANTIC_PANTHEON
   // The complete vocabulary for semantic compression
@@ -61,7 +62,25 @@ META:
     BOOL::true
   ]
 
-§4b::CONSTRAINTS
+  §4b::V6_HOLOGRAPHIC_CONTRACTS
+    // v6 innovation: Documents carry their own validation law
+    CONTRACT::HOLOGRAPHIC[
+      PRINCIPLE::"Validation rules embedded in document META block",
+      MECHANISM::JIT_GRAMMAR_COMPILATION[META→GBNF],
+      ANCHORING::HERMETIC[frozen@sha256|latest@local],
+      BENEFIT::"Self-validating documents, no external schema needed"
+    ]
+    GRAMMAR::[
+      GENERATOR::OCTAVE_GBNF_COMPILER[planned],
+      INTEGRATION::[llama.cpp,Outlines,vLLM],
+      OUTPUT::"Constrained generation - impossible to produce invalid syntax"
+    ]
+    EXAMPLE_META::[
+      CONTRACT::TYPE_CONSTRAINTS[field1::STRING,field2::NUMBER],
+      GRAMMAR::GBNF[rules_for_structured_output]
+    ]
+
+§4c::CONSTRAINTS
   // Available constraint types for holographic patterns
   CORE::[REQ,OPT,CONST,ENUM,TYPE,REGEX,DIR,APPEND_ONLY]
   EXTENDED::[RANGE,MAX_LENGTH,MIN_LENGTH,DATE,ISO8601]
@@ -73,6 +92,7 @@ META:
     "DATE"[strict_YYYY_MM_DD],
     "ISO8601"[full_datetime]
   ]
+  V6_USAGE::constraints_in_CONTRACT_block[self_contained_validation]
 
 §5::ANTI_PATTERNS
   SMELLS::[


### PR DESCRIPTION
Skills now provide better documentation of v6 features rather than just referencing specs:

octave-literacy v1.3.0:
- Documents v6 CONTRACT/GRAMMAR blocks in META
- Explains envelope name requirements ([A-Z_][A-Z0-9_]*)
- Clarifies assembly rules for concatenating profiles
- Notes .oct.md as canonical file extension

octave-mastery v2.3.0:
- Explains v6 holographic contracts concept
- Documents JIT grammar compilation mechanism
- Shows how constraints work in CONTRACT blocks
- Clarifies self-validating document principle

octave-compression v2.4.0:
- Explains v6 loss accounting system philosophy
- Links compression to OCTAVE-MCP core immutables (I1, I4)
- Documents tier metadata tracking requirements
- Clarifies fidelity guarantees and audit trails

This improves discoverability of v6 features directly within skills without requiring developers to cross-reference spec documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)