### PR TITLE
fix(comments): remove stale #244 references now that Zone 2 validation is delivered

### DIFF
--- a/src/octave_mcp/mcp/eject.py
+++ b/src/octave_mcp/mcp/eject.py
@@ -304,7 +304,7 @@ META:
                 "dsl": {"status": "valid", "errors": []},
                 "container": {
                     "status": "preserved" if result.filtered_doc.raw_frontmatter else "absent",
-                    "validation_status": "UNVALIDATED",  # I5: no schema covers Zone 2 yet (#244)
+                    "validation_status": "UNVALIDATED",  # I5: default before schema validation runs
                 },
                 "literal": {
                     "status": "preserved",

--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -445,7 +445,7 @@ class ValidateTool(BaseTool):
                     "dsl": {"status": "valid", "errors": []},
                     "container": {
                         "status": "preserved" if doc.raw_frontmatter else "absent",
-                        "validation_status": "UNVALIDATED",  # I5: no schema covers Zone 2 yet (#244)
+                        "validation_status": "UNVALIDATED",  # I5: default before schema validation runs
                     },
                     "literal": {
                         "status": "preserved",

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1123,7 +1123,7 @@ class WriteTool(BaseTool):
                 "dsl": {"status": "valid", "errors": []},
                 "container": {
                     "status": "preserved" if doc.raw_frontmatter else "absent",
-                    "validation_status": "UNVALIDATED",  # I5: no schema covers Zone 2 yet (#244)
+                    "validation_status": "UNVALIDATED",  # I5: default before schema validation runs
                 },
                 "literal": {
                     "status": "preserved",


### PR DESCRIPTION
## Summary
- Updates 3 stale comments in `write.py`, `validate.py`, and `eject.py` that claimed "no schema covers Zone 2 yet (#244)"
- PR #254 delivered Zone 2 frontmatter validation, making these comments inaccurate
- Comments now read `# I5: default before schema validation runs` which accurately describes the runtime behavior
- 8 legitimate #244 provenance references (attribution, not status claims) left intact

## Test plan
- [x] No functional changes — comment-only updates
- [x] Quality gates: ruff, black, mypy all passing
- [x] Pre-push hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)