### PR TITLE
fix: write mutations + schema validation; hermetic resolver security

### DIFF
--- a/src/octave_mcp/core/emitter.py
+++ b/src/octave_mcp/core/emitter.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from octave_mcp.core.ast_nodes import Absent, Assignment, Block, Document, InlineMap, ListValue, Section
 
-IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*$")
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*\Z")
 
 
 def needs_quotes(value: Any) -> bool:
@@ -30,6 +30,12 @@ def needs_quotes(value: Any) -> bool:
 
     # Empty string needs quotes
     if not value:
+        return True
+
+    # Newlines/tabs must be escaped, so they must be quoted.
+    # NOTE: Regex `$` matches before a trailing newline; IDENTIFIER_PATTERN uses `\\Z`
+    # to avoid treating "A\\n" as a bare identifier.
+    if "\n" in value or "\t" in value or "\r" in value:
         return True
 
     # Reserved words need quotes to avoid becoming literals or operators

--- a/tests/unit/test_section_parsing.py
+++ b/tests/unit/test_section_parsing.py
@@ -129,10 +129,24 @@ META:
         Example: →§./path/to/target
         This test ensures we don't break existing functionality.
         """
-        # This test validates that § in other contexts still works
-        # (if such usage exists in codebase)
-        # TODO: Verify if this edge case needs handling
-        pass
+        content = """===TEST===
+ROUTE::→§./path/to/target
+SIBLING::value
+===END===
+"""
+        doc = parse(content)
+
+        assert len(doc.sections) == 2
+        assert doc.sections[0].key == "ROUTE"
+        assert doc.sections[0].value == "→§./path/to/target"
+        assert doc.sections[1].key == "SIBLING"
+
+        # Round-trip should preserve the value semantics
+        emitted = emit(doc)
+        doc2 = parse(emitted)
+        assert len(doc2.sections) == 2
+        assert doc2.sections[0].key == "ROUTE"
+        assert doc2.sections[0].value == "→§./path/to/target"
 
     def test_parses_section_with_suffix_id(self):
         """Should parse §2b::NAME pattern with suffix IDs (BLOCKING-1)."""


### PR DESCRIPTION
Summary:
- Implement META mutations in `octave_write` at AST level.
- Integrate SchemaDefinition-backed validation (incl hermetic schema load).
- Coerce ListValue/InlineMap to Python primitives for constraint evaluation.
- Harden `resolve_hermetic_standard` against path traversal.
- Fix emitter quoting for strings containing newlines (idempotence).
- Replace placeholder test with concrete assertions; add new regression tests.

Verification:
- ruff/black/mypy/pytest+coverage gates green (local).
