### PR TITLE
feat: add lenient octave_write mode

### DIFF
--- a/.hestai/reports/debate-2026-01-15-gh169-lenient-octave-write.oct.md
+++ b/.hestai/reports/debate-2026-01-15-gh169-lenient-octave-write.oct.md
@@ -1,0 +1,133 @@
+===DEBATE_TRANSCRIPT===
+
+META:
+  THREAD_ID::"2026-01-15-issue-169-lenient-octave-write"
+  TOPIC::"GH#169: Design and implementation approach for `octave_write` lenient mode (Prettier-like auto-correction) with deterministic audit trail and diff-first output."
+  MODE::fixed
+  STATUS::synthesis
+
+PARTICIPANTS::[Door,Wall,Wind]
+
+TURNS::[
+  T1::Wind[PATHOS]::"OPTIONS::[
+  A_PRETTIFY_ONLY::\"lenient=true uses tolerant parse + canonical emit; still errors if parse fails\",
+  B_PRETTIFY_PLUS_REPAIR::\"lenient=true also applies schema repair (enum casefold/type coercion) when schema provided\",
+  C_ALWAYS_CANONICAL_SALVAGE::\"if parse fails, wrap raw text into a canonical carrier doc + log corrections; avoids catch-22\"
+]
+
+IDEAS::[
+  DIFF_FIRST::\"Return unified diff + corrections log by default to save context; only return full canonical when requested\",
+  CORRECTION_TIERS::[NORMALIZATION,LENIENT_PARSE,SCHEMA_REPAIR]→each_change_logged,
+  FORBIDDEN::[semantic_inference,field_invention,target_invention]
+]
+
+QUESTIONS::[
+  \"When lenient=true and parse fails, do we prefer error (Prettier) or salvage (always-canonical)?\",
+  \"Should corrections_only return canonical preview, unified diff, or both?\",
+  \"Do we want schema repair in octave_write, or keep it exclusive to octave_validate fix=true?\"
+]",
+  T2::Wall[ETHOS]::"VERDICT: Proceed with GH#169 only with deterministic + lossless guarantees and an explicit boundary between prettify/repair vs semantic translation.
+
+[EVIDENCE]
+- src/octave_mcp/mcp/write.py uses strict parse() and returns E_PARSE on failure.
+- src/octave_mcp/mcp/validate.py uses parse_with_warnings() + repair() with audit surfaces.
+- src/octave_mcp/resources/specs/octave-mcp-architecture.oct.md asserts lenient-in→canonical-out and “auditable not silent”.
+- .hestai/context/context-negatives.oct.md forbids semantic inference.
+
+YES_BUT:
+1) Prettier analogy breaks at parse-failure: if we promise always-canonical, we must define a salvage carrier contract.
+2) parse_with_warnings() may still drop bare/free-text lines (unexpected tokens). That is data loss unless we preserve bytes.
+3) Issue #169’s semantic mapping examples must be opt-in, not default lenient.
+
+GUARDS:
+- lenient=true must pre-process would-be-dropped lines into deterministic STRING assignments under a known block BEFORE parsing.
+- salvage carrier must embed original bytes verbatim and log a correction describing the wrap.
+- corrections_only must be read-only (no mkdir/write side-effects).
+
+QUESTIONS?
+- Is salvage always-on for lenient=true, or a separate explicit mode?
+- Does lenient imply schema repair, or keep repair exclusive to octave_validate fix=true?",
+  T3::Door[LOGOS]::"1. DECISION: Implement GH#169 as deterministic canonicalization + optional schema repair + explicit salvage policy; keep semantic translation out of `octave_write` lenient by default.
+
+2. API:
+- Add `lenient: bool=false` and `corrections_only: bool=false` to `octave_write`.
+- Return `diff_unified` (or upgrade `diff`), `corrections[]`, `canonical_hash`, `validation_status`.
+
+3. PIPELINE:
+- strict (default): tokenize repairs → parse() strict → emit() → validate (no repairs).
+- lenient=true: tokenize repairs → preprocess free-text into deterministic RAW assignments → parse_with_warnings() → if schema: validate → repair(fix=True) → revalidate → emit().
+- corrections_only=true: run pipeline but do not write.
+
+4. SALVAGE POLICY:
+- Trigger salvage only when parse fails OR tolerant parse would drop tokens.
+- Canonical carrier: `===DOC===` + META(TYPE,VERSION defaults) + `BODY:` `RAW::<verbatim>` + `===END===`.
+- Audit: always log wrap + all repairs into `corrections[]`.
+
+5. PHASED IMPLEMENTATION:
+- P1: Add flags + corrections_only no-write gate; add unified diff field.
+- P2: Wire parse_with_warnings + map warnings into corrections.
+- P3: Add RAW-preservation preprocessor to prevent silent drops.
+- P4: Add optional schema repair in lenient (reuse `core/repair.py`) + tests.
+- P5: Update docs (`docs/api.md`) to match real envelope + new flags.
+
+6. TEST MATRIX:
+- strict behavior unchanged.
+- lenient quotes multiword values deterministically.
+- lenient preserves free text as RAW (no loss).
+- lenient schema enum casefold/type coercion logged.
+- corrections_only does not write.
+- diff_unified is compact and consistent.",
+]
+
+SYNTHESIS::"1. DECISION: Implement GH#169 by adding deterministic `lenient` + `corrections_only` to `octave_write`, keeping default strict behavior unchanged.
+2. PRINCIPLE: Lenient mode = syntactic tolerance + schema repair (explicit), NOT semantic inference; any NL→OCTAVE translation is out-of-scope for `octave_write`.
+3. CONTRACT: When parse would fail or drop tokens, use a canonical salvage carrier that embeds the original bytes verbatim and logs a correction (I4).
+4. OUTPUT: Prefer diff-first (unified diff) + corrections log to minimize context; return full canonical only when requested.
+
+===DEBATE_SYNTHESIS===
+META:
+  TYPE::DEBATE_SYNTHESIS
+  ISSUE::GH_169
+  TOPIC::\"octave_write lenient (Prettier-like)\"
+
+RESOLUTION::[
+  API::[
+    octave_write_add_params::[lenient::bool=false,corrections_only::bool=false],
+    response_add_fields::[diff_unified?],
+    preserve_existing::[status,path,canonical_hash,corrections,diff,errors,validation_status]
+  ],
+  PIPELINE::[
+    STRICT_DEFAULT::tokenize_repairs→parse_strict→emit→validate,
+    LENIENT_TRUE::tokenize_repairs→preprocess_free_text_to_RAW_assignments→parse_with_warnings→(if schema: validate→repair→revalidate)→emit,
+    CORRECTIONS_ONLY::no_write_side_effects
+  ],
+  SALVAGE_CONTRACT::[
+    TRIGGER::parse_fail∨would_drop_tokens,
+    CARRIER_DOC::\"===DOC=== + META defaults + BODY: RAW::<verbatim> + ===END===\",
+    I4_AUDIT::\"wrap + every byte-change logged in corrections[]\"
+  ],
+  DIFF_FIRST::[
+    DEFAULT_RETURN::unified_diff_when_small,
+    FALLBACK::structural_summary_when_large
+  ],
+  NON_GOALS::[
+    NEVER::semantic_inference_in_lenient_mode,
+    NEVER::mythology_mapping_or_target_invention_as_autofix
+  ]
+]
+
+FILES_RELEVANT::[
+  specs::[src/octave_mcp/resources/specs/octave-mcp-architecture.oct.md,src/octave_mcp/resources/specs/octave-core-spec.oct.md,src/octave_mcp/resources/specs/octave-execution-spec.oct.md],
+  constraints::[.hestai/context/context-negatives.oct.md],
+  code::[src/octave_mcp/mcp/write.py,src/octave_mcp/mcp/validate.py,src/octave_mcp/core/parser.py,src/octave_mcp/core/repair.py]
+]
+
+NEXT_STEPS::[
+  1::tests_red→green_for_lenient_and_corrections_only,
+  2::implement_preprocessor_for_free_text_preservation,
+  3::wire_schema_repair_in_lenient_path,
+  4::update_docs_api_contract
+]
+===END==="
+
+===END===


### PR DESCRIPTION
## Summary\n- add , , and  flags to , defaulting to strict, production-safe behavior\n- emit , log every correction, support deterministic RAW wrapping for prose, and optionally repair builtin schema enums\n- cover the new behavior with focused unit tests and keep the debate transcript archived in \n\n## Testing\n- ============================= test session starts ==============================
platform darwin -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /Volumes/OCTAVE/octave-mcp/worktrees/release-v061
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.12.0, timeout-2.4.0, hypothesis-6.148.7, asyncio-1.3.0, cov-7.0.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 1246 items

tests/integration/test_coverage_cli.py ............                      [  0%]
tests/integration/test_e2e.py ................                           [  2%]
tests/integration/test_hydrate_cli.py .............................      [  4%]
tests/integration/test_normalize_cli.py .........                        [  5%]
tests/integration/test_routing_log_exposure.py ....                      [  5%]
tests/integration/test_seal_cli.py ............                          [  6%]
tests/integration/test_seal_verify.py .................                  [  7%]
tests/integration/test_server.py ....                                    [  8%]
tests/integration/test_vocab_cli.py ............s                        [  9%]
tests/properties/test_canonicalization.py ...........                    [ 10%]
tests/test_constraint_compilation.py ....................                [ 11%]
tests/test_constraint_special_chars.py ........                          [ 12%]
tests/test_parser_meta_pass.py ..........                                [ 13%]
tests/test_spec_validation.py ......s..s.......                          [ 14%]
tests/unit/test_at_operator.py ...........                               [ 15%]
tests/unit/test_bug_fixes_i1_i3.py .............                         [ 16%]
tests/unit/test_builtin_schemas.py .                                     [ 16%]
tests/unit/test_cli.py ..........................................        [ 19%]
tests/unit/test_constraints.py ......................................... [ 23%]
.......................................................................  [ 28%]
tests/unit/test_context_section.py ..........                            [ 29%]
tests/unit/test_coverage_mapper.py ................                      [ 31%]
tests/unit/test_debate_schema.py ........ss                              [ 31%]
tests/unit/test_eject_conversion.py ..........................           [ 33%]
tests/unit/test_eject_tool.py ......................                     [ 35%]
tests/unit/test_emitter.py ..............................                [ 38%]
tests/unit/test_file_ops.py ...............................              [ 40%]
tests/unit/test_forbidden_repairs.py ..........                          [ 41%]
tests/unit/test_gh63_gh66_fixes.py ...................................   [ 44%]
tests/unit/test_gh87_number_underscore.py ................               [ 45%]
tests/unit/test_grammar_sentinel.py ..............                       [ 46%]
tests/unit/test_holographic_pattern.py ................................. [ 49%]
...................                                                      [ 50%]
tests/unit/test_hydrator.py ............................................ [ 54%]
.............................................                            [ 57%]
tests/unit/test_i2_deterministic_absence.py ...............              [ 59%]
tests/unit/test_json_schema_resources.py ..........                      [ 59%]
tests/unit/test_lexer.py ............................................... [ 63%]
.................                                                        [ 65%]
tests/unit/test_mcp_base.py ........                                     [ 65%]
tests/unit/test_parser.py ..................ss.....................      [ 69%]
tests/unit/test_parser_assignment_brackets.py .........                  [ 69%]
tests/unit/test_parser_bare_lines.py ..............................      [ 72%]
tests/unit/test_parser_siblings.py .............                         [ 73%]
tests/unit/test_projection.py ..................                         [ 74%]
tests/unit/test_property_fixes.py ......                                 [ 75%]
tests/unit/test_repair.py ..............................                 [ 77%]
tests/unit/test_routing.py ...............                               [ 78%]
tests/unit/test_schema.py .......                                        [ 79%]
tests/unit/test_schema_extractor.py ...........................          [ 81%]
tests/unit/test_schema_loader.py ...............                         [ 82%]
tests/unit/test_schema_loading.py .                                      [ 82%]
tests/unit/test_schema_repository.py ........                            [ 83%]
tests/unit/test_sealer.py .................                              [ 84%]
tests/unit/test_section_parsing.py .......ss....                         [ 85%]
tests/unit/test_server_integration.py .....................              [ 87%]
tests/unit/test_single_colon_values.py .........                         [ 88%]
tests/unit/test_unknown_fields.py ........                               [ 88%]
tests/unit/test_validate_tool.py ....................................... [ 91%]
....................                                                     [ 93%]
tests/unit/test_validator_section.py ............                        [ 94%]
tests/unit/test_write_tool.py .......................................... [ 97%]
...................                                                      [ 99%]
tests/vectors/test_vectors.py .......                                    [100%]

================================ tests coverage ================================
______________ coverage: platform darwin, python 3.12.12-final-0 _______________

Name                                                           Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------------------
src/octave_mcp/__init__.py                                        32      6    81%   100-165
src/octave_mcp/cli/__init__.py                                     0      0   100%
src/octave_mcp/cli/main.py                                       535     61    89%   26, 43, 64-67, 147-149, 173, 337-344, 387-389, 488-491, 526-528, 642, 691, 696, 728-729, 733-734, 748-750, 802-803, 807-808, 815, 876-877, 881-882, 888-892, 965-969, 1051-1053, 1089-1090, 1143
src/octave_mcp/core/__init__.py                                    0      0   100%
src/octave_mcp/core/ast_nodes.py                                  53      1    98%   62
src/octave_mcp/core/constraints.py                               343     20    94%   75, 80, 90, 259, 307, 331-332, 356, 390, 395, 426, 460-461, 527-528, 593-594, 708-709, 983
src/octave_mcp/core/coverage_mapper.py                            42      0   100%
src/octave_mcp/core/emitter.py                                   106      7    93%   29, 133-134, 158, 162-163, 176
src/octave_mcp/core/file_ops.py                                   81     13    84%   41-42, 73-74, 136, 188-189, 198-204
src/octave_mcp/core/grammar.py                                     6      6     0%   9-51
src/octave_mcp/core/holographic.py                               146      1    99%   294
src/octave_mcp/core/hydrator.py                                  419     39    91%   73-74, 129, 390, 409, 418, 427, 478-479, 517, 539-541, 584-587, 595, 658, 662, 678-681, 685, 697-698, 777-778, 792, 851, 960, 1154, 1173-1176, 1242-1243, 1299-1300
src/octave_mcp/core/lexer.py                                     148      1    99%   340
src/octave_mcp/core/parser.py                                    524     26    95%   65, 86, 153, 176, 183, 242-243, 247, 326, 343, 416, 424, 441, 706, 850-851, 914, 1074, 1128-1130, 1136, 1203-1204, 1254-1255
src/octave_mcp/core/projector.py                                  50      1    98%   82
src/octave_mcp/core/repair.py                                     91      6    93%   125, 183, 193, 312-315
src/octave_mcp/core/repair_log.py                                 23      0   100%
src/octave_mcp/core/routing.py                                    22      0   100%
src/octave_mcp/core/schema.py                                     12      2    83%   42-45
src/octave_mcp/core/schema_extractor.py                          189     72    62%   59, 110, 130-133, 219, 223, 230, 282, 284, 286, 289-303, 325-410
src/octave_mcp/core/sealer.py                                     59      0   100%
src/octave_mcp/core/validator.py                                 108      6    94%   46, 212, 243-251, 262
src/octave_mcp/mcp/__init__.py                                     0      0   100%
src/octave_mcp/mcp/base_tool.py                                   44      4    91%   89, 98, 107, 119
src/octave_mcp/mcp/eject.py                                      104      4    96%   101-102, 250-253
src/octave_mcp/mcp/server.py                                      60      9    85%   123, 127-129, 141-144, 149, 153
src/octave_mcp/mcp/validate.py                                   153     19    88%   109-110, 116-119, 123-126, 271-272, 351-353, 419, 447, 462-465
src/octave_mcp/mcp/write.py                                      399     61    85%   139-140, 167-186, 325-326, 370-371, 465, 505-506, 554-555, 609, 676-677, 700-701, 709-710, 727-728, 787-788, 795-797, 813-814, 835, 841-842, 858-860, 890, 893, 897, 921-942, 977, 1006-1007, 1021-1027
src/octave_mcp/resources/__init__.py                               0      0   100%
src/octave_mcp/resources/specs/__init__.py                         0      0   100%
src/octave_mcp/resources/specs/schemas/__init__.py                 0      0   100%
src/octave_mcp/resources/specs/schemas/json/__init__.py            0      0   100%
src/octave_mcp/resources/specs/vocabularies/__init__.py            0      0   100%
src/octave_mcp/resources/specs/vocabularies/core/__init__.py       0      0   100%
src/octave_mcp/schemas/__init__.py                                 0      0   100%
src/octave_mcp/schemas/builtin/__init__.py                         0      0   100%
src/octave_mcp/schemas/loader.py                                  55      3    95%   85, 185-187
src/octave_mcp/schemas/repository.py                              12      1    92%   34
--------------------------------------------------------------------------------------------
TOTAL                                                           3816    369    90%
Coverage HTML written to dir htmlcov
======================= 1237 passed, 9 skipped in 2.56s ======================== (1237 passed, 9 skipped)\n