### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "1.9.6"
+version = "1.10.0"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Version bump from 1.9.6 to 1.10.0 reflecting 6 new features, 10+ bug fixes, and 650+ new tests merged via PR #361 and #362.

## Test plan
- [x] No code changes — version string only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `octave-mcp` to v1.10.0 to ship recent work (6 new features, 10+ bug fixes, 650+ tests). No code changes — only the version field in `pyproject.toml` is updated.

<sup>Written for commit 941a526dc497c021a9fe4dda524927ee51a897d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

