### PR TITLE
feat: add format_style parameter to write command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`format_style` parameter on `octave_write`** (#376, PR-A) — New optional parameter on the MCP tool (`format_style`) and CLI command (`--format-style`) accepting `"preserve"`, `"expanded"`, or `"compact"`. The three modes are AST-level pre-passes that funnel into the single canonical `emit()` (I1 Single-Canon Discipline), not parallel emitters:
+  - `"preserve"` — Strategy C narrow short-circuit: when `parse(new_content) == parse(baseline_content)`, write baseline bytes verbatim and skip canonical re-emission.
+  - `"expanded"` — Lift `InlineMap` (and `ListValue` items that are `InlineMap`) into `Block` form before `emit()`.
+  - `"compact"` — Collapse atom-only Blocks (no comments anywhere in subtree, arity ≤ 8) into `inline-list-of-InlineMap` form. Comment-bearing subtrees are vetoed and a new `W_COMPACT_REFUSED` correction is appended to the repair log (I3 Mirror Constraint + I4 Auditability). The CLI surfaces these records on stderr.
+  - Unknown values are rejected with `E_INVALID_FORMAT_STYLE` (I5 Schema Sovereignty).
+
+  This is **purely additive**: when the parameter is omitted, today's canonical behaviour is preserved byte-for-byte and all baseline tests pass unchanged. Default behaviour is **not** changed in this release. Richer per-key dirty tracking (Strategy A), deep changes-mode paths, and the SemVer-staged default flip are deferred to [#377](https://github.com/elevanaltd/octave-mcp/issues/377).
+
 ## [1.11.0] - 2026-04-17 - "Lexer Safety & Skill Upgrades" Release
 
 This release fixes silent data loss from `#` characters in values and `://` in URLs (W002 warning), hardens the lexer against trailing `#` edge cases, and fixes E005 false positives on digit-prefix hash values. On the skills side, three major version upgrades ship: `octave-literacy` v3.0 (LLM-consumption paradigm), `octave-mastery` v3.0, and `octave-compression` v3.0 with the new ULTRA_MYTHIC compression tier.

--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,7 @@ Unified entry point for writing OCTAVE files. Handles creation (new files) and m
 | `schema` | string | No | - | Schema name for validation |
 | `mutations` | object | No | - | META field overrides (applies to both modes) |
 | `base_hash` | string | No | - | Expected SHA-256 hash of existing file for consistency check (CAS) |
+| `format_style` | string | No | _(unset)_ | Output formatting projection — one of `"preserve"`, `"expanded"`, `"compact"`. When omitted, today's canonical emit behaviour is preserved exactly. See [Format-style modes](#format-style-modes-gh376-pr-a) below. |
 
 #### Returns
 
@@ -219,6 +220,58 @@ if any descriptor is invalid, none are applied (fail-fast atomicity).
 > diff is not yet guaranteed to be byte-stable outside the changed region — the
 > renderer canonicalises the whole document. Renderer stability is tracked
 > separately in [GH#371](https://github.com/elevanaltd/octave-mcp/issues/371).
+
+#### Format-style modes (GH#376 PR-A)
+
+`format_style` is an optional output-formatting projection. The three accepted
+values are **AST-level pre-passes that all funnel into the single canonical
+`emit()`** — they are projections of one canon, not parallel emitters
+(I1 Single-Canon Discipline). Unknown values are rejected with
+`E_INVALID_FORMAT_STYLE` (I5 Schema Sovereignty).
+
+| Mode | Semantics | When to use |
+|---|---|---|
+| _(unset / `null`)_ | Today's canonical behaviour byte-for-byte. No pre-pass, no short-circuit. | Default — preserves existing call-site behaviour. All baseline tests pass unchanged. |
+| `"preserve"` | **Strategy C narrow short-circuit.** If `parse(new_content) == parse(baseline_content)` (AST-equality, ignoring whitespace), write the baseline file's bytes verbatim and skip canonical re-emission entirely. Otherwise fall through to canonical `emit()`. | Governance / context files where whitespace-only or no-op edits should produce a zero-byte diff. **Note:** richer per-key dirty tracking (Strategy A) is intentionally deferred to [GH#377](https://github.com/elevanaltd/octave-mcp/issues/377). |
+| `"expanded"` | AST normalisation pre-pass that lifts `InlineMap` (and `ListValue` items that are `InlineMap`) into `Block` form before `emit()`. Materially changes on-disk shape vs default. | Canonicalisation pipelines where compact inline shapes must be normalised to multi-line Blocks for diff stability or downstream tooling. |
+| `"compact"` | AST pre-pass that collapses atom-only Blocks (no `Comment` anywhere in subtree, arity ≤ 8) into `Assignment(value=ListValue([InlineMap{...}, ...]))` form. Subtrees containing **any** `Comment` are vetoed and a `W_COMPACT_REFUSED` correction is appended to the repair log. | Token-minimised outputs for LLM consumption — but mind the comment veto. |
+
+##### `W_COMPACT_REFUSED` repair record
+
+When `format_style="compact"` encounters a Block whose subtree contains any
+`Comment` node, the collapse is **refused for that subtree** (the Block is
+left in its multi-line form) and a structured correction is appended to the
+response's repair log:
+
+```typescript
+{
+  code: "W_COMPACT_REFUSED",
+  field: "<dotted.path.to.block>",
+  message: "Compact projection refused: comment(s) present in subtree (I3 Mirror Constraint)."
+}
+```
+
+This record IS the I4 Auditability expression of compact-mode — every
+attempted-and-refused collapse leaves a receipt. The MCP tool surfaces it in
+the `corrections` field of the standard response; the CLI surfaces each entry
+on **stderr** after the write completes:
+
+```
+correction: W_COMPACT_REFUSED <field> -- <message>
+```
+
+Rationale: comments are I3 first-class content. Collapsing a Block to inline
+form would silently drop them. The veto + audit-log pattern preserves both
+the source content and a transparent record of where compact-mode could not
+be applied.
+
+##### Forward reference
+
+Strategy A (per-key dirty tracking, deep changes-mode paths, source-span
+infrastructure, and the `_normalize_value_for_ast` Block-shape preservation
+fix) is tracked in [GH#377](https://github.com/elevanaltd/octave-mcp/issues/377).
+The default value of `format_style` may flip from unset to `"preserve"` at
+that point; today's PR-A ships the toggle as purely additive.
 
 ---
 
@@ -705,6 +758,31 @@ octave validate document.oct.md --schema DECISION_LOG --strict
 
 - `0`: Valid (no errors)
 - `1`: Invalid (validation errors found)
+
+---
+
+### octave write — `--format-style` flag (GH#376 PR-A)
+
+The `octave write` CLI command (which mirrors the `octave_write` MCP tool)
+accepts a `--format-style` option with the same three modes documented in
+[Format-style modes](#format-style-modes-gh376-pr-a) above:
+
+```bash
+octave write FILE --content '...' [--format-style {preserve|expanded|compact}]
+octave write FILE --changes '{...}' [--format-style {preserve|expanded|compact}]
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--format-style` | choice | _(unset)_ | One of `preserve`, `expanded`, `compact`. Unset preserves today's canonical behaviour. See [Format-style modes](#format-style-modes-gh376-pr-a). |
+
+When `--format-style=compact` is used, any `W_COMPACT_REFUSED` records are
+surfaced on **stderr** (one line per refused collapse), in addition to the
+normal stdout success information:
+
+```
+correction: W_COMPACT_REFUSED <field> -- <message>
+```
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -252,6 +252,7 @@ asyncio.run(main())
 - `changes` (optional): Dictionary of field updates for existing files
 - `schema` (optional): Schema name for validation
 - `mutations` (optional): META field overrides
+- `format_style` (optional, GH#376 PR-A): Output projection — `"preserve"`, `"expanded"`, or `"compact"`. Unset preserves today's canonical behaviour. See [API reference](api.md#format-style-modes-gh376-pr-a) for full mode semantics and the `W_COMPACT_REFUSED` audit record.
 
 **Example:**
 

--- a/src/octave_mcp/cli/main.py
+++ b/src/octave_mcp/cli/main.py
@@ -438,7 +438,7 @@ def write(
     from octave_mcp.core.file_ops import atomic_write_octave, validate_octave_path
     from octave_mcp.core.parser import parse
     from octave_mcp.core.validator import Validator
-    from octave_mcp.mcp.write import _emit_with_style
+    from octave_mcp.mcp.write import OctaveASTCycleError, _emit_with_style
     from octave_mcp.schemas.loader import get_builtin_schema
 
     # CRS-FIX #3: XOR enforcement - exactly ONE input source
@@ -486,7 +486,12 @@ def write(
                 if _existing.exists():
                     try:
                         baseline_for_preserve = _existing.read_text(encoding="utf-8")
-                    except OSError:
+                    except (OSError, UnicodeError):
+                        # Cubic C1 (#376 PR-A): UnicodeDecodeError is a
+                        # ValueError, not an OSError, so a baseline file
+                        # with invalid UTF-8 previously aborted the write.
+                        # Degrade gracefully — preserve short-circuit just
+                        # cannot fire, and we fall through to canonical emit.
                         baseline_for_preserve = None
             canonical_content = _emit_with_style(
                 doc,
@@ -579,6 +584,14 @@ def write(
     except json_module.JSONDecodeError as e:
         click.echo(f"Error: Invalid JSON in --changes: {e}", err=True)
         raise SystemExit(1) from e
+    except OctaveASTCycleError as cyc:
+        # Cubic C3 (#376 PR-A): surface the structured E_AST_CYCLE code on
+        # stderr so CLI consumers can discriminate cycle errors from generic
+        # exit-1 failures. MUST appear BEFORE the broad ``except Exception``
+        # below — OctaveASTCycleError is a ValueError subclass and would
+        # otherwise be swallowed into the generic error path.
+        click.echo(f"Error: {OctaveASTCycleError.code} {cyc}", err=True)
+        raise SystemExit(1) from cyc
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
         raise SystemExit(1) from e

--- a/src/octave_mcp/cli/main.py
+++ b/src/octave_mcp/cli/main.py
@@ -396,6 +396,21 @@ def validate(file: str | None, use_stdin: bool, schema: str | None, fix: bool, v
 @click.option("--changes", help="JSON string of field changes for existing files")
 @click.option("--base-hash", help="Expected SHA-256 hash for CAS consistency check")
 @click.option("--schema", help="Schema name for validation before write")
+@click.option(
+    "--format-style",
+    "format_style",
+    type=click.Choice(["preserve", "expanded", "compact"]),
+    default=None,
+    help=(
+        "Output formatting style (GH#376 PR-A). "
+        "'preserve' = Strategy C no-op shortcut (write baseline bytes verbatim "
+        "when new content is AST-equal to existing file). "
+        "'expanded' = lift inline-map shapes into Block form. "
+        "'compact' = collapse atom-only Blocks to inline-list form (vetoed on "
+        "comment-bearing subtrees, W_COMPACT_REFUSED logged). "
+        "Default: today's canonical behaviour."
+    ),
+)
 def write(
     file: str,
     content: str | None,
@@ -403,6 +418,7 @@ def write(
     changes: str | None,
     base_hash: str | None,
     schema: str | None,
+    format_style: str | None,
 ):
     """Write OCTAVE file with validation.
 
@@ -418,10 +434,11 @@ def write(
     import sys
 
     from octave_mcp.core.ast_nodes import Assignment
-    from octave_mcp.core.emitter import emit
+    from octave_mcp.core.emitter import emit  # noqa: F401 -- kept for backwards-compatible imports
     from octave_mcp.core.file_ops import atomic_write_octave, validate_octave_path
     from octave_mcp.core.parser import parse
     from octave_mcp.core.validator import Validator
+    from octave_mcp.mcp.write import _emit_with_style
     from octave_mcp.schemas.loader import get_builtin_schema
 
     # CRS-FIX #3: XOR enforcement - exactly ONE input source
@@ -449,12 +466,35 @@ def write(
     if use_stdin:
         content = sys.stdin.read()
 
+    # GH#376 PR-A: corrections collector for CLI W_COMPACT_REFUSED entries.
+    # Surfaced via stderr after write completes when format_style="compact".
+    cli_corrections: list[dict] = []
+    baseline_for_preserve: str | None = None
+
     try:
         # Handle content mode (create/overwrite)
         if content is not None:
             # Parse and emit canonical form
             doc = parse(content)
-            canonical_content = emit(doc)
+            # GH#376 PR-A: when --format-style=preserve, read existing baseline
+            # bytes (if any) so the Strategy C short-circuit can return them
+            # verbatim on AST-equality.
+            if format_style == "preserve":
+                from pathlib import Path as _Path
+
+                _existing = _Path(file)
+                if _existing.exists():
+                    try:
+                        baseline_for_preserve = _existing.read_text(encoding="utf-8")
+                    except OSError:
+                        baseline_for_preserve = None
+            canonical_content = _emit_with_style(
+                doc,
+                baseline_bytes=baseline_for_preserve,
+                new_bytes=content,
+                format_style=format_style,
+                corrections=cli_corrections,
+            )
 
         else:
             # Handle changes mode (delta update)
@@ -468,6 +508,7 @@ def write(
 
             # Read existing file
             original_content = target_path.read_text(encoding="utf-8")
+            baseline_for_preserve = original_content
 
             # Parse existing content
             doc = parse(original_content)
@@ -492,7 +533,13 @@ def write(
                     if not found:
                         doc.sections.append(Assignment(key=key, value=value))
 
-            canonical_content = emit(doc)
+            canonical_content = _emit_with_style(
+                doc,
+                baseline_bytes=baseline_for_preserve,
+                new_bytes=None,
+                format_style=format_style,
+                corrections=cli_corrections,
+            )
 
         # Schema validation if requested
         validation_status = "UNVALIDATED"
@@ -517,6 +564,15 @@ def write(
         click.echo(f"path: {write_result['path']}")
         click.echo(f"canonical_hash: {write_result['canonical_hash']}")
         click.echo(f"validation_status: {validation_status}")
+
+        # GH#376 PR-A: surface compact-mode veto records (I4 Auditability)
+        for correction in cli_corrections:
+            if correction.get("code"):
+                click.echo(
+                    f"correction: {correction['code']} {correction.get('field') or ''} "
+                    f"-- {correction.get('message') or ''}".rstrip(),
+                    err=True,
+                )
 
     except SystemExit:
         raise

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -12,6 +12,7 @@ Implements octave_write tool - replaces octave_create + octave_amend with:
 - I5 (Schema Sovereignty): Always returns validation_status
 """
 
+import copy
 import hashlib
 import os
 import re
@@ -25,6 +26,7 @@ from octave_mcp.core.ast_nodes import (
     Assignment,
     ASTNode,
     Block,
+    Comment,
     Document,
     InlineMap,
     ListValue,
@@ -63,6 +65,34 @@ W_UNQUOTED_SECTION_IN_VALUE = "W_UNQUOTED_SECTION_IN_VALUE"
 
 # GH#349: Data loss warning for bare lines dropped during lenient parsing (I4)
 W_BARE_LINE_DROPPED = "W_BARE_LINE_DROPPED"
+
+# GH#376 PR-A: format_style parameter constants.
+# Three modes are projections of one canonical AST→bytes function (I1
+# Single-Canon Discipline). They are NOT parallel emitters.
+#
+# - "preserve": Strategy C — if parse(new_content) == parse(baseline_content)
+#   (AST-equality, ignoring whitespace) write baseline bytes verbatim and
+#   short-circuit; otherwise fall through to canonical emit().
+# - "expanded": AST normalisation pre-pass that lifts InlineMap (and ListValue
+#   items that are InlineMap) into Block form before emit(). Output is the
+#   canonical multi-line form.
+# - "compact": AST normalisation pre-pass that collapses eligible Blocks
+#   (atom-only children, no Comments anywhere in subtree, arity-bounded) into
+#   Assignment(value=ListValue([InlineMap{...}, ...])). Subtrees containing a
+#   Comment are vetoed (left untouched) and a W_COMPACT_REFUSED entry surfaces
+#   in the repair log (I3 Mirror Constraint + I4 Auditability).
+#
+# When format_style is omitted (None), today's behaviour is preserved exactly:
+# emit(doc) with no pre-pass and no short-circuit (the "current" sentinel
+# documented in the PR description). This guarantees the 2788 baseline tests
+# remain byte-identical.
+FORMAT_STYLE_VALUES: tuple[str, str, str] = ("preserve", "expanded", "compact")
+E_INVALID_FORMAT_STYLE = "E_INVALID_FORMAT_STYLE"
+W_COMPACT_REFUSED = "W_COMPACT_REFUSED"
+
+# Compact mode arity bound — collapse only "small" Blocks to keep output
+# readable. Values above this stay in Block form.
+_COMPACT_MAX_PAIRS = 8
 
 # GH#352: Guidance hint for UNVALIDATED status (I5)
 # GH#361r3: Base hint text; available schemas appended dynamically at runtime.
@@ -602,6 +632,277 @@ def _normalize_value_for_ast(value: Any) -> Any:
         return InlineMap(pairs=normalized_pairs)
     # Other types (str, int, bool, None, etc.) are handled by emit_value directly
     return value
+
+
+# ---------------------------------------------------------------------------
+# GH#376 PR-A: format_style AST projections (I1 Single-Canon Discipline).
+#
+# These helpers form AST normalisation pre-passes feeding the SAME emit()
+# function used by today's canonical pipeline. They never fork the emitter.
+# ---------------------------------------------------------------------------
+
+
+def _is_atom_value(v: Any) -> bool:
+    """Return True for primitive values safe to put inside an InlineMap pair.
+
+    Excludes structured nodes (ListValue, InlineMap, HolographicValue,
+    LiteralZoneValue) since collapsing those into an inline pair would change
+    semantics.
+    """
+    return v is None or isinstance(v, (bool, int, float, str))
+
+
+def _subtree_has_comment(node: Any) -> bool:
+    """Recursively check whether a subtree contains any Comment node.
+
+    Compact mode MUST NOT collapse any subtree containing a Comment — doing so
+    would erase the comment, violating I3 Mirror Constraint. Comments may live
+    as Comment children, leading_comments, or trailing_comment annotations on
+    any ASTNode.
+    """
+    if isinstance(node, Comment):
+        return True
+    if isinstance(node, ASTNode):
+        if getattr(node, "leading_comments", None):
+            return True
+        if getattr(node, "trailing_comment", None):
+            return True
+    if isinstance(node, (Block, Section)):
+        return any(_subtree_has_comment(c) for c in node.children)
+    if isinstance(node, Document):
+        if node.trailing_comments:
+            return True
+        return any(_subtree_has_comment(c) for c in node.sections)
+    return False
+
+
+def _block_compact_eligible(block: Block) -> bool:
+    """Return True if a Block can safely collapse into an inline-list-of-InlineMap.
+
+    Eligibility requires:
+    - Every child is an Assignment (no nested Blocks/Sections/Comments)
+    - Every Assignment's value is an atom (str/int/float/bool/None)
+    - The Block carries no comments (leading_comments/trailing_comment)
+    - No Assignment child carries comments
+    - The Block has at least one and at most _COMPACT_MAX_PAIRS children
+    - The Block has no target annotation (collapsing would lose it)
+    """
+    if block.target:
+        return False
+    if block.leading_comments or block.trailing_comment:
+        return False
+    if not block.children or len(block.children) > _COMPACT_MAX_PAIRS:
+        return False
+    for child in block.children:
+        if not isinstance(child, Assignment):
+            return False
+        if child.leading_comments or child.trailing_comment:
+            return False
+        if not _is_atom_value(child.value):
+            return False
+    return True
+
+
+def _block_to_compact_assignment(block: Block) -> Assignment:
+    """Convert an eligible Block into Assignment(KEY, ListValue([InlineMap, ...])).
+
+    Each child Assignment becomes a single-pair InlineMap inside the ListValue.
+    This mirrors the parsed shape of bracket-notation inline lists (verified by
+    parser experiment: ``[K::V,L::W]`` parses as ListValue of two InlineMaps,
+    each with one pair) so that re-parsing the emitted form is structurally
+    stable.
+    """
+    items: list[Any] = []
+    for child in block.children:
+        assert isinstance(child, Assignment)  # noqa: S101 -- _block_compact_eligible guarantees
+        items.append(InlineMap(pairs={child.key: child.value}))
+    return Assignment(
+        key=block.key,
+        value=ListValue(items=items),
+        line=block.line,
+        column=block.column,
+    )
+
+
+def _compact_pass(
+    children: list[Any],
+    corrections: list[dict[str, Any]],
+    field_path: str,
+) -> list[Any]:
+    """Walk a list of AST children, collapsing eligible Blocks in place.
+
+    Inelegible Blocks have their children recursively visited (so a Block that
+    can't collapse may still contain a Block deeper down that can). Subtrees
+    containing Comments are vetoed and a W_COMPACT_REFUSED record is appended
+    to ``corrections`` (I4 Audit). Other node types pass through unchanged.
+    """
+    out: list[Any] = []
+    for child in children:
+        if isinstance(child, Block):
+            child_path = f"{field_path}.{child.key}" if field_path else child.key
+            if _subtree_has_comment(child):
+                # I3 veto — leave Block untouched so comments survive.
+                corrections.append(
+                    {
+                        "code": W_COMPACT_REFUSED,
+                        "tier": "FORMAT_STYLE",
+                        "field": child_path,
+                        "message": (
+                            f"Compact mode refused to collapse subtree '{child_path}': "
+                            "contains comment(s) (I3 Mirror Constraint)."
+                        ),
+                        "safe": True,
+                        "semantics_changed": False,
+                    }
+                )
+                # Still recurse into children — deeper Blocks without comments
+                # can still collapse where safe.
+                child.children = _compact_pass(child.children, corrections, child_path)
+                out.append(child)
+                continue
+            if _block_compact_eligible(child):
+                out.append(_block_to_compact_assignment(child))
+                continue
+            # Not eligible (e.g. mixed children) but no comments — recurse.
+            child.children = _compact_pass(child.children, corrections, child_path)
+            out.append(child)
+        elif isinstance(child, Section):
+            child_path = f"{field_path}.§{child.section_id}" if field_path else f"§{child.section_id}"
+            child.children = _compact_pass(child.children, corrections, child_path)
+            out.append(child)
+        else:
+            out.append(child)
+    return out
+
+
+def _expand_pass(children: list[Any]) -> list[Any]:
+    """Walk a list of AST children, lifting InlineMap shapes into Blocks.
+
+    Two patterns are lifted:
+    - ``Assignment(KEY, InlineMap{k1:v1,...})`` → ``Block(KEY, [Assignment(k1,v1),...])``
+    - ``Assignment(KEY, ListValue([InlineMap{k1:v1}, InlineMap{k2:v2}, ...]))``
+      where every list item is an atom-valued InlineMap → ``Block(KEY, [...])``
+
+    Only atom-valued InlineMaps are lifted; structured values stay inline so we
+    do not fabricate semantic content (I3 Mirror Constraint).
+    """
+    out: list[Any] = []
+    for child in children:
+        if isinstance(child, Assignment):
+            lifted = _maybe_lift_assignment_to_block(child)
+            if lifted is not None:
+                out.append(lifted)
+                continue
+            out.append(child)
+        elif isinstance(child, Block):
+            child.children = _expand_pass(child.children)
+            out.append(child)
+        elif isinstance(child, Section):
+            child.children = _expand_pass(child.children)
+            out.append(child)
+        else:
+            out.append(child)
+    return out
+
+
+def _maybe_lift_assignment_to_block(assignment: Assignment) -> Block | None:
+    """Return a Block lifted from an InlineMap-shaped Assignment, or None.
+
+    Returns None when the value is not an InlineMap shape eligible for lifting.
+    """
+    value = assignment.value
+    pairs: list[tuple[str, Any]] = []
+
+    if isinstance(value, InlineMap):
+        for k, v in value.pairs.items():
+            if not _is_atom_value(v):
+                return None
+            pairs.append((k, v))
+    elif isinstance(value, ListValue):
+        if not value.items or not all(isinstance(it, InlineMap) for it in value.items):
+            return None
+        for item in value.items:
+            assert isinstance(item, InlineMap)  # noqa: S101
+            for k, v in item.pairs.items():
+                if not _is_atom_value(v):
+                    return None
+                pairs.append((k, v))
+    else:
+        return None
+
+    if not pairs:
+        return None
+
+    block_children: list[Any] = [
+        Assignment(key=k, value=v, line=assignment.line, column=assignment.column) for k, v in pairs
+    ]
+    return Block(
+        key=assignment.key,
+        children=block_children,
+        line=assignment.line,
+        column=assignment.column,
+        leading_comments=list(assignment.leading_comments),
+        trailing_comment=assignment.trailing_comment,
+    )
+
+
+def _apply_format_style(doc: Document, format_style: str | None, corrections: list[dict[str, Any]]) -> Document:
+    """Return a Document transformed for the given format_style mode.
+
+    Operates on a deep copy so the caller's AST is never mutated. For
+    'expanded' / 'compact' applies the corresponding pre-pass; for any other
+    value (including None and 'preserve') returns the deep copy unchanged.
+    """
+    new_doc = copy.deepcopy(doc)
+    if format_style == "expanded":
+        new_doc.sections = _expand_pass(new_doc.sections)
+    elif format_style == "compact":
+        new_doc.sections = _compact_pass(new_doc.sections, corrections, field_path="")
+    return new_doc
+
+
+def _emit_with_style(
+    doc: Document,
+    *,
+    baseline_bytes: str | None = None,
+    new_bytes: str | None = None,  # noqa: ARG001 -- reserved for future preserve variants (#377)
+    format_style: str | None,
+    corrections: list[dict[str, Any]],
+) -> str:
+    """Single canon orchestrator: produce canonical bytes for ``doc`` under
+    ``format_style``.
+
+    Strategy:
+    - 'expanded' / 'compact' → apply AST pre-pass and emit().
+    - 'preserve' (Strategy C short-circuit): emit canonically; if
+      ``baseline_bytes`` is provided AND its canonical form equals the new
+      canonical form, return ``baseline_bytes`` verbatim (zero diff for
+      whitespace-only edits). Otherwise return the canonical bytes.
+    - Anything else (including None) → emit(doc) (today's behaviour preserved
+      byte-for-byte; this is the documented "current" sentinel).
+
+    All non-shortcut paths route through one and only one ``emit()`` call on
+    the doc (or its pre-pass projection), satisfying I1 Single-Canon Discipline.
+
+    The ``new_bytes`` parameter is reserved for future preserve-mode variants
+    (full Strategy A in #377) where source-span infrastructure may need access
+    to the original input bytes; PR-A uses canonical-form comparison only.
+    """
+    if format_style in ("expanded", "compact"):
+        projected = _apply_format_style(doc, format_style, corrections)
+        canonical = emit(projected)
+    else:
+        canonical = emit(doc)
+
+    if format_style == "preserve" and baseline_bytes is not None:
+        try:
+            baseline_canonical = emit(parse(baseline_bytes))
+        except (LexerError, ParserError):
+            return canonical
+        if baseline_canonical == canonical:
+            return baseline_bytes
+
+    return canonical
 
 
 # GH#263: Regex pattern for detecting NAME{qualifier} curly-brace annotations
@@ -1317,6 +1618,26 @@ class WriteTool(BaseTool):
             required=False,
             description='Policy when tokenization/parsing fails in lenient mode: "error" (default) or "salvage".',
             enum=["error", "salvage"],
+        )
+
+        # GH#376 PR-A: format_style toggle. Three modes are AST projections
+        # of one canonical emit() (I1 Single-Canon Discipline).
+        schema.add_parameter(
+            "format_style",
+            "string",
+            required=False,
+            description=(
+                "Output formatting style for canonical emission. "
+                "'preserve' (Strategy C): if new content is AST-equal to the existing file, "
+                "write the baseline bytes verbatim — zero diff for whitespace-only edits. "
+                "'expanded': lift inline-map shapes (KEY::[K::V,...]) into Block form before emit. "
+                "'compact': collapse atom-only Blocks (no comments, arity-bounded) into "
+                "inline-list-of-InlineMap form. Comment-bearing subtrees are vetoed and a "
+                f"{W_COMPACT_REFUSED} record surfaces in corrections (I3 Mirror Constraint, "
+                "I4 Auditability). When omitted, today's canonical behaviour is preserved exactly. "
+                "(GH#376 PR-A — full preserve-mode strategy A is tracked separately as #377.)"
+            ),
+            enum=list(FORMAT_STYLE_VALUES),
         )
 
         return schema.build()
@@ -2389,11 +2710,26 @@ class WriteTool(BaseTool):
         # GH#354: Accept dry_run as alias for corrections_only (either triggers dry-run)
         corrections_only = params.get("corrections_only", False) or params.get("dry_run", False)
         parse_error_policy = params.get("parse_error_policy", "error")
+        # GH#376 PR-A: format_style is optional; None preserves today's behaviour.
+        format_style = params.get("format_style")
 
         if parse_error_policy not in ("error", "salvage"):
             return self._error_envelope(
                 target_path,
                 [{"code": "E_INPUT", "message": f"Invalid parse_error_policy: {parse_error_policy}"}],
+            )
+
+        if format_style is not None and format_style not in FORMAT_STYLE_VALUES:
+            return self._error_envelope(
+                target_path,
+                [
+                    {
+                        "code": E_INVALID_FORMAT_STYLE,
+                        "message": (
+                            f"Invalid format_style: {format_style!r}. " f"Expected one of {list(FORMAT_STYLE_VALUES)}."
+                        ),
+                    }
+                ],
             )
 
         # Initialize result with unified envelope per D2 design
@@ -2738,9 +3074,19 @@ class WriteTool(BaseTool):
                         }
                     )
 
-        # Emit canonical form (may be re-emitted after schema repair)
+        # Emit canonical form (may be re-emitted after schema repair).
+        # GH#376 PR-A: format_style routes through _emit_with_style — a single
+        # canonical AST→bytes orchestrator that applies expanded/compact AST
+        # pre-passes or the preserve Strategy C short-circuit, all via the
+        # SAME emit() call (I1 Single-Canon Discipline).
         try:
-            canonical_content = emit(doc)
+            canonical_content = _emit_with_style(
+                doc,
+                baseline_bytes=baseline_content_for_diff or None,
+                new_bytes=content,
+                format_style=format_style,
+                corrections=corrections,
+            )
             canonical_metrics = extract_structural_metrics(doc)
         except Exception as e:
             return self._error_envelope(
@@ -2934,7 +3280,15 @@ class WriteTool(BaseTool):
                         )
 
                     if did_repair:
-                        canonical_content = emit(doc)
+                        # GH#376 PR-A: re-emit through the single-canon orchestrator
+                        # so format_style applies to schema-repaired output too.
+                        canonical_content = _emit_with_style(
+                            doc,
+                            baseline_bytes=baseline_content_for_diff or None,
+                            new_bytes=content,
+                            format_style=format_style,
+                            corrections=result["corrections"],
+                        )
                         canonical_metrics = extract_structural_metrics(doc)
                         validation_errors = validator.validate(doc, strict=False, section_schemas=section_schemas)
 
@@ -2954,8 +3308,15 @@ class WriteTool(BaseTool):
                                     "message": f"Schema repair: {entry.rule_id}",
                                 }
                             )
-                        # Re-emit canonical after repairs
-                        canonical_content = emit(doc)
+                        # Re-emit canonical after repairs (GH#376 PR-A: single-canon
+                        # orchestrator so format_style applies to repaired output).
+                        canonical_content = _emit_with_style(
+                            doc,
+                            baseline_bytes=baseline_content_for_diff or None,
+                            new_bytes=content,
+                            format_style=format_style,
+                            corrections=result["corrections"],
+                        )
                         canonical_metrics = extract_structural_metrics(doc)
                         # Revalidate
                         validation_errors = validator.validate(doc, strict=False, section_schemas=section_schemas)

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -699,6 +699,12 @@ def _subtree_has_comment(node: Any, _seen: set[int] | None = None) -> bool:
     ``OctaveASTCycleError`` (``code = E_AST_CYCLE``) instead of escaping as a
     bare ``RecursionError``. Keys on ``id(node)`` because AST nodes are
     mutable dataclasses and therefore unhashable.
+
+    Cubic C2 (#376 PR-A rework): the visited-set is a DFS *path stack*, not a
+    permanent visited record — entries are discarded on frame exit via the
+    ``finally`` block. This distinguishes a true cycle (same node reachable
+    from itself along the current ancestry) from a shared-acyclic reference
+    (same node reached via two distinct paths under different parents).
     """
     if _seen is None:
         _seen = set()
@@ -706,21 +712,23 @@ def _subtree_has_comment(node: Any, _seen: set[int] | None = None) -> bool:
     if nid in _seen:
         raise OctaveASTCycleError(node, where="_subtree_has_comment")
     _seen.add(nid)
-
-    if isinstance(node, Comment):
-        return True
-    if isinstance(node, ASTNode):
-        if getattr(node, "leading_comments", None):
+    try:
+        if isinstance(node, Comment):
             return True
-        if getattr(node, "trailing_comment", None):
-            return True
-    if isinstance(node, (Block, Section)):
-        return any(_subtree_has_comment(c, _seen) for c in node.children)
-    if isinstance(node, Document):
-        if node.trailing_comments:
-            return True
-        return any(_subtree_has_comment(c, _seen) for c in node.sections)
-    return False
+        if isinstance(node, ASTNode):
+            if getattr(node, "leading_comments", None):
+                return True
+            if getattr(node, "trailing_comment", None):
+                return True
+        if isinstance(node, (Block, Section)):
+            return any(_subtree_has_comment(c, _seen) for c in node.children)
+        if isinstance(node, Document):
+            if node.trailing_comments:
+                return True
+            return any(_subtree_has_comment(c, _seen) for c in node.sections)
+        return False
+    finally:
+        _seen.discard(nid)
 
 
 def _block_compact_eligible(block: Block) -> bool:
@@ -821,6 +829,12 @@ def _compact_pass(
     CIV B2: traversal carries an id-keyed visited-set; a self-referential AST
     raises ``OctaveASTCycleError`` (``E_AST_CYCLE``) instead of escaping as a
     ``RecursionError``.
+
+    Cubic C2 (#376 PR-A rework): the visited-set is a DFS *path stack*. Each
+    frame discards its own id() on exit via ``finally``, so two distinct
+    parents may legally share an acyclic child by reference without the guard
+    misfiring. A genuine cycle is still caught — the offending node remains on
+    the stack along its own ancestry.
     """
     if _seen is None:
         _seen = set()
@@ -843,79 +857,75 @@ def _compact_pass(
         nid = id(child)
         if nid in _seen:
             raise OctaveASTCycleError(child, where="_compact_pass")
+        _seen.add(nid)
+        try:
+            if isinstance(child, Block):
+                key: str = child.key
+                n = ordinals.get(key, 0)
+                ordinals[key] = n + 1
+                suffix = f"#{n}" if key_counts[key] > 1 else ""
+                base = f"{field_path}.{key}" if field_path else key
+                child_path = base + suffix
 
-        if isinstance(child, Block):
-            key: str = child.key
-            n = ordinals.get(key, 0)
-            ordinals[key] = n + 1
-            suffix = f"#{n}" if key_counts[key] > 1 else ""
-            base = f"{field_path}.{key}" if field_path else key
-            child_path = base + suffix
-
-            # Mark this Block visited before descending.
-            _seen.add(nid)
-
-            if _subtree_has_comment(child):
-                # I3 veto — leave Block untouched so comments survive (I4 audit).
-                corrections.append(
-                    {
-                        "code": W_COMPACT_REFUSED,
-                        "tier": "FORMAT_STYLE",
-                        "field": child_path,
-                        "reason": _REFUSE_REASON_COMMENT,
-                        "message": (
-                            f"Compact mode refused to collapse subtree '{child_path}': "
-                            "contains comment(s) (I3 Mirror Constraint)."
-                        ),
-                        "safe": True,
-                        "semantics_changed": False,
-                    }
-                )
-                # Still recurse into children — deeper Blocks without comments
-                # can still collapse where safe.
+                if _subtree_has_comment(child):
+                    # I3 veto — leave Block untouched so comments survive (I4 audit).
+                    corrections.append(
+                        {
+                            "code": W_COMPACT_REFUSED,
+                            "tier": "FORMAT_STYLE",
+                            "field": child_path,
+                            "reason": _REFUSE_REASON_COMMENT,
+                            "message": (
+                                f"Compact mode refused to collapse subtree '{child_path}': "
+                                "contains comment(s) (I3 Mirror Constraint)."
+                            ),
+                            "safe": True,
+                            "semantics_changed": False,
+                        }
+                    )
+                    # Still recurse into children — deeper Blocks without comments
+                    # can still collapse where safe.
+                    child.children = _compact_pass(child.children, corrections, child_path, _seen)
+                    out.append(child)
+                elif _block_compact_eligible(child):
+                    out.append(_block_to_compact_assignment(child))
+                elif _block_would_collapse_but_for_arity(child):
+                    # CIV B3 — eligible-but-too-large block, surface receipt.
+                    corrections.append(
+                        {
+                            "code": W_COMPACT_REFUSED,
+                            "tier": "FORMAT_STYLE",
+                            "field": child_path,
+                            "reason": _REFUSE_REASON_ARITY,
+                            "message": (
+                                f"Compact mode refused to collapse subtree '{child_path}': "
+                                f"{len(child.children)} children exceed _COMPACT_MAX_PAIRS="
+                                f"{_COMPACT_MAX_PAIRS}."
+                            ),
+                            "safe": True,
+                            "semantics_changed": False,
+                        }
+                    )
+                    # Even though we won't collapse, recurse to honour deeper opportunities.
+                    child.children = _compact_pass(child.children, corrections, child_path, _seen)
+                    out.append(child)
+                else:
+                    # Not eligible (e.g. mixed children) but no comments — recurse.
+                    child.children = _compact_pass(child.children, corrections, child_path, _seen)
+                    out.append(child)
+            elif isinstance(child, Section):
+                sk = f"§{child.section_id}"
+                n = ordinals.get(sk, 0)
+                ordinals[sk] = n + 1
+                suffix = f"#{n}" if key_counts[sk] > 1 else ""
+                base = f"{field_path}.{sk}" if field_path else sk
+                child_path = base + suffix
                 child.children = _compact_pass(child.children, corrections, child_path, _seen)
                 out.append(child)
-                continue
-            if _block_compact_eligible(child):
-                out.append(_block_to_compact_assignment(child))
-                continue
-            if _block_would_collapse_but_for_arity(child):
-                # CIV B3 — eligible-but-too-large block, surface receipt.
-                corrections.append(
-                    {
-                        "code": W_COMPACT_REFUSED,
-                        "tier": "FORMAT_STYLE",
-                        "field": child_path,
-                        "reason": _REFUSE_REASON_ARITY,
-                        "message": (
-                            f"Compact mode refused to collapse subtree '{child_path}': "
-                            f"{len(child.children)} children exceed _COMPACT_MAX_PAIRS="
-                            f"{_COMPACT_MAX_PAIRS}."
-                        ),
-                        "safe": True,
-                        "semantics_changed": False,
-                    }
-                )
-                # Even though we won't collapse, recurse to honour deeper opportunities.
-                child.children = _compact_pass(child.children, corrections, child_path, _seen)
+            else:
                 out.append(child)
-                continue
-            # Not eligible (e.g. mixed children) but no comments — recurse.
-            child.children = _compact_pass(child.children, corrections, child_path, _seen)
-            out.append(child)
-        elif isinstance(child, Section):
-            sk = f"§{child.section_id}"
-            n = ordinals.get(sk, 0)
-            ordinals[sk] = n + 1
-            suffix = f"#{n}" if key_counts[sk] > 1 else ""
-            base = f"{field_path}.{sk}" if field_path else sk
-            child_path = base + suffix
-            _seen.add(nid)
-            child.children = _compact_pass(child.children, corrections, child_path, _seen)
-            out.append(child)
-        else:
-            _seen.add(nid)
-            out.append(child)
+        finally:
+            _seen.discard(nid)
     return out
 
 
@@ -933,6 +943,11 @@ def _expand_pass(children: list[Any], _seen: set[int] | None = None) -> list[Any
     CIV B2 (#376 PR-A rework): traversal carries an id-keyed visited-set so a
     self-referential AST raises ``OctaveASTCycleError`` (``E_AST_CYCLE``)
     instead of escaping as a bare ``RecursionError``.
+
+    Cubic C2 (#376 PR-A rework): the visited-set is a DFS *path stack*; each
+    frame discards its id() on exit so shared-acyclic references (the same
+    child instance under two parents) traverse cleanly. True cycles still
+    raise because the offending node remains on its own ancestry path.
     """
     if _seen is None:
         _seen = set()
@@ -942,21 +957,23 @@ def _expand_pass(children: list[Any], _seen: set[int] | None = None) -> list[Any
         if nid in _seen:
             raise OctaveASTCycleError(child, where="_expand_pass")
         _seen.add(nid)
-
-        if isinstance(child, Assignment):
-            lifted = _maybe_lift_assignment_to_block(child)
-            if lifted is not None:
-                out.append(lifted)
-                continue
-            out.append(child)
-        elif isinstance(child, Block):
-            child.children = _expand_pass(child.children, _seen)
-            out.append(child)
-        elif isinstance(child, Section):
-            child.children = _expand_pass(child.children, _seen)
-            out.append(child)
-        else:
-            out.append(child)
+        try:
+            if isinstance(child, Assignment):
+                lifted = _maybe_lift_assignment_to_block(child)
+                if lifted is not None:
+                    out.append(lifted)
+                else:
+                    out.append(child)
+            elif isinstance(child, Block):
+                child.children = _expand_pass(child.children, _seen)
+                out.append(child)
+            elif isinstance(child, Section):
+                child.children = _expand_pass(child.children, _seen)
+                out.append(child)
+            else:
+                out.append(child)
+        finally:
+            _seen.discard(nid)
     return out
 
 
@@ -3246,6 +3263,17 @@ class WriteTool(BaseTool):
                 corrections=corrections,
             )
             canonical_metrics = extract_structural_metrics(doc)
+        except OctaveASTCycleError as cyc:
+            # Cubic C3 (#376 PR-A): preserve the structured E_AST_CYCLE code
+            # so clients can discriminate cycle errors from generic emit
+            # failures. MUST appear BEFORE the broad ``except Exception``
+            # below — OctaveASTCycleError is a ValueError subclass and would
+            # otherwise be swallowed into the generic E_EMIT envelope.
+            return self._error_envelope(
+                target_path,
+                [{"code": OctaveASTCycleError.code, "message": str(cyc)}],
+                corrections,
+            )
         except Exception as e:
             return self._error_envelope(
                 target_path,

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -90,9 +90,43 @@ FORMAT_STYLE_VALUES: tuple[str, str, str] = ("preserve", "expanded", "compact")
 E_INVALID_FORMAT_STYLE = "E_INVALID_FORMAT_STYLE"
 W_COMPACT_REFUSED = "W_COMPACT_REFUSED"
 
+# CIV B2 (#376 PR-A rework): structured error code raised when an AST cycle is
+# detected by the format_style traversals. AST nodes are mutable dataclasses
+# that can be programmatically constructed into self-referential graphs; the
+# traversals MUST surface this as a stable code rather than letting a
+# RecursionError escape unwrapped.
+E_AST_CYCLE = "E_AST_CYCLE"
+
+
+class OctaveASTCycleError(ValueError):
+    """Raised when a format_style AST traversal detects a cycle.
+
+    Carries a stable ``code`` attribute (``E_AST_CYCLE``) so downstream
+    error envelopes can surface a structured identifier rather than a bare
+    RecursionError.
+    """
+
+    code: str = E_AST_CYCLE
+
+    def __init__(self, node: Any, where: str) -> None:
+        msg = (
+            f"{E_AST_CYCLE}: AST cycle detected during format_style traversal "
+            f"at {where} (node id={id(node)}, type={type(node).__name__}). "
+            "Format_style traversals require an acyclic AST."
+        )
+        super().__init__(msg)
+
+
 # Compact mode arity bound — collapse only "small" Blocks to keep output
 # readable. Values above this stay in Block form.
 _COMPACT_MAX_PAIRS = 8
+
+# CIV B3 (#376 PR-A rework): W_COMPACT_REFUSED record carries a ``reason``
+# discriminant so callers can distinguish why a subtree was not collapsed.
+# This closes the I4 audit-symmetry gap where arity-exceeded blocks were
+# previously skipped silently.
+_REFUSE_REASON_COMMENT = "contains_comment"
+_REFUSE_REASON_ARITY = "arity_exceeded"
 
 # GH#352: Guidance hint for UNVALIDATED status (I5)
 # GH#361r3: Base hint text; available schemas appended dynamically at runtime.
@@ -652,14 +686,27 @@ def _is_atom_value(v: Any) -> bool:
     return v is None or isinstance(v, (bool, int, float, str))
 
 
-def _subtree_has_comment(node: Any) -> bool:
+def _subtree_has_comment(node: Any, _seen: set[int] | None = None) -> bool:
     """Recursively check whether a subtree contains any Comment node.
 
     Compact mode MUST NOT collapse any subtree containing a Comment — doing so
     would erase the comment, violating I3 Mirror Constraint. Comments may live
     as Comment children, leading_comments, or trailing_comment annotations on
     any ASTNode.
+
+    CIV B2 (#376 PR-A rework): traversal carries an id-keyed visited-set so
+    that programmatically-constructed cyclic ASTs surface a structured
+    ``OctaveASTCycleError`` (``code = E_AST_CYCLE``) instead of escaping as a
+    bare ``RecursionError``. Keys on ``id(node)`` because AST nodes are
+    mutable dataclasses and therefore unhashable.
     """
+    if _seen is None:
+        _seen = set()
+    nid = id(node)
+    if nid in _seen:
+        raise OctaveASTCycleError(node, where="_subtree_has_comment")
+    _seen.add(nid)
+
     if isinstance(node, Comment):
         return True
     if isinstance(node, ASTNode):
@@ -668,11 +715,11 @@ def _subtree_has_comment(node: Any) -> bool:
         if getattr(node, "trailing_comment", None):
             return True
     if isinstance(node, (Block, Section)):
-        return any(_subtree_has_comment(c) for c in node.children)
+        return any(_subtree_has_comment(c, _seen) for c in node.children)
     if isinstance(node, Document):
         if node.trailing_comments:
             return True
-        return any(_subtree_has_comment(c) for c in node.sections)
+        return any(_subtree_has_comment(c, _seen) for c in node.sections)
     return False
 
 
@@ -692,6 +739,32 @@ def _block_compact_eligible(block: Block) -> bool:
     if block.leading_comments or block.trailing_comment:
         return False
     if not block.children or len(block.children) > _COMPACT_MAX_PAIRS:
+        return False
+    for child in block.children:
+        if not isinstance(child, Assignment):
+            return False
+        if child.leading_comments or child.trailing_comment:
+            return False
+        if not _is_atom_value(child.value):
+            return False
+    return True
+
+
+def _block_would_collapse_but_for_arity(block: Block) -> bool:
+    """Return True if ``block`` is collapse-eligible apart from arity.
+
+    Used by the compact pre-pass to surface a W_COMPACT_REFUSED record with
+    ``reason="arity_exceeded"`` when an otherwise-collapsible Block has more
+    than ``_COMPACT_MAX_PAIRS`` children. This closes the I4 audit-symmetry
+    gap (CIV B3): the contract is "compact tells you what it refused", so an
+    eligible-but-too-large Block must produce an audit record rather than
+    pass through silently.
+    """
+    if len(block.children) <= _COMPACT_MAX_PAIRS:
+        return False
+    if block.target:
+        return False
+    if block.leading_comments or block.trailing_comment:
         return False
     for child in block.children:
         if not isinstance(child, Assignment):
@@ -728,25 +801,68 @@ def _compact_pass(
     children: list[Any],
     corrections: list[dict[str, Any]],
     field_path: str,
+    _seen: set[int] | None = None,
 ) -> list[Any]:
     """Walk a list of AST children, collapsing eligible Blocks in place.
 
-    Inelegible Blocks have their children recursively visited (so a Block that
+    Ineligible Blocks have their children recursively visited (so a Block that
     can't collapse may still contain a Block deeper down that can). Subtrees
-    containing Comments are vetoed and a W_COMPACT_REFUSED record is appended
-    to ``corrections`` (I4 Audit). Other node types pass through unchanged.
+    containing Comments are vetoed and a W_COMPACT_REFUSED record with
+    ``reason="contains_comment"`` is appended to ``corrections`` (I3 Mirror
+    Constraint + I4 Audit). Blocks that would otherwise be eligible but exceed
+    ``_COMPACT_MAX_PAIRS`` produce a W_COMPACT_REFUSED with
+    ``reason="arity_exceeded"`` (CIV B3 audit-symmetry). Other node types
+    pass through unchanged.
+
+    CIV B1: when sibling Blocks/Sections share a key, audit IDs are
+    disambiguated with a ``#N`` suffix so refusal records remain uniquely
+    attributable.
+
+    CIV B2: traversal carries an id-keyed visited-set; a self-referential AST
+    raises ``OctaveASTCycleError`` (``E_AST_CYCLE``) instead of escaping as a
+    ``RecursionError``.
     """
-    out: list[Any] = []
+    if _seen is None:
+        _seen = set()
+
+    # Per-call ordinal tracker for this children-list (CIV B1 sibling ID).
+    ordinals: dict[str, int] = {}
+
+    # First pass: count collision occurrences so singletons stay un-suffixed
+    # (``KEY``) while genuine collisions surface as ``KEY#0``, ``KEY#1``, etc.
+    key_counts: dict[str, int] = {}
     for child in children:
         if isinstance(child, Block):
-            child_path = f"{field_path}.{child.key}" if field_path else child.key
+            key_counts[child.key] = key_counts.get(child.key, 0) + 1
+        elif isinstance(child, Section):
+            sk = f"§{child.section_id}"
+            key_counts[sk] = key_counts.get(sk, 0) + 1
+
+    out: list[Any] = []
+    for child in children:
+        nid = id(child)
+        if nid in _seen:
+            raise OctaveASTCycleError(child, where="_compact_pass")
+
+        if isinstance(child, Block):
+            key: str = child.key
+            n = ordinals.get(key, 0)
+            ordinals[key] = n + 1
+            suffix = f"#{n}" if key_counts[key] > 1 else ""
+            base = f"{field_path}.{key}" if field_path else key
+            child_path = base + suffix
+
+            # Mark this Block visited before descending.
+            _seen.add(nid)
+
             if _subtree_has_comment(child):
-                # I3 veto — leave Block untouched so comments survive.
+                # I3 veto — leave Block untouched so comments survive (I4 audit).
                 corrections.append(
                     {
                         "code": W_COMPACT_REFUSED,
                         "tier": "FORMAT_STYLE",
                         "field": child_path,
+                        "reason": _REFUSE_REASON_COMMENT,
                         "message": (
                             f"Compact mode refused to collapse subtree '{child_path}': "
                             "contains comment(s) (I3 Mirror Constraint)."
@@ -757,25 +873,53 @@ def _compact_pass(
                 )
                 # Still recurse into children — deeper Blocks without comments
                 # can still collapse where safe.
-                child.children = _compact_pass(child.children, corrections, child_path)
+                child.children = _compact_pass(child.children, corrections, child_path, _seen)
                 out.append(child)
                 continue
             if _block_compact_eligible(child):
                 out.append(_block_to_compact_assignment(child))
                 continue
+            if _block_would_collapse_but_for_arity(child):
+                # CIV B3 — eligible-but-too-large block, surface receipt.
+                corrections.append(
+                    {
+                        "code": W_COMPACT_REFUSED,
+                        "tier": "FORMAT_STYLE",
+                        "field": child_path,
+                        "reason": _REFUSE_REASON_ARITY,
+                        "message": (
+                            f"Compact mode refused to collapse subtree '{child_path}': "
+                            f"{len(child.children)} children exceed _COMPACT_MAX_PAIRS="
+                            f"{_COMPACT_MAX_PAIRS}."
+                        ),
+                        "safe": True,
+                        "semantics_changed": False,
+                    }
+                )
+                # Even though we won't collapse, recurse to honour deeper opportunities.
+                child.children = _compact_pass(child.children, corrections, child_path, _seen)
+                out.append(child)
+                continue
             # Not eligible (e.g. mixed children) but no comments — recurse.
-            child.children = _compact_pass(child.children, corrections, child_path)
+            child.children = _compact_pass(child.children, corrections, child_path, _seen)
             out.append(child)
         elif isinstance(child, Section):
-            child_path = f"{field_path}.§{child.section_id}" if field_path else f"§{child.section_id}"
-            child.children = _compact_pass(child.children, corrections, child_path)
+            sk = f"§{child.section_id}"
+            n = ordinals.get(sk, 0)
+            ordinals[sk] = n + 1
+            suffix = f"#{n}" if key_counts[sk] > 1 else ""
+            base = f"{field_path}.{sk}" if field_path else sk
+            child_path = base + suffix
+            _seen.add(nid)
+            child.children = _compact_pass(child.children, corrections, child_path, _seen)
             out.append(child)
         else:
+            _seen.add(nid)
             out.append(child)
     return out
 
 
-def _expand_pass(children: list[Any]) -> list[Any]:
+def _expand_pass(children: list[Any], _seen: set[int] | None = None) -> list[Any]:
     """Walk a list of AST children, lifting InlineMap shapes into Blocks.
 
     Two patterns are lifted:
@@ -785,9 +929,20 @@ def _expand_pass(children: list[Any]) -> list[Any]:
 
     Only atom-valued InlineMaps are lifted; structured values stay inline so we
     do not fabricate semantic content (I3 Mirror Constraint).
+
+    CIV B2 (#376 PR-A rework): traversal carries an id-keyed visited-set so a
+    self-referential AST raises ``OctaveASTCycleError`` (``E_AST_CYCLE``)
+    instead of escaping as a bare ``RecursionError``.
     """
+    if _seen is None:
+        _seen = set()
     out: list[Any] = []
     for child in children:
+        nid = id(child)
+        if nid in _seen:
+            raise OctaveASTCycleError(child, where="_expand_pass")
+        _seen.add(nid)
+
         if isinstance(child, Assignment):
             lifted = _maybe_lift_assignment_to_block(child)
             if lifted is not None:
@@ -795,10 +950,10 @@ def _expand_pass(children: list[Any]) -> list[Any]:
                 continue
             out.append(child)
         elif isinstance(child, Block):
-            child.children = _expand_pass(child.children)
+            child.children = _expand_pass(child.children, _seen)
             out.append(child)
         elif isinstance(child, Section):
-            child.children = _expand_pass(child.children)
+            child.children = _expand_pass(child.children, _seen)
             out.append(child)
         else:
             out.append(child)
@@ -896,6 +1051,9 @@ def _emit_with_style(
 
     if format_style == "preserve" and baseline_bytes is not None:
         try:
+            # TODO(#377): pass the already-parsed baseline_doc through and
+            # skip this reparse — Strategy A reworks preserve mode entirely
+            # (CRS P3-01 / TMG advisory).
             baseline_canonical = emit(parse(baseline_bytes))
         except (LexerError, ParserError):
             return canonical

--- a/tests/unit/test_format_style.py
+++ b/tests/unit/test_format_style.py
@@ -572,3 +572,179 @@ class TestDefaultUnchanged:
         doc = parse(src)
         out = _emit_with_style(doc, baseline_bytes=None, new_bytes=None, format_style=None, corrections=[])
         assert out == emit(doc)
+
+
+# ---------------------------------------------------------------------------
+# Cubic C1 — preserve-mode CLI degrades gracefully on invalid-UTF-8 baseline.
+# ---------------------------------------------------------------------------
+
+
+class TestPreserveInvalidUTF8Baseline:
+    def test_cli_preserve_invalid_utf8_baseline_does_not_crash(self):
+        """When the on-disk baseline contains invalid UTF-8, ``--format-style
+        preserve`` must NOT crash; the preserve short-circuit simply cannot
+        fire and the canonical write proceeds (cubic C1)."""
+        from click.testing import CliRunner
+
+        from octave_mcp.cli.main import cli
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "doc.oct.md")
+            # Write invalid UTF-8 directly to bypass any encoder normalisation.
+            with open(target, "wb") as f:
+                f.write(b"\xff\xfe invalid utf-8 baseline bytes")
+
+            new_content = "===T===\n§1::A\n  K::value\n===END===\n"
+            result = runner.invoke(
+                cli,
+                [
+                    "write",
+                    target,
+                    "--content",
+                    new_content,
+                    "--format-style",
+                    "preserve",
+                ],
+            )
+            assert result.exit_code == 0, (
+                f"expected exit 0 (graceful degrade), got {result.exit_code}; "
+                f"stdout={result.output!r}; exc={result.exception!r}"
+            )
+            # File must now hold the canonical form (preserve fell through).
+            with open(target, encoding="utf-8") as f:
+                on_disk = f.read()
+            assert "K::value" in on_disk
+
+
+# ---------------------------------------------------------------------------
+# Cubic C2 — DFS path-stack: shared-acyclic refs do NOT raise E_AST_CYCLE.
+# ---------------------------------------------------------------------------
+
+
+class TestSharedAcyclicReferences:
+    def _shared_child_doc(self) -> Document:
+        """Build an acyclic AST where two distinct Block parents reference
+        the SAME atom-valued Assignment instance (same id())."""
+        shared_child = Assignment(key="K", value="v")
+        b1 = Block(key="A", children=[shared_child])
+        b2 = Block(key="B", children=[shared_child])  # same instance, different parent
+        return Document(
+            name="T",
+            sections=[Section(section_id="1", key="S", children=[b1, b2])],
+        )
+
+    def test_subtree_has_comment_handles_shared_acyclic_node(self):
+        """Two Blocks sharing an Assignment by reference is acyclic — the
+        traversal must NOT raise (cubic C2)."""
+        doc = self._shared_child_doc()
+        # Each Block independently traverses the shared child; with the DFS
+        # path-stack pattern, the id() is discarded on frame exit.
+        for block in doc.sections[0].children:
+            assert _subtree_has_comment(block) is False
+
+    def test_compact_pass_handles_shared_acyclic_node(self):
+        """_compact_pass must traverse a shared-acyclic AST without raising."""
+        doc = self._shared_child_doc()
+        corrections: list = []
+        # Should not raise OctaveASTCycleError.
+        out = _compact_pass(doc.sections, corrections, "")
+        assert len(out) == 1  # one Section back
+
+    def test_expand_pass_handles_shared_acyclic_node(self):
+        """_expand_pass must traverse a shared-acyclic AST without raising."""
+        doc = self._shared_child_doc()
+        out = _expand_pass(doc.sections)
+        assert len(out) == 1
+
+    def test_true_cycles_still_raise(self):
+        """Regression guard for cubic C2 fix: genuine self-reference is still
+        caught even with the path-stack discard semantics."""
+        b = Block(key="X", children=[])
+        b.children.append(b)  # true cycle: b is its own descendant
+        with pytest.raises(OctaveASTCycleError, match=E_AST_CYCLE):
+            _subtree_has_comment(b)
+        with pytest.raises(OctaveASTCycleError, match=E_AST_CYCLE):
+            _compact_pass([b], corrections=[], field_path="")
+        with pytest.raises(OctaveASTCycleError, match=E_AST_CYCLE):
+            _expand_pass([b])
+
+
+# ---------------------------------------------------------------------------
+# Cubic C3 — OctaveASTCycleError surfaced as structured envelope/CLI error.
+# ---------------------------------------------------------------------------
+
+
+class TestCycleErrorStructuredSurface:
+    @pytest.mark.asyncio
+    async def test_execute_surfaces_e_ast_cycle_envelope(self, monkeypatch):
+        """End-to-end MCP path: a cyclic AST inside the pre-pass MUST produce
+        an error envelope with ``code='E_AST_CYCLE'``, NOT a generic
+        ``E_EMIT`` (cubic C3)."""
+        import octave_mcp.mcp.write as write_mod
+
+        original_apply = write_mod._apply_format_style
+
+        def cyclic_apply(doc, style, corrections):
+            # Inject a cycle into the parsed doc, then exercise the real
+            # _expand_pass via _apply_format_style — this raises
+            # OctaveASTCycleError from inside _emit_with_style, which is
+            # the integration boundary cubic C3 targets.
+            if doc.sections:
+                first = doc.sections[0]
+                if isinstance(first, Section) and first.children:
+                    first.children.append(first)  # cycle
+            return original_apply(doc, style, corrections)
+
+        monkeypatch.setattr(write_mod, "_apply_format_style", cyclic_apply)
+
+        tool = WriteTool()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "doc.oct.md")
+            result = await tool.execute(
+                target_path=target,
+                content="===T===\n§1::A\n  K::value\n===END===\n",
+                format_style="expanded",
+            )
+            assert result["status"] == "error"
+            codes = [e["code"] for e in result["errors"]]
+            assert E_AST_CYCLE in codes, f"expected E_AST_CYCLE in error codes, got {codes!r}"
+            assert "E_EMIT" not in codes, f"E_AST_CYCLE was swallowed into generic E_EMIT: {codes!r}"
+
+    def test_cli_surfaces_e_ast_cycle_message(self, monkeypatch):
+        """CLI path: a cyclic AST inside the pre-pass MUST produce a stderr
+        message containing ``E_AST_CYCLE`` and exit non-zero (cubic C3)."""
+        from click.testing import CliRunner
+
+        import octave_mcp.mcp.write as write_mod
+        from octave_mcp.cli.main import cli
+
+        original_apply = write_mod._apply_format_style
+
+        def cyclic_apply(doc, style, corrections):
+            if doc.sections:
+                first = doc.sections[0]
+                if isinstance(first, Section) and first.children:
+                    first.children.append(first)
+            return original_apply(doc, style, corrections)
+
+        monkeypatch.setattr(write_mod, "_apply_format_style", cyclic_apply)
+
+        # click 8.3+ keeps stdout/stderr separate by default; ``result.stderr``
+        # captures the OctaveASTCycleError surface.
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "doc.oct.md")
+            result = runner.invoke(
+                cli,
+                [
+                    "write",
+                    target,
+                    "--content",
+                    "===T===\n§1::A\n  K::value\n===END===\n",
+                    "--format-style",
+                    "expanded",
+                ],
+            )
+            assert result.exit_code == 1, f"expected exit 1, got {result.exit_code}"
+            assert E_AST_CYCLE in (result.stderr or ""), f"expected E_AST_CYCLE in stderr, got stderr={result.stderr!r}"

--- a/tests/unit/test_format_style.py
+++ b/tests/unit/test_format_style.py
@@ -1,0 +1,408 @@
+"""Tests for format_style parameter on octave_write (GitHub Issue #376, PR-A).
+
+TDD RED-then-GREEN: tests authored before implementation.
+
+format_style modes:
+- "preserve": Strategy C — if parse(new) == parse(baseline), write baseline bytes
+  verbatim; else fall through to canonical emit().
+- "expanded": AST pre-pass lifting InlineMap (and ListValue items that are
+  InlineMap) into Block form before emit(). Output is canonical multi-line.
+- "compact": AST pre-pass collapsing eligible Blocks (atom-only children, no
+  Comments anywhere in subtree, arity-bounded) into Assignment(value=ListValue
+  of InlineMap). Comment-bearing subtrees are vetoed and W_COMPACT_REFUSED
+  surfaces in corrections (I3 Mirror Constraint + I4 Auditability).
+
+All three modes are projections of one canonical AST→bytes function (I1
+Single-Canon Discipline) — there is exactly one emit() in the pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+from octave_mcp.core.ast_nodes import (
+    Assignment,
+    Block,
+    Comment,
+    Document,
+    InlineMap,
+    ListValue,
+    Section,
+)
+from octave_mcp.core.emitter import emit
+from octave_mcp.core.parser import parse
+from octave_mcp.mcp.write import (
+    E_INVALID_FORMAT_STYLE,
+    FORMAT_STYLE_VALUES,
+    W_COMPACT_REFUSED,
+    WriteTool,
+    _apply_format_style,
+    _emit_with_style,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _semantic_key(doc: Document) -> dict:
+    """Flatten a Document to a structure that treats Block-form and
+    InlineList-of-InlineMap as equivalent.
+
+    Used by the single-canon-discipline test to compare across format_style
+    modes. This embodies the I1 "bijective on semantic space" invariant: the
+    three modes differ in syntactic form but encode the same semantic content.
+    """
+
+    def value_key(v):
+        if isinstance(v, ListValue):
+            # List of InlineMaps — flatten to dict (semantic equivalence to a Block).
+            if v.items and all(isinstance(it, InlineMap) for it in v.items):
+                merged: dict = {}
+                for it in v.items:
+                    for k, vv in it.pairs.items():
+                        merged[k] = value_key(vv)
+                return ("BLOCKLIKE", merged)
+            return ("LIST", [value_key(it) for it in v.items])
+        if isinstance(v, InlineMap):
+            return ("BLOCKLIKE", {k: value_key(vv) for k, vv in v.pairs.items()})
+        return ("ATOM", v)
+
+    def child_key(node):
+        if isinstance(node, Assignment):
+            return ("KV", node.key, value_key(node.value))
+        if isinstance(node, Block):
+            # Treat a Block with only atom-valued Assignment children as the
+            # semantic equivalent of an Assignment(KEY, BLOCKLIKE{...}) — this
+            # is exactly the expanded↔compact pair that PR-A normalises.
+            if node.children and all(
+                isinstance(c, Assignment) and not isinstance(c.value, (ListValue, InlineMap)) for c in node.children
+            ):
+                merged = {c.key: value_key(c.value) for c in node.children if isinstance(c, Assignment)}
+                return ("KV", node.key, ("BLOCKLIKE", merged))
+            return ("B", node.key, [child_key(c) for c in node.children])
+        if isinstance(node, Section):
+            return ("S", node.section_id, node.key, [child_key(c) for c in node.children])
+        if isinstance(node, Comment):
+            return ("C", node.text)
+        return ("X", repr(node))
+
+    return {
+        "name": doc.name,
+        "meta": doc.meta,
+        "sections": [child_key(s) for s in doc.sections],
+    }
+
+
+def _expanded_fixture_block_form() -> Document:
+    """Document where compact-form (InlineList-of-InlineMap) is the source."""
+    return parse("""===T===
+§1::PROFILES
+  ALICE::[
+    NAME::Alice,
+    AGE::30
+  ]
+  BOB::[
+    NAME::Bob,
+    AGE::25
+  ]
+===END===
+""")
+
+
+def _compact_eligible_block_doc() -> Document:
+    """Block of atom-only children, no comments — eligible for compact."""
+    return Document(
+        name="T",
+        sections=[
+            Section(
+                section_id="1",
+                key="A",
+                children=[
+                    Block(
+                        key="PROFILE",
+                        children=[
+                            Assignment(key="NAME", value="Alice"),
+                            Assignment(key="AGE", value=30),
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+
+def _compact_with_comment_block_doc() -> Document:
+    """Block carrying a Comment — compact must veto."""
+    return Document(
+        name="T",
+        sections=[
+            Section(
+                section_id="1",
+                key="A",
+                children=[
+                    Block(
+                        key="PROFILE",
+                        children=[
+                            Comment(text="canonical contact"),
+                            Assignment(key="NAME", value="Alice"),
+                            Assignment(key="AGE", value=30),
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema acceptance / rejection (I5 Schema Sovereignty)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatStyleSchema:
+    def test_format_style_param_accepted(self):
+        tool = WriteTool()
+        schema = tool.get_input_schema()
+        assert "format_style" in schema["properties"]
+        prop = schema["properties"]["format_style"]
+        assert prop["type"] == "string"
+        # Enum lists exactly the three documented values
+        assert set(prop["enum"]) == {"preserve", "expanded", "compact"}
+        # Optional (not required)
+        assert "format_style" not in schema.get("required", [])
+
+    def test_format_style_constants_exposed(self):
+        # Stable identifiers usable by callers / tests / repair logs (I4).
+        assert FORMAT_STYLE_VALUES == ("preserve", "expanded", "compact")
+        assert E_INVALID_FORMAT_STYLE == "E_INVALID_FORMAT_STYLE"
+        assert W_COMPACT_REFUSED == "W_COMPACT_REFUSED"
+
+    @pytest.mark.asyncio
+    async def test_invalid_format_style_rejected(self):
+        tool = WriteTool()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "doc.oct.md")
+            result = await tool.execute(
+                target_path=target,
+                content="===T===\nKEY::value\n===END===\n",
+                format_style="bogus",
+            )
+            assert result["status"] == "error"
+            codes = [e["code"] for e in result["errors"]]
+            assert E_INVALID_FORMAT_STYLE in codes
+
+
+# ---------------------------------------------------------------------------
+# Expanded mode (AST pre-pass)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandedMode:
+    def test_expanded_lifts_inline_map_list_to_block(self):
+        """ListValue([InlineMap{...}]) value lifts into a Block of Assignments."""
+        doc = _expanded_fixture_block_form()
+        expanded_doc = _apply_format_style(doc, "expanded", corrections=[])
+        # ALICE / BOB should now be Blocks, not Assignments with ListValue
+        section = expanded_doc.sections[0]
+        assert isinstance(section, Section)
+        keys = {c.key for c in section.children}
+        assert keys == {"ALICE", "BOB"}
+        for child in section.children:
+            assert isinstance(child, Block), f"expected Block for {child.key}, got {type(child).__name__}"
+            child_keys = {a.key for a in child.children if isinstance(a, Assignment)}
+            assert child_keys == {"NAME", "AGE"}
+
+    def test_expanded_idempotent_on_already_expanded(self):
+        """Expanded pre-pass is a no-op on a Document that already has Block form."""
+        doc = parse("""===T===
+§1::A
+  PROFILE:
+    NAME::Alice
+    AGE::30
+===END===
+""")
+        before = emit(doc)
+        out = _emit_with_style(doc, baseline_bytes=None, new_bytes=None, format_style="expanded", corrections=[])
+        # Re-emit through expanded should match plain emit (already canonical)
+        assert out == before
+
+    def test_expanded_matches_validate_canonical(self):
+        """For 5 fixtures with InlineMap shapes, expanded output matches the
+        canonical multi-line form produced by lifting + plain emit()."""
+        fixtures = [
+            "===A===\n§1::S\n  X::[K::1,L::2]\n===END===\n",
+            "===B===\n§1::S\n  Y::[A::foo,B::bar]\n===END===\n",
+            "===C===\n§1::S\n  Z::[NAME::Alice,AGE::30]\n===END===\n",
+            "===D===\n§1::S\n  W::[K1::v1,K2::v2,K3::v3]\n===END===\n",
+            "===E===\n§1::S\n  V::[ID::1,LABEL::root]\n===END===\n",
+        ]
+        for src in fixtures:
+            doc = parse(src)
+            corr: list = []
+            out = _emit_with_style(doc, baseline_bytes=None, new_bytes=None, format_style="expanded", corrections=corr)
+            # Output must round-trip
+            reparsed = parse(out)
+            # And re-emitting expanded on the reparsed doc must be byte-identical (idempotence)
+            again = _emit_with_style(
+                reparsed, baseline_bytes=None, new_bytes=None, format_style="expanded", corrections=[]
+            )
+            assert again == out, f"expanded not idempotent for fixture: {src!r}"
+            # Block-form must have appeared
+            assert ":" in out
+            # Output must NOT contain the inline-list bracket form for the lifted key
+            # (basic structural assertion — a `KEY::[` would mean inline form remained)
+            for line in out.splitlines():
+                stripped = line.strip()
+                # Allow "===NAME===" envelope and section headers
+                if stripped.startswith("===") or stripped.startswith("§"):
+                    continue
+                if "::" in stripped and stripped.endswith("["):
+                    raise AssertionError(f"inline-list-form survived expanded pass: {line!r}")
+
+
+# ---------------------------------------------------------------------------
+# Compact mode (AST pre-pass + W_COMPACT_REFUSED veto)
+# ---------------------------------------------------------------------------
+
+
+class TestCompactMode:
+    def test_compact_collapses_simple_inline_maps(self):
+        doc = _compact_eligible_block_doc()
+        corrections: list = []
+        out = _emit_with_style(
+            doc, baseline_bytes=None, new_bytes=None, format_style="compact", corrections=corrections
+        )
+        # Output should contain the inline-list-of-inlinemap form
+        assert "PROFILE::[" in out
+        assert "NAME::Alice" in out
+        assert "AGE::30" in out
+        # No W_COMPACT_REFUSED for this clean fixture
+        assert all(c.get("code") != W_COMPACT_REFUSED for c in corrections)
+
+    def test_compact_vetoes_subtrees_with_comments(self):
+        doc = _compact_with_comment_block_doc()
+        corrections: list = []
+        out = _emit_with_style(
+            doc, baseline_bytes=None, new_bytes=None, format_style="compact", corrections=corrections
+        )
+        # Block-form must survive (no collapse)
+        assert "PROFILE:" in out
+        assert "// canonical contact" in out
+        # W_COMPACT_REFUSED must be logged (I4 Audit)
+        veto_codes = [c.get("code") for c in corrections]
+        assert W_COMPACT_REFUSED in veto_codes
+        # Veto entry should reference the field
+        veto = next(c for c in corrections if c.get("code") == W_COMPACT_REFUSED)
+        assert veto.get("safe") is True
+        assert veto.get("semantics_changed") is False
+        # Has a message identifying the subtree
+        assert "PROFILE" in (veto.get("message") or "") or "PROFILE" in (veto.get("field") or "")
+
+    def test_compact_idempotent(self):
+        doc = _compact_eligible_block_doc()
+        once = _emit_with_style(doc, baseline_bytes=None, new_bytes=None, format_style="compact", corrections=[])
+        twice_doc = parse(once)
+        twice = _emit_with_style(twice_doc, baseline_bytes=None, new_bytes=None, format_style="compact", corrections=[])
+        assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# Preserve mode (Strategy C — parse-equality short-circuit)
+# ---------------------------------------------------------------------------
+
+
+class TestPreserveMode:
+    @pytest.mark.asyncio
+    async def test_preserve_no_op_on_parse_equality(self):
+        """Whitespace-only difference from baseline writes baseline bytes verbatim."""
+        baseline = "===T===\n§1::A\n  K::value\n===END===\n"
+        # Add semantically-irrelevant whitespace difference (extra blank line)
+        new_content = "===T===\n§1::A\n  K::value\n\n===END===\n"
+
+        tool = WriteTool()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "doc.oct.md")
+            with open(target, "w", encoding="utf-8") as f:
+                f.write(baseline)
+
+            result = await tool.execute(
+                target_path=target,
+                content=new_content,
+                format_style="preserve",
+            )
+            assert result["status"] == "success"
+            with open(target, encoding="utf-8") as f:
+                on_disk = f.read()
+            # Strategy C: baseline preserved byte-for-byte
+            assert on_disk == baseline
+
+    @pytest.mark.asyncio
+    async def test_preserve_falls_through_on_ast_diff(self):
+        """Semantic difference falls through to canonical emit()."""
+        baseline = "===T===\n§1::A\n  K::value\n===END===\n"
+        new_content = "===T===\n§1::A\n  K::different\n===END===\n"
+
+        tool = WriteTool()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "doc.oct.md")
+            with open(target, "w", encoding="utf-8") as f:
+                f.write(baseline)
+
+            result = await tool.execute(
+                target_path=target,
+                content=new_content,
+                format_style="preserve",
+            )
+            assert result["status"] == "success"
+            with open(target, encoding="utf-8") as f:
+                on_disk = f.read()
+            # Fell through to canonical emit — content reflects new value
+            assert "K::different" in on_disk
+            # And it's parse-equal to the new content
+            assert _semantic_key(parse(on_disk)) == _semantic_key(parse(new_content))
+
+
+# ---------------------------------------------------------------------------
+# Single-canon discipline & idempotence (I1)
+# ---------------------------------------------------------------------------
+
+
+_CORPUS = [
+    "===A===\n§1::S\n  K::value\n===END===\n",
+    "===B===\n§1::S\n  PROFILE::[NAME::Alice,AGE::30]\n===END===\n",
+    "===C===\nMETA:\n  TYPE::TEST\n§1::S\n  K::v\n===END===\n",
+    "===D===\n§1::S\n  L::[a,b,c]\n===END===\n",
+]
+
+
+class TestSingleCanonDiscipline:
+    @pytest.mark.parametrize("src", _CORPUS)
+    def test_modes_agree_on_semantic_space(self, src):
+        """parse(emit(doc, X)) ≈ parse(emit(doc, Y)) under semantic equivalence
+        (Block↔InlineList-of-InlineMap normalised)."""
+        doc = parse(src)
+        outputs = {}
+        for mode in ("preserve", "expanded", "compact"):
+            outputs[mode] = _emit_with_style(
+                doc, baseline_bytes=None, new_bytes=None, format_style=mode, corrections=[]
+            )
+        keys = {m: _semantic_key(parse(out)) for m, out in outputs.items()}
+        # All three semantic keys must match — bijective on semantic space (I1)
+        assert keys["preserve"] == keys["expanded"] == keys["compact"], (
+            f"mode outputs diverge semantically:\n preserve={outputs['preserve']!r}\n"
+            f" expanded={outputs['expanded']!r}\n compact={outputs['compact']!r}"
+        )
+
+    @pytest.mark.parametrize("src", _CORPUS)
+    @pytest.mark.parametrize("mode", ["preserve", "expanded", "compact"])
+    def test_idempotent_per_mode(self, src, mode):
+        """emit(parse(emit(doc, M)), M) == emit(doc, M) for each mode M."""
+        doc = parse(src)
+        once = _emit_with_style(doc, baseline_bytes=None, new_bytes=None, format_style=mode, corrections=[])
+        reparsed = parse(once)
+        twice = _emit_with_style(reparsed, baseline_bytes=None, new_bytes=None, format_style=mode, corrections=[])
+        assert once == twice, f"mode {mode} not idempotent for {src!r}: once={once!r} twice={twice!r}"

--- a/tests/unit/test_format_style.py
+++ b/tests/unit/test_format_style.py
@@ -35,12 +35,17 @@ from octave_mcp.core.ast_nodes import (
 from octave_mcp.core.emitter import emit
 from octave_mcp.core.parser import parse
 from octave_mcp.mcp.write import (
+    E_AST_CYCLE,
     E_INVALID_FORMAT_STYLE,
     FORMAT_STYLE_VALUES,
     W_COMPACT_REFUSED,
+    OctaveASTCycleError,
     WriteTool,
     _apply_format_style,
+    _compact_pass,
     _emit_with_style,
+    _expand_pass,
+    _subtree_has_comment,
 )
 
 # ---------------------------------------------------------------------------
@@ -406,3 +411,164 @@ class TestSingleCanonDiscipline:
         reparsed = parse(once)
         twice = _emit_with_style(reparsed, baseline_bytes=None, new_bytes=None, format_style=mode, corrections=[])
         assert once == twice, f"mode {mode} not idempotent for {src!r}: once={once!r} twice={twice!r}"
+
+
+# ---------------------------------------------------------------------------
+# CIV B1 — W_COMPACT_REFUSED audit-ID disambiguation (I4 attributability).
+# ---------------------------------------------------------------------------
+
+
+class TestSiblingPathDisambiguation:
+    def test_two_sibling_blocks_same_key_get_unique_paths(self):
+        """Two sibling Blocks sharing a key (both with comments) must produce
+        TWO refusal records with DISTINCT field IDs (CIV B1)."""
+        doc = parse(
+            "===T===\n"
+            "§1::A\n"
+            "  PROFILE:\n"
+            "    // c1\n"
+            "    NAME::Alice\n"
+            "  PROFILE:\n"
+            "    // c2\n"
+            "    NAME::Bob\n"
+            "===END===\n"
+        )
+        corrections: list = []
+        _compact_pass(doc.sections, corrections, "")
+        veto = [c for c in corrections if c.get("code") == W_COMPACT_REFUSED]
+        assert len(veto) == 2, f"expected 2 veto records, got {len(veto)}: {veto!r}"
+        fields = {c["field"] for c in veto}
+        assert len(fields) == 2, f"expected 2 distinct fields, got {fields!r}"
+        # The two paths share a base prefix and differ in the ordinal suffix.
+        assert all("PROFILE" in f for f in fields)
+        assert any(f.endswith("#0") for f in fields)
+        assert any(f.endswith("#1") for f in fields)
+
+    def test_singleton_block_path_has_no_ordinal_suffix(self):
+        """A Block whose key is unique among its siblings keeps an unsuffixed
+        path so audit IDs stay readable in the common case."""
+        doc = parse("===T===\n" "§1::A\n" "  PROFILE:\n" "    // c1\n" "    NAME::Alice\n" "===END===\n")
+        corrections: list = []
+        _compact_pass(doc.sections, corrections, "")
+        veto = [c for c in corrections if c.get("code") == W_COMPACT_REFUSED]
+        assert len(veto) == 1
+        # Singleton — no '#' disambiguator.
+        assert "#" not in veto[0]["field"]
+        assert "PROFILE" in veto[0]["field"]
+
+
+# ---------------------------------------------------------------------------
+# CIV B2 — Cycle traversal raises structured error (E_AST_CYCLE).
+# ---------------------------------------------------------------------------
+
+
+class TestCycleGuard:
+    def test_subtree_has_comment_raises_on_cycle(self):
+        b = Block(key="X", children=[Assignment(key="K", value="v")])
+        b.children.append(b)  # self-referential
+        with pytest.raises(OctaveASTCycleError, match=E_AST_CYCLE):
+            _subtree_has_comment(b)
+
+    def test_compact_pass_raises_on_cycle(self):
+        b = Block(key="X", children=[Assignment(key="K", value="v")])
+        b.children.append(b)
+        with pytest.raises(OctaveASTCycleError, match=E_AST_CYCLE):
+            _compact_pass([b], corrections=[], field_path="")
+
+    def test_expand_pass_raises_on_cycle(self):
+        b = Block(key="X", children=[Assignment(key="K", value="v")])
+        b.children.append(b)
+        with pytest.raises(OctaveASTCycleError, match=E_AST_CYCLE):
+            _expand_pass([b])
+
+    def test_cycle_error_carries_stable_code(self):
+        b = Block(key="X", children=[])
+        b.children.append(b)
+        try:
+            _subtree_has_comment(b)
+        except OctaveASTCycleError as exc:
+            assert exc.code == E_AST_CYCLE
+            assert E_AST_CYCLE in str(exc)
+        else:  # pragma: no cover
+            raise AssertionError("expected OctaveASTCycleError")
+
+    def test_acyclic_ast_unaffected_by_guard(self):
+        """The cycle guard must not regress normal traversal — sibling Blocks
+        sharing a child reference are NOT cycles (no ancestor link)."""
+        # Build two independent Blocks that share NO node identity.
+        b1 = Block(key="A", children=[Assignment(key="K", value="v1")])
+        b2 = Block(key="B", children=[Assignment(key="K", value="v2")])
+        # Each must traverse cleanly.
+        assert _subtree_has_comment(b1) is False
+        assert _subtree_has_comment(b2) is False
+
+
+# ---------------------------------------------------------------------------
+# CIV B3 — Arity-exceeded W_COMPACT_REFUSED audit symmetry.
+# ---------------------------------------------------------------------------
+
+
+class TestArityRefusal:
+    def _make_block_with_n_atom_children(self, n: int) -> Document:
+        children = [Assignment(key=f"K{i}", value=i) for i in range(n)]
+        return Document(
+            name="T",
+            sections=[
+                Section(
+                    section_id="1",
+                    key="A",
+                    children=[Block(key="WIDE", children=children)],
+                )
+            ],
+        )
+
+    def test_arity_exceeded_emits_refusal_with_reason(self):
+        """A Block with 9 atom-only children (no comments) exceeds the arity
+        bound and must produce exactly one W_COMPACT_REFUSED record carrying
+        ``reason='arity_exceeded'`` (CIV B3)."""
+        doc = self._make_block_with_n_atom_children(9)
+        corrections: list = []
+        _compact_pass(doc.sections, corrections, "")
+        arity_records = [
+            c for c in corrections if c.get("code") == W_COMPACT_REFUSED and c.get("reason") == "arity_exceeded"
+        ]
+        assert len(arity_records) == 1, f"expected 1 arity refusal, got {arity_records!r}"
+        rec = arity_records[0]
+        assert "WIDE" in rec["field"]
+        assert "9" in rec["message"]
+        assert rec["safe"] is True
+        assert rec["semantics_changed"] is False
+
+    def test_arity_at_bound_collapses_with_no_refusal(self):
+        """A Block with exactly _COMPACT_MAX_PAIRS=8 children collapses cleanly
+        with NO refusal record (boundary check)."""
+        doc = self._make_block_with_n_atom_children(8)
+        corrections: list = []
+        _compact_pass(doc.sections, corrections, "")
+        assert all(c.get("code") != W_COMPACT_REFUSED for c in corrections), corrections
+
+    def test_comment_refusal_carries_reason_discriminant(self):
+        """Existing comment-veto records must also carry the new ``reason``
+        field (audit-symmetry)."""
+        doc = parse("===T===\n" "§1::A\n" "  PROFILE:\n" "    // c\n" "    NAME::Alice\n" "===END===\n")
+        corrections: list = []
+        _compact_pass(doc.sections, corrections, "")
+        veto = [c for c in corrections if c.get("code") == W_COMPACT_REFUSED]
+        assert len(veto) == 1
+        assert veto[0].get("reason") == "contains_comment"
+
+
+# ---------------------------------------------------------------------------
+# CIV B4 — explicit byte-identity guard for default (format_style=None).
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultUnchanged:
+    @pytest.mark.parametrize("src", _CORPUS)
+    def test_format_style_none_byte_identical_to_emit(self, src):
+        """When ``format_style`` is omitted, ``_emit_with_style`` MUST return
+        the same bytes as plain ``emit(doc)`` — guards the documented
+        "current" sentinel default against silent regression (TMG/CIV)."""
+        doc = parse(src)
+        out = _emit_with_style(doc, baseline_bytes=None, new_bytes=None, format_style=None, corrections=[])
+        assert out == emit(doc)


### PR DESCRIPTION
## Summary
- Add configurable `format_style` parameter to the write command to support multiple output formatting options
- Extend CLI interface in `main.py` to expose format_style configuration
- Implement comprehensive formatting logic in `write.py` module with full test coverage

## Changes
- **CLI Enhancement**: Updated `src/octave_mcp/cli/main.py` to accept and pass format_style parameter
- **Write Module**: Extended `src/octave_mcp/mcp/write.py` with format_style handling and formatting implementation (371 lines added)
- **Test Coverage**: Added `tests/unit/test_format_style.py` with 408 lines of unit tests validating format_style behavior across different scenarios

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `format_style` option to the write command (CLI and MCP) with three modes—`preserve`, `expanded`, and `compact`. Default behavior is unchanged; this enables zero-noise diffs and alternate shapes where needed (GH#376).

- **New Features**
  - CLI flag `--format-style {preserve|expanded|compact}` and MCP parameter on `octave_write`.
  - Preserve: if new content is AST-equal to the existing file, write baseline bytes verbatim; else emit canonically.
  - Expanded: lift `InlineMap` shapes (and lists of `InlineMap`) into `Block` form before a single canonical `emit()`.
  - Compact: collapse atom-only `Block`s (no comments, ≤8 pairs) into an inline list of `InlineMap`; vetoed subtrees log `W_COMPACT_REFUSED` with `reason` (`contains_comment` or `arity_exceeded`). CLI surfaces these on stderr.
  - Single-canon orchestrator `_emit_with_style` ensures all modes route through one `emit()`; invalid values are rejected with `E_INVALID_FORMAT_STYLE`. Docs updated in `docs/api.md`, `docs/usage.md`, and `CHANGELOG.md`.

- **Bug Fixes**
  - Unique audit IDs: `W_COMPACT_REFUSED` fields get `#N` suffixes when sibling keys repeat for clear attribution.
  - Cycle guard: AST traversals detect cycles and raise `OctaveASTCycleError` (`E_AST_CYCLE`); now distinguishes true cycles from shared-acyclic references. MCP envelopes and the CLI surface `E_AST_CYCLE` explicitly.
  - Preserve-mode fallback: CLI gracefully handles invalid UTF‑8 baselines (short-circuit disabled, canonical write proceeds).
  - Default guard: when `format_style` is unset, output is byte-identical to today’s `emit()` (idempotence test added).

<sup>Written for commit 85ca7669f206828a7490bf9d8040e449253158f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

