### PR TITLE
fix(mcp): make octave_eject template parseable

### DIFF
--- a/src/octave_mcp/mcp/eject.py
+++ b/src/octave_mcp/mcp/eject.py
@@ -233,7 +233,7 @@ META:
   TYPE::{schema_name}
   VERSION::"1.0"
 
-# Template generated for schema: {schema_name}
+// Template generated for schema: {schema_name}
 ===END==="""
             # I5 (Schema Sovereignty): validation_status must be UNVALIDATED to make bypass visible
             # "Schema bypass shall be visible, never silent" - North Star I5
@@ -251,7 +251,7 @@ META:
             # If parsing fails, return error
             # I5 (Schema Sovereignty): validation_status must be UNVALIDATED to make bypass visible
             return {
-                "output": f"# Parse error: {str(e)}\n{content}",
+                "output": f"// Parse error: {str(e)}\n{content}",
                 "lossy": False,
                 "fields_omitted": [],
                 "validation_status": "UNVALIDATED",  # I5: Explicit bypass - no schema validator yet

--- a/tests/unit/test_eject_tool.py
+++ b/tests/unit/test_eject_tool.py
@@ -9,6 +9,7 @@ Tests projection modes:
 
 import pytest
 
+from octave_mcp.core.parser import parse
 from octave_mcp.mcp.eject import EjectTool
 
 
@@ -139,6 +140,15 @@ TESTS::passing
         assert result["lossy"] is False
         # Template generation returns minimal structure
         assert len(result["output"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_eject_template_is_parseable_octave(self, eject_tool):
+        """Template output must be parseable OCTAVE (dogfooding)."""
+        result = await eject_tool.execute(content=None, schema="DEBATE_TRANSCRIPT", format="octave")
+        doc = parse(result["output"])
+        assert doc is not None
+        assert doc.meta is not None
+        assert doc.meta.get("TYPE") == "DEBATE_TRANSCRIPT"
 
     @pytest.mark.asyncio
     async def test_eject_default_mode_is_canonical(self, eject_tool):


### PR DESCRIPTION
Summary
- Fix octave_eject template generation to emit valid OCTAVE instead of markdown-style '#' lines.
- Ensure template output is parseable (dogfooding) via a new unit test.

Changes
- src/octave_mcp/mcp/eject.py
  - Replace '# Template generated…' with '// Template generated…'
  - Replace '# Parse error…' with '// Parse error…' in the error output path
- tests/unit/test_eject_tool.py
  - Add regression: template output for DEBATE_TRANSCRIPT parses via core parser and preserves META.TYPE

Co-Authored-By: Warp <agent@warp.dev>