### PR TITLE
feat(spec): update octave-agents-spec to v7.0.0 — cognitive separation

### DIFF
--- a/src/octave_mcp/resources/specs/octave-agents-spec.oct.md
+++ b/src/octave_mcp/resources/specs/octave-agents-spec.oct.md
@@ -16,14 +16,16 @@ META:
 // - §2 renamed from BEHAVIOR to OPERATIONAL_BEHAVIOR
 // - §1 CORE:: wrapper removed — properties are direct children of §1
 // - AUTHORITY flattened to AUTHORITY_BLOCKING, AUTHORITY_MANDATE, etc.
-// - COGNITION::TYPE in §1 serves as link key to cognition master file
+// - COGNITION field in §1 serves as link key to cognition master file
 // - Cognition masters: library/cognitions/logos.oct.md, ethos.oct.md, pathos.oct.md
 //
 // MIGRATION NOTE:
 // Cognition-derived properties (FORCE, ESSENCE, ELEMENT, MODE, THINK, THINK_NEVER)
 // live in standalone cognition files loaded before the anchor ceremony.
-// Agent files reference their cognition type via COGNITION::TYPE in §1.
-// No §0 section — cognition is a pre-ceremony load, not an in-file section.
+// Agent files reference their cognition type via COGNITION field in §1.
+// No §0::COGNITIVE_FOUNDATION section in agent files — cognition is a
+// pre-ceremony load, not an in-file section. §0::META below defines
+// the spec's own contract metadata (unchanged from v6).
 §0::META
   PURPOSE::"Contract definition and versioning"
   REQUIRED::[TYPE,VERSION]


### PR DESCRIPTION
## Summary

- Updates `octave-agents-spec.oct.md` from v6.2.0 to v7.0.0 implementing the "Cognitive Separation" schema
- Removes ACTIVATION (FORCE/ESSENCE/ELEMENT) and MODE from agent file spec — these move to standalone cognition master files (`library/cognitions/{logos,ethos,pathos}.oct.md`)
- Renames §2::BEHAVIOR → §2::OPERATIONAL_BEHAVIOR, flattens §1 structure (removes CORE:: wrapper, flattens AUTHORITY), adds COGNITION_LOAD to §5

## Context

Issue #314 RFC proposed §0::COGNITIVE_FOUNDATION embedded in agent files. After holistic review against Project #15 (OA Rebuild), the interim approach avoids throwaway work: cognition lives in separate files loaded pre-ceremony, not as an in-file §0 section. Full rationale in [#314 comments](https://github.com/elevanaltd/octave-mcp/issues/314).

## Test plan

- [x] All 2437 tests passing (spec file is a resource, not parsed by tests)
- [ ] Verify hestai-mcp agent migration follows this spec structure
- [ ] Verify cognition master files created in hestai-mcp

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)