### PR TITLE
docs: clarify immutables in agent bootstrap section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ DEV_SETUP::docs/guides/development-setup.md
 SPECS::src/octave_mcp/resources/specs/
 SKILLS::src/octave_mcp/resources/skills/
 PRIMERS::src/octave_mcp/resources/primers/
-IMMUTABLES::[I1,I2,I3,I4,I5]
+
+// Five core immutables that define OCTAVE's behavior
+IMMUTABLES::[
+  I1::SYNTACTIC_FIDELITY,     // Preserve semantic meaning exactly
+  I2::DETERMINISTIC_ABSENCE,  // Distinguish absent vs null vs default
+  I3::MIRROR_CONSTRAINT,      // Reflect only what exists, create nothing
+  I4::TRANSFORM_AUDITABILITY, // Log every transformation with IDs
+  I5::SCHEMA_SOVEREIGNTY      // Make validation status visible
+]
 ===END===
 ```
 


### PR DESCRIPTION
## Summary
- Add inline comments explaining each immutable's purpose in the agent bootstrap section
- Makes the bootstrap more self-documenting for new agents encountering the project

## Changes
Updated the `IMMUTABLES` section in README.md from:
```octave
IMMUTABLES::[I1,I2,I3,I4,I5]
```

To:
```octave
// Five core immutables that define OCTAVE's behavior
IMMUTABLES::[
  I1::SYNTACTIC_FIDELITY,     // Preserve semantic meaning exactly
  I2::DETERMINISTIC_ABSENCE,  // Distinguish absent vs null vs default
  I3::MIRROR_CONSTRAINT,      // Reflect only what exists, create nothing
  I4::TRANSFORM_AUDITABILITY, // Log every transformation with IDs
  I5::SCHEMA_SOVEREIGNTY      // Make validation status visible
]
```

## Rationale
When a new agent sees `IMMUTABLES::[I1,I2,I3,I4,I5]`, they have no context for what these mean. This change makes the bootstrap section immediately understandable while maintaining valid OCTAVE syntax.

## Test plan
- [x] Maintains valid OCTAVE syntax
- [x] Comments are properly formatted
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)