### PR TITLE
chore: release v1.2.0 "Specification Refinement"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-02-15 - "Specification Refinement" Release
+
+This release enhances the specification suite with improved skills and agents specs, and introduces Streamable HTTP transport for web-based client access.
+
 ### Added
 - **Streamable HTTP Transport** (#218, #221) - Web-based clients can now access OCTAVE tools via HTTP
   - Single `/mcp` endpoint per MCP Streamable HTTP specification
@@ -18,6 +22,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Stateless mode support for serverless deployments (`--stateless`)
   - New optional `[http]` dependency group: `pip install octave-mcp[http]`
   - 31 new tests covering transport, security, CLI, and integration
+- **Enhanced Skills Specification** (#225) - octave-skills-spec v8.0 with canonical structure requirements
+  - Compression mandate for all skills (AGGRESSIVE tier minimum)
+  - Standardized canonical sections: ESSENCE, SYNTAX, CONSTRAINTS, VALIDATE
+  - Clarified that archetype vocabulary is open (extensible), not closed
+- **Enhanced Agents Specification** (#225) - octave-agents-spec v6 improvements
+  - Added `AUTHORITY` as optional field for agent role hierarchy
+  - Enables explicit authority level declarations for agent coordination
+
+### Changed
+- **Documentation Clarity** (#229) - README improvements for generative constraints
+  - Clarified implementation status of generative holographic contracts
+  - Updated feature documentation to reflect current capabilities
+
+### Fixed
+- **Specification Syntax** (#227) - Fixed OCTAVE spec compliance issues
+  - Fixed `MARKDOWN_EMBEDDING` value quoting to prevent lexer errors
+  - Aligned specs and `octave_write` tool with markdown code fence syntax
+  - Ensures all specifications parse correctly without syntax warnings
+
+### Quality Gates
+- All changes reviewed per tier requirements
+- Constitutional compliance verified: I1, I3, I5
+- HTTP transport includes comprehensive security testing
 
 ## [1.1.0] - 2026-02-02 - "Decision Scaffolding" Release
 
@@ -319,7 +346,8 @@ the architectural separation of the OCTAVE language specification from implement
 - Non-reasoning document processing
 - Deterministic, idempotent transformations
 
-[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/elevanaltd/octave-mcp/compare/v0.6.1...v1.0.0
 [0.6.1]: https://github.com/elevanaltd/octave-mcp/compare/v0.6.0...v0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release v1.2.0 with specification enhancements and Streamable HTTP transport.

## Changes

### Added
- **Streamable HTTP Transport** (#218, #221) - Web-based clients can now access OCTAVE tools via HTTP
  - Single `/mcp` endpoint per MCP Streamable HTTP specification
  - DNS rebinding protection enabled by default
  - Localhost binding (127.0.0.1) by default for security
  - CLI support: `--transport http --port 8080 --host 127.0.0.1`
  - Environment variables: `MCP_TRANSPORT`, `MCP_HOST`, `MCP_PORT`
  - Health check endpoint at `/health` for load balancers
  - Stateless mode support for serverless deployments
  - New optional `[http]` dependency group: `pip install octave-mcp[http]`
  - 31 new tests covering transport, security, CLI, and integration

- **Enhanced Skills Specification** (#225) - octave-skills-spec v8.0
  - Compression mandate for all skills (AGGRESSIVE tier minimum)
  - Standardized canonical sections: ESSENCE, SYNTAX, CONSTRAINTS, VALIDATE
  - Clarified that archetype vocabulary is open (extensible), not closed

- **Enhanced Agents Specification** (#225) - octave-agents-spec v6
  - Added `AUTHORITY` as optional field for agent role hierarchy
  - Enables explicit authority level declarations for agent coordination

### Changed
- **Documentation Clarity** (#229) - README improvements
  - Clarified implementation status of generative holographic contracts
  - Updated feature documentation to reflect current capabilities

### Fixed
- **Specification Syntax** (#227) - Fixed OCTAVE spec compliance issues
  - Fixed `MARKDOWN_EMBEDDING` value quoting to prevent lexer errors
  - Aligned specs and `octave_write` tool with markdown code fence syntax
  - Ensures all specifications parse correctly without syntax warnings

## Quality Gates
- ✅ All changes reviewed per tier requirements
- ✅ Constitutional compliance verified: I1, I3, I5
- ✅ HTTP transport includes comprehensive security testing

## Test plan
- [x] CHANGELOG.md updated with all changes since v1.1.0
- [x] Version bumped to 1.2.0 in pyproject.toml
- [x] Commit message follows Conventional Commits format
- [ ] CI passes all tests
- [ ] Version tag created after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)