### PR TITLE
chore: bump version to 1.0.0 for stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@ All notable changes to OCTAVE-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] - 2026-01-30 - "Generative Holographic Contracts" Release
 
-This release represents the v1.0.0 development push with four internal milestones (M1-M4) completing full OCTAVE v6 specification compliance. All changes target the v1.0.0 release.
+This release marks the stable v1.0.0 of OCTAVE-MCP, completing four internal milestones (M1-M4) with full OCTAVE v6 specification compliance. OCTAVE-MCP is now production-ready for LLM communication with generative holographic contracts.
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "0.6.1"
+version = "1.0.0"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -22,7 +22,7 @@ keywords = [
     "compression"
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",

--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "0.6.1"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version from `0.6.1` to `1.0.0` in `pyproject.toml`
- Update classifier to `Development Status :: 5 - Production/Stable`
- Update CHANGELOG: `[Unreleased]` → `[1.0.0] - 2026-01-30 - "Generative Holographic Contracts" Release`

## Pre-Release Validation

### Stub Detection Scan
| Category | Findings | Status |
|----------|----------|--------|
| NotImplementedError | 0 | ✅ Clean |
| TODO/FIXME markers | 0 | ✅ Clean |
| Hidden stubs | 2 (legitimate) | ✅ Verified OK |
| Dead parameters | 0 | ✅ All params used |

### Quality Gates
| Check | Result |
|-------|--------|
| **pytest** | 1610 passed, 10 skipped |
| **ruff** | All checks passed |
| **mypy** | No issues in 43 source files |
| **black** | All files formatted |
| **MCP Tools** | All 3 functional (validate, write, eject) |
| **CLI** | All 8 commands working |

## Test plan
- [x] Full test suite passes (1610 tests)
- [x] All quality gates pass (ruff, mypy, black)
- [x] MCP tools manually tested
- [x] CLI commands verified
- [x] Stub detection scan completed
- [x] Version number consistent across files

🤖 Generated with [Claude Code](https://claude.com/claude-code)