### PR TITLE
fix(zone-report): add UNVALIDATED status to container in all three to…

### DIFF
--- a/src/octave_mcp/mcp/eject.py
+++ b/src/octave_mcp/mcp/eject.py
@@ -304,6 +304,7 @@ META:
                 "dsl": {"status": "valid", "errors": []},
                 "container": {
                     "status": "preserved" if result.filtered_doc.raw_frontmatter else "absent",
+                    "validation_status": "UNVALIDATED",  # I5: no schema covers Zone 2 yet (#244)
                 },
                 "literal": {
                     "status": "preserved",

--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -445,6 +445,7 @@ class ValidateTool(BaseTool):
                     "dsl": {"status": "valid", "errors": []},
                     "container": {
                         "status": "preserved" if doc.raw_frontmatter else "absent",
+                        "validation_status": "UNVALIDATED",  # I5: no schema covers Zone 2 yet (#244)
                     },
                     "literal": {
                         "status": "preserved",

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1025,6 +1025,7 @@ class WriteTool(BaseTool):
                 "dsl": {"status": "valid", "errors": []},
                 "container": {
                     "status": "preserved" if doc.raw_frontmatter else "absent",
+                    "validation_status": "UNVALIDATED",  # I5: no schema covers Zone 2 yet (#244)
                 },
                 "literal": {
                     "status": "preserved",


### PR DESCRIPTION
…ols (#244)

I5 (Schema Sovereignty) requires honest reporting — if we can't validate, say so. Zone 2 (YAML frontmatter) is preserved but never schema-validated. All three tools (validate, write, eject) now report:

  zone_report.container.validation_status = "UNVALIDATED"

This is a one-liner per tool, zero risk, no behaviour change — purely honest I5 reporting until Issue #244 (frontmatter schema support) ships.