### PR TITLE
feat(mcp): add startup dependency sync to prevent stale venv

### DIFF
--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,64 @@
+"""Tests for MCP server startup and configuration."""
+
+import os
+from unittest.mock import patch
+
+from octave_mcp.mcp.server import ensure_dependencies_synced, parse_disabled_tools
+
+
+class TestEnsureDependenciesSynced:
+    """Tests for startup dependency sync."""
+
+    def test_skip_sync_when_env_var_set(self):
+        """Should skip sync when OCTAVE_MCP_SKIP_SYNC=1."""
+        with patch.dict(os.environ, {"OCTAVE_MCP_SKIP_SYNC": "1"}):
+            # Should return early without doing anything
+            ensure_dependencies_synced()
+            # No exception means success
+
+    def test_sync_runs_in_real_project(self):
+        """Should attempt sync when in a real project directory."""
+        # This test runs in a real project with pyproject.toml
+        # Just verify it doesn't crash
+        with patch.dict(os.environ, {"OCTAVE_MCP_SKIP_SYNC": ""}):
+            # Should not raise - may or may not actually run uv sync
+            # depending on whether uv is available
+            ensure_dependencies_synced()
+
+    def test_skip_sync_when_uv_not_available(self):
+        """Should skip sync gracefully when uv is not installed."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("uv not found")
+            # Should not raise
+            ensure_dependencies_synced()
+
+
+class TestParseDisabledTools:
+    """Tests for DISABLED_TOOLS parsing."""
+
+    def test_empty_env_returns_empty_set(self):
+        """Empty DISABLED_TOOLS returns empty set."""
+        with patch.dict(os.environ, {"DISABLED_TOOLS": ""}):
+            assert parse_disabled_tools() == set()
+
+    def test_single_tool_disabled(self):
+        """Single tool can be disabled."""
+        with patch.dict(os.environ, {"DISABLED_TOOLS": "octave_eject"}):
+            assert parse_disabled_tools() == {"octave_eject"}
+
+    def test_multiple_tools_disabled(self):
+        """Multiple tools can be disabled."""
+        with patch.dict(os.environ, {"DISABLED_TOOLS": "octave_eject, octave_validate"}):
+            assert parse_disabled_tools() == {"octave_eject", "octave_validate"}
+
+    def test_whitespace_handling(self):
+        """Whitespace around tool names is trimmed."""
+        with patch.dict(os.environ, {"DISABLED_TOOLS": "  octave_eject  ,  octave_validate  "}):
+            assert parse_disabled_tools() == {"octave_eject", "octave_validate"}
+
+    def test_unset_env_returns_empty_set(self):
+        """Unset DISABLED_TOOLS returns empty set."""
+        env = os.environ.copy()
+        env.pop("DISABLED_TOOLS", None)
+        with patch.dict(os.environ, env, clear=True):
+            assert parse_disabled_tools() == set()


### PR DESCRIPTION
## Summary

Add automatic dependency sync at MCP server startup to prevent issues where the server runs with stale dependencies after `uv.lock` is updated.

## Problem

The MCP server runs independently from user worktrees. If `uv.lock` is updated (e.g., new dependencies added), the server's venv may be out of sync, causing import errors or running with old code.

This was observed with debate-hall-mcp where `python-ulid` was missing after a lock file update.

## Solution

Add `ensure_dependencies_synced()` that runs at server startup:

1. **Find project root** - Walk up from package location to find `pyproject.toml`
2. **Check for uv.lock** - Only sync if lock file exists
3. **Check for uv** - Skip gracefully if uv not installed
4. **Run `uv sync --quiet`** - Ensure venv matches lock file
5. **Graceful degradation** - Log warnings but don't fail if sync fails

## Configuration

- **OCTAVE_MCP_SKIP_SYNC=1** - Skip dependency sync (for CI or production)

## Test plan

- [x] 8 new tests for server configuration
- [x] All 1609 tests passing
- [x] Quality gates passing

## Files Changed

- `src/octave_mcp/mcp/server.py` - Add `ensure_dependencies_synced()`, call from `run()`
- `tests/unit/test_mcp_server.py` - New test file for server startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)