### PR TITLE
fix(lexer): support comma-separated qualifiers in angle bracket annotations

### DIFF
--- a/src/octave_mcp/core/lexer.py
+++ b/src/octave_mcp/core/lexer.py
@@ -497,8 +497,21 @@ def _match_unicode_identifier(
         if qualifier_start < len(content) and _is_valid_identifier_start(content[qualifier_start]):
             qualifier_end = qualifier_start + 1
             # Consume remaining qualifier characters (identifier body chars)
+            # GH#320: Support comma-separated qualifier lists like NEVER<PEDANTIC,DISMISSIVE,VAGUE>
+            # Commas are allowed ONLY between valid identifier segments (no leading/trailing commas)
             while qualifier_end < len(content) and _is_valid_identifier_char(content[qualifier_end]):
                 qualifier_end += 1
+            # After consuming first qualifier segment, check for comma + next segment
+            while (
+                qualifier_end < len(content)
+                and content[qualifier_end] == ","
+                and qualifier_end + 1 < len(content)
+                and _is_valid_identifier_start(content[qualifier_end + 1])
+            ):
+                qualifier_end += 1  # consume the comma
+                # consume the next identifier segment
+                while qualifier_end < len(content) and _is_valid_identifier_char(content[qualifier_end]):
+                    qualifier_end += 1
             # Strip trailing hyphens from qualifier (same as identifier rule)
             while qualifier_end > qualifier_start + 1 and content[qualifier_end - 1] == "-":
                 qualifier_end -= 1

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -997,6 +997,40 @@ class TestAngleBracketAnnotation:
         with pytest.raises(LexerError):
             tokenize("A<-x>")
 
+    def test_comma_separated_qualifiers_standalone(self):
+        """GH#320: NEVER<PEDANTIC,DISMISSIVE,VAGUE> should tokenize as single IDENTIFIER."""
+        tokens, _ = tokenize("NEVER<PEDANTIC,DISMISSIVE,VAGUE>")
+        identifiers = [t for t in tokens if t.type == TokenType.IDENTIFIER]
+        assert len(identifiers) == 1
+        assert identifiers[0].value == "NEVER<PEDANTIC,DISMISSIVE,VAGUE>"
+
+    def test_comma_separated_qualifiers_in_array(self):
+        """GH#320: Comma-separated qualifiers inside array context."""
+        tokens, _ = tokenize("[NEVER<PEDANTIC,DISMISSIVE,VAGUE>,ALWAYS<CONSTRUCTIVE,EDUCATIONAL,SPECIFIC>]")
+        identifiers = [t for t in tokens if t.type == TokenType.IDENTIFIER]
+        assert len(identifiers) == 2
+        assert identifiers[0].value == "NEVER<PEDANTIC,DISMISSIVE,VAGUE>"
+        assert identifiers[1].value == "ALWAYS<CONSTRUCTIVE,EDUCATIONAL,SPECIFIC>"
+
+    def test_comma_separated_qualifiers_in_gates_syntax(self):
+        """GH#320: Exact spec syntax GATES::[NEVER<prohibited>,ALWAYS<required>]."""
+        tokens, _ = tokenize("GATES::[NEVER<prohibited>,ALWAYS<required>]")
+        identifiers = [t for t in tokens if t.type == TokenType.IDENTIFIER]
+        assert len(identifiers) == 3
+        assert identifiers[0].value == "GATES"
+        assert identifiers[1].value == "NEVER<prohibited>"
+        assert identifiers[2].value == "ALWAYS<required>"
+
+    def test_comma_separated_qualifiers_no_leading_comma(self):
+        """GH#320: Leading comma in qualifier should NOT form annotation."""
+        with pytest.raises(LexerError):
+            tokenize("NEVER<,PEDANTIC>")
+
+    def test_comma_separated_qualifiers_no_trailing_comma(self):
+        """GH#320: Trailing comma in qualifier should NOT form annotation."""
+        with pytest.raises(LexerError):
+            tokenize("NEVER<PEDANTIC,>")
+
 
 class TestLexerPercentInValues:
     """GH#287 P1: Lexer must accept % in values when preceded by alphanumeric."""


### PR DESCRIPTION
## Summary
- Fixes lexer E005 error when `NEVER<PEDANTIC,DISMISSIVE,VAGUE>` or `ALWAYS<CONSTRUCTIVE,EDUCATIONAL,SPECIFIC>` constructor syntax appears inside `::[]` arrays
- Extends `_match_unicode_identifier()` qualifier loop to consume commas between valid identifier segments
- Adds 5 new tests covering comma-separated qualifiers (standalone, array, gates syntax, edge cases)

Closes #320

## Changes
- `src/octave_mcp/core/lexer.py` — 13 lines added to qualifier consumption loop
- `tests/unit/test_lexer.py` — 34 lines: 5 new test cases in `TestAngleBracketAnnotation`

## Test plan
- [x] RED: 2 new tests fail before fix (comma-separated qualifiers)
- [x] GREEN: All 2442 tests pass after fix
- [x] Existing `test_annotation_in_list` still passes (single qualifier)
- [x] Existing `test_tension_operator_still_works` still passes (`<->`)
- [x] Edge cases: leading/trailing commas correctly rejected
- [x] Quality gates: ruff, mypy, pytest all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)