### PR TITLE
fix(guides): tighten lite instruction from cross-model feedback

### DIFF
--- a/docs/guides/octave-custom-instruction-lite.md
+++ b/docs/guides/octave-custom-instruction-lite.md
@@ -31,6 +31,9 @@ You know the OCTAVE format — a structured notation for LLM communication achie
 - `KEY::value` — double colon, no spaces around `::`
 - `KEY:` + newline + 2-space indent — nested block
 - `[a,b,c]` — lists. `[key::val,key2::val2]` — inline maps (atoms only, no nesting)
+- `NAME[args]` — parameterized term (e.g., `SISYPHEAN[loop_detail]`, `GORDIAN[solution]`)
+- `---` separates META block from body (optional)
+- Quotes required for strings with spaces or special chars; optional for bare words
 - 2-space indent per level. No tabs.
 - `//` comments — never inside the META block
 
@@ -66,7 +69,7 @@ You know the OCTAVE format — a structured notation for LLM communication achie
 
 **Never:** add absolutes not in source | merge distinct concepts | strengthen/weaken hedged claims | drop numbers
 
-**Only convert if** OCTAVE is shorter or more parseable than prose. If not → recommend prose.
+Source <100 words with no structure → recommend prose instead of converting.
 
 ### NAMING AND MYTHOLOGY
 
@@ -78,7 +81,7 @@ You know the OCTAVE format — a structured notation for LLM communication achie
 - `GORDIAN` → unconventional breakthrough cutting impossible constraints
 - `PANDORAN` → cascading unforeseen consequences from a single action
 - `HUBRIS→NEMESIS` → overconfidence heading toward inevitable consequence
-- Literal wins when equally clear: `AUTH_MODULE` > `ARES_GATEWAY`, `VALIDATOR` > `APOLLO`
+- Mythology is optional. Use when a single term replaces a multi-word state description. Skip when a literal term is equally short.
 
 When writing documents for other agents who haven't seen OCTAVE before, include a one-line context note: *"Mythology terms (SISYPHEAN, GORDIAN etc.) are semantic zip files — compressed meaning, not system names."*
 
@@ -100,7 +103,7 @@ META:
 
 PROBLEM:
   PATTERN::SISYPHEAN[integration_test_failures→fix→overnight_reset→repeat]
-  ROOT_CAUSE::shared_staging_db[multi_team_writes∧no_coordination→unpredictable_state]
+  ROOT_CAUSE::shared_staging_db[□[multi_team_writes]∧no_coordination→unpredictable_state]
 
 SOLUTION:
   APPROACH::GORDIAN[isolated_test_env_per_team]
@@ -113,7 +116,6 @@ SOLUTION:
 
 - **ZERO CHATTER:** When converting, output ONLY the OCTAVE code block. Notes after `===END===` if necessary.
 - **DYNAMIC NAMING:** Generate descriptive `===NAME===` from content. Never reuse the system prompt's name.
-- Source <100 words with no structure → suggest prose instead
 - When unsure → preserve rather than drop
 
 ## --- END CUSTOM INSTRUCTION ---


### PR DESCRIPTION
## Summary

Addresses gaps identified from zero-shot reviews by Gemini, ChatGPT, Claude Sonnet, and Claude Haiku on the lite custom instruction.

- **Define `NAME[args]` constructor in FORMAT** — used in the example (`SISYPHEAN[...]`, `GORDIAN[...]`) but undocumented, causing a rule/example mismatch that LLMs copy the example over the rule
- **Define `---` separator in FORMAT** — present in the example but not in the spec, flagged by both Gemini and ChatGPT
- **Add quote usage rule to FORMAT** — clarifies when quotes are required vs optional
- **Replace subjective conversion gate** — "Only convert if OCTAVE is shorter or more parseable" is a judgment call LLMs apply inconsistently; replaced with deterministic `<100 words with no structure → recommend prose`
- **Add provenance marker `□` to example** — Gemini and Claude Sonnet both noted the markers are taught in rules but not modelled in the example; added one instance to `ROOT_CAUSE`
- **Sharpen mythology decision test** — replace abstract "Literal wins when equally clear" with measurable: "Use when a single term replaces a multi-word state description. Skip when a literal term is equally short"
- **Remove duplicate prose-fallback rule** from BEHAVIOR (now only in COMPRESSION)

## Test plan

- [ ] Read the updated lite instruction cold and verify the example is fully consistent with the FORMAT rules
- [ ] Confirm `NAME[args]`, `---`, and quote rules are all present in FORMAT before their first use in the example

🤖 Generated with [Claude Code](https://claude.com/claude-code)