### PR TITLE
chore: sync uv.lock with version 1.9.4

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -610,7 +610,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.9.2"
+version = "1.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Syncs `uv.lock` to reflect the version bump from 1.9.2 → 1.9.4 in pyproject.toml
- This was missed from PR #338 (the lockfile wasn't staged before the merge)

## Test plan
- [x] Single lockfile line change — no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `uv.lock` to set `octave-mcp` to version 1.9.4, matching `pyproject.toml` and fixing the missed lockfile sync from the previous bump. No functional impact; one-line lockfile change.

<sup>Written for commit 13a32dd44b5ac0977e5f1a3431b2f6532af17f47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

