### PR TITLE
docs(write): clarify E_INVALID_OP_DESCRIPTOR for DELETE op

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -212,7 +212,7 @@ if any descriptor is invalid, none are applied (fail-fast atomicity).
 |---|---|
 | `E_OP_TARGET_MISMATCH` | `APPEND`/`PREPEND` on a non-array, or `MERGE` on a non-block |
 | `E_UNRESOLVABLE_PATH` | path does not resolve in the AST (auto-create is forbidden) |
-| `E_INVALID_OP_DESCRIPTOR` | unknown `$op`, missing `value`, or `MERGE` with non-dict `value` |
+| `E_INVALID_OP_DESCRIPTOR` | unknown `$op`, missing `value` for `APPEND`/`PREPEND`/`MERGE` (not `DELETE`), or `MERGE` with non-dict `value` |
 
 > **Diff-locality note.** `$op` descriptors give you correct, targeted *semantics*
 > (e.g. APPEND mutates only the array's contents in the AST), but the rendered


### PR DESCRIPTION
## Summary

Clarify that the missing `value` validation in `E_INVALID_OP_DESCRIPTOR` only applies to APPEND, PREPEND, and MERGE operations. DELETE is valid without a value field per design (payload-free operation).

## Context

Code review of GH#373 (PR#374) identified a documentation accuracy issue:
- The error table description for `E_INVALID_OP_DESCRIPTOR` generically states 'missing value' is invalid
- However, the implementation correctly allows DELETE without a value field (see write.py:477-479)
- The implementation is correct per design, but the docs need clarification

## Changes

Updated docs/api.md line 215 to explicitly note that the missing `value` validation applies only to APPEND/PREPEND/MERGE, not DELETE.

Test coverage for DELETE-without-value is already present in test_gh373_op_aware_mutation.py:490-506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified `E_INVALID_OP_DESCRIPTOR` docs: missing `value` is only invalid for `APPEND`, `PREPEND`, and `MERGE`; `DELETE` is valid without `value` as a payload-free op. This aligns the docs with current behavior and existing tests.

<sup>Written for commit 9bfc3e15a86c0dacdf2f1e38746efb7bca96c66e. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/375?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

