### PR TITLE
fix: update __version__ to 1.2.0 in __init__.py

### DIFF
--- a/src/octave_mcp/__init__.py
+++ b/src/octave_mcp/__init__.py
@@ -39,7 +39,7 @@ from octave_mcp.core.schema_extractor import FieldDefinition, SchemaDefinition, 
 from octave_mcp.core.sealer import SealVerificationResult, seal_document, verify_seal
 from octave_mcp.core.validator import ValidationError, Validator
 
-__version__ = "0.6.1"
+__version__ = "1.2.0"
 
 # Canonical OCTAVE operators (per specs/octave-5-llm-core.oct.md §2)
 # These are the Unicode canonical forms. ASCII aliases are also accepted by the lexer.


### PR DESCRIPTION
## Summary

Fixes version synchronization issue that caused the v1.2.0 release to fail verification.

## Problem

The GitHub Actions publish workflow failed at the verification step because:
- `pyproject.toml` had version `1.2.0`
- `src/octave_mcp/__init__.py` still had version `0.6.1`
- The CLI `octave --version` was reading from `__init__.py.__version__`

See failed workflow: https://github.com/elevanaltd/octave-mcp/actions/runs/22035270071/job/63666993708

## Fix

Updated `src/octave_mcp/__init__.py` to set `__version__ = "1.2.0"` to match `pyproject.toml`.

## Verification

After this fix:
- ✅ `pyproject.toml` version: `1.2.0`
- ✅ `src/octave_mcp/__init__.py` version: `1.2.0`
- ✅ CLI `octave --version` will report: `1.2.0`
- ✅ Python `octave_mcp.__version__` will return: `1.2.0`

## Next Steps

After merge:
1. Delete the failed v1.2.0 GitHub release
2. Delete the v1.2.0 tag
3. Re-create the tag from the fixed commit
4. Re-create the GitHub release to trigger PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)