### PR TITLE
docs(readme): clarify implementation status of generative constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ This repository ships the **OCTAVE MCP Server** (v1.0.0)—a Model Context Proto
 OCTAVE (Olympian Common Text And Vocabulary Engine) is a deterministic document format and control plane for LLM systems. It keeps meaning durable when text is compressed, routed between agents, or projected into different views.
 
 **Core Philosophy: Validation Precedes Generation**
-Instead of checking if an LLM wrote a valid document *after* the fact, OCTAVE v6 compiles the document's `META` block into a strict grammar (Regex/GBNF) that *constrains* the LLM's output generation. It is structurally impossible to generate invalid syntax.
+OCTAVE v6 introduces the principle that schemas should constrain LLM output *during* generation, not just validate it afterward. The `META` block can compile to strict grammars (Regex/GBNF) for constrained generation.
 
-- **Generative Constraints**: `META.CONTRACT` compiles to regex/grammar for LLM guidance.
+> **Implementation Status (v0.6.0):** Grammar compilation is implemented and available via `debug_grammar=True`. However, the MCP tools (`octave_validate`, `octave_write`) currently perform post-hoc validation rather than enforcing grammar constraints during generation. See the [architecture spec](src/octave_mcp/resources/specs/octave-mcp-architecture.oct.md) for details.
+
+- **Generative Constraints**: `META.CONTRACT` compiles to regex/GBNF grammar (use `debug_grammar=True` to inspect).
 - **Holographic Sovereignty**: The document defines its own schema laws inline.
 - **Hermetic Anchoring**: No network calls in the hot path. Standards are frozen or local.
 - **Auditable Loss**: Compression tiers declared in `META` (`LOSSLESS`, `AGGRESSIVE`).
@@ -99,7 +101,7 @@ See the [protocol specs in `src/octave_mcp/resources/specs/`](src/octave_mcp/res
 `octave-mcp` bundles the OCTAVE tooling as MCP tools and a CLI.
 
 - **3 MCP tools**: `octave_validate`, `octave_write`, `octave_eject`
-- **Generative Engine**: Compiles constraints to grammars (`debug_grammar=True`).
+- **Grammar Compiler**: Compiles `META.CONTRACT` constraints to GBNF grammars (inspect via `debug_grammar=True`).
 - **Hermetic Hydrator**: Resolves standards without network dependency.
 
 ## When OCTAVE Helps
@@ -215,10 +217,12 @@ format: str           # Output: octave, json, yaml, markdown, gbnf
 
 ### Generative Holographic Contracts (v6)
 
-OCTAVE v6 introduces the **Holographic Contract**:
+OCTAVE v6 introduces the **Holographic Contract** concept:
 1.  **Read META**: The parser reads the `META` block first.
-2.  **Compile Grammar**: It compiles the constraints (`REQ`, `ENUM`, `REGEX`) into a generative grammar.
-3.  **Generate/Validate**: The body is generated/validated against this bespoke grammar.
+2.  **Compile Grammar**: Constraints (`REQ`, `ENUM`, `REGEX`) compile into GBNF grammar (available via `debug_grammar=True`).
+3.  **Generate/Validate**: The body can be validated against this bespoke grammar.
+
+> **Note:** In v0.6.0, grammar compilation is implemented but tools perform post-hoc validation. Grammar-constrained generation is a roadmap feature.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

This PR updates the README to accurately reflect the current implementation status of generative constraints in OCTAVE-MCP v0.6.0.

## Changes

- Clarified that while grammar compilation is implemented, the MCP tools currently perform post-hoc validation rather than enforcing constraints during generation
- Added implementation status note explaining that `debug_grammar=True` exposes the compiled grammars
- Updated terminology from "Generative Engine" to "Grammar Compiler" for accuracy
- Added notes indicating that grammar-constrained generation is a roadmap feature

## Context

These changes address the philosophical tension between "Validation Precedes Generation" and the current implementation reality:
- OCTAVE-MCP cannot control LLM generation (it's a tool, not the inference engine)
- The grammar compiler exists and works, but enforcement happens at the inference layer
- This transparency helps users understand what the tools can and cannot do

## Related

- Issue #228: Grammar Compilation Implementation Gap
- Architecture spec: `src/octave_mcp/resources/specs/octave-mcp-architecture.oct.md`

These documentation updates ensure users have accurate expectations about the current capabilities while the team works on exposing the grammar compilation functionality more directly.