### PR TITLE
fix+test(corpus): SR1-T2a — remove W_DUPLICATE_TARGET collision + lock clean state (#387)

### DIFF
--- a/docs/research/02_benchmarking_and_generation/octave-write-test-outputs/stress-clink.oct.md
+++ b/docs/research/02_benchmarking_and_generation/octave-write-test-outputs/stress-clink.oct.md
@@ -112,5 +112,5 @@ CONDUCT:
     skipping_rollback_verification,
     approving_outside_deployment_window_without_escalation
   ]
-ROLE.TIER::deep
+ROLE_TIER::deep
 ===END===

--- a/tests/unit/test_corpus_no_duplicate_target.py
+++ b/tests/unit/test_corpus_no_duplicate_target.py
@@ -1,0 +1,83 @@
+"""Corpus invariant test: no shipped .oct.md document trips W_DUPLICATE_TARGET.
+
+GH#387 (SR1-T2a, scope-pure split from #372): the migration sweep showed the
+in-tree corpus is clean of W_DUPLICATE_TARGET collisions after one hand-patch
+to a benchmark research output. This test locks the clean state so any future
+regression (a shipped fixture, governance doc, or example acquiring a
+Block(K) + flat Assignment("K.X", ...) corruption fingerprint at the same
+nesting level) fails CI immediately.
+
+Parent issue #372 (full hard-fail conversion + --resolve-duplicates escape
+hatch) remains deferred to deep-tier work post-SR1-T1.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from octave_mcp.core.parser import parse
+from octave_mcp.core.validator import Validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Directories whose contents are not part of the shipped corpus invariant.
+# - .venv / __pycache__ / .git / node_modules / .tox: tooling artefacts.
+# - .ruff_cache / .mypy_cache / .pytest_cache: tooling artefacts.
+EXCLUDED_PARTS = {
+    ".venv",
+    "__pycache__",
+    ".git",
+    "node_modules",
+    ".tox",
+    ".ruff_cache",
+    ".mypy_cache",
+    ".pytest_cache",
+}
+
+
+def _iter_corpus_files() -> list[Path]:
+    files: list[Path] = []
+    for path in REPO_ROOT.rglob("*.oct.md"):
+        if any(part in EXCLUDED_PARTS for part in path.parts):
+            continue
+        files.append(path)
+    return sorted(files)
+
+
+def test_corpus_has_no_duplicate_target_collisions() -> None:
+    """Every parseable .oct.md in the in-tree corpus must validate without
+    emitting W_DUPLICATE_TARGET. Files that fail to parse for unrelated reasons
+    (lexer-side errors out of scope for this invariant) are skipped, not
+    asserted against — this test exclusively guards the duplicate-target
+    structural invariant.
+    """
+    files = _iter_corpus_files()
+    assert files, "Corpus scan found zero .oct.md files; check REPO_ROOT resolution."
+
+    hits: list[tuple[str, str]] = []
+    for path in files:
+        try:
+            doc = parse(path.read_text(encoding="utf-8"))
+        except Exception:
+            # Parse failures are out of scope for this invariant. Other tests
+            # cover lexer/parser correctness; this test only checks the
+            # post-parse structural collision.
+            continue
+        validator = Validator(schema=None)
+        for err in validator.validate(doc):
+            if err.code == "W_DUPLICATE_TARGET":
+                rel = path.relative_to(REPO_ROOT)
+                hits.append((str(rel), err.field_path or "<unknown>"))
+
+    if hits:
+        formatted = "\n".join(f"  - {p} (field: {f})" for p, f in hits)
+        pytest.fail(
+            "W_DUPLICATE_TARGET collision(s) detected in shipped corpus "
+            f"({len(hits)} hit(s)):\n{formatted}\n\n"
+            "Each hit indicates a Block(K) coexisting with a flat "
+            'Assignment("K.X", ...) at the same nesting level — the GH#369 '
+            "corruption fingerprint. Repair by nesting the dotted assignment "
+            "inside the block or renaming it to remove the prefix collision."
+        )

--- a/tests/unit/test_corpus_no_duplicate_target.py
+++ b/tests/unit/test_corpus_no_duplicate_target.py
@@ -17,7 +17,8 @@ from pathlib import Path
 
 import pytest
 
-from octave_mcp.core.parser import parse
+from octave_mcp.core.lexer import LexerError
+from octave_mcp.core.parser import ParserError, parse
 from octave_mcp.core.validator import Validator
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -36,6 +37,27 @@ EXCLUDED_PARTS = {
     ".pytest_cache",
 }
 
+# Allowlist for intentional negative fixtures: relative paths (POSIX-style,
+# relative to REPO_ROOT) of `.oct.md` files that are EXPECTED to trip
+# W_DUPLICATE_TARGET — e.g. fixtures backing tests that exercise the
+# corruption-detection path itself. The corpus invariant skips these.
+#
+# Add entries here only when a new test deliberately needs a duplicate-target
+# fixture as input. Each addition should be justified in the commit message
+# and ideally paired with a test that consumes the fixture so its presence
+# is auditable.
+INTENTIONAL_NEGATIVE_FIXTURES: frozenset[str] = frozenset()
+
+# Exception types that may legitimately be raised by `parse()` on
+# unrelated lexer/parser malformations. Any OTHER exception type surfacing
+# from the parse path is treated as a real bug and surfaced as a test
+# failure rather than silently skipped (CE follow-up to PR #389).
+_TOLERATED_PARSE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    LexerError,
+    ParserError,
+    UnicodeDecodeError,
+)
+
 
 def _iter_corpus_files() -> list[Path]:
     files: list[Path] = []
@@ -48,22 +70,28 @@ def _iter_corpus_files() -> list[Path]:
 
 def test_corpus_has_no_duplicate_target_collisions() -> None:
     """Every parseable .oct.md in the in-tree corpus must validate without
-    emitting W_DUPLICATE_TARGET. Files that fail to parse for unrelated reasons
-    (lexer-side errors out of scope for this invariant) are skipped, not
-    asserted against — this test exclusively guards the duplicate-target
-    structural invariant.
+    emitting W_DUPLICATE_TARGET. Files in INTENTIONAL_NEGATIVE_FIXTURES are
+    skipped (they exist to exercise the corruption-detection path). Files
+    that fail to parse with a tolerated lexer/parser exception type are also
+    skipped — those malformations are out of scope for this invariant. Any
+    OTHER exception type surfaces as a test failure rather than being
+    silently swallowed.
     """
     files = _iter_corpus_files()
     assert files, "Corpus scan found zero .oct.md files; check REPO_ROOT resolution."
 
     hits: list[tuple[str, str]] = []
     for path in files:
+        rel_posix = path.relative_to(REPO_ROOT).as_posix()
+        if rel_posix in INTENTIONAL_NEGATIVE_FIXTURES:
+            continue
         try:
             doc = parse(path.read_text(encoding="utf-8"))
-        except Exception:
-            # Parse failures are out of scope for this invariant. Other tests
-            # cover lexer/parser correctness; this test only checks the
-            # post-parse structural collision.
+        except _TOLERATED_PARSE_EXCEPTIONS:
+            # Lexer/parser malformations and encoding errors are out of
+            # scope for this invariant. Other tests cover those failure
+            # modes; this test exclusively guards the post-parse
+            # duplicate-target structural collision.
             continue
         validator = Validator(schema=None)
         for err in validator.validate(doc):


### PR DESCRIPTION
## Summary

Scope-pure SR1-T2a (split from #372) per ADR-0006 Sprint 1 sequencing decision (Option B): hand-patch the sole pre-existing W_DUPLICATE_TARGET collision in the in-tree corpus and add a regression test that locks the clean state.

- **Corpus sweep** (208 `.oct.md` files scanned): 1 hit — `docs/research/02_benchmarking_and_generation/octave-write-test-outputs/stress-clink.oct.md` (LLM-generated benchmark output, Block `ROLE` line 6 colliding with flat `ROLE.TIER::deep` line 115).
- **Repair**: rename the dangling root-level dotted assignment to `ROLE_TIER::deep`. Removes the prefix collision while preserving the original semantic intent (the agent's tier classification). No other content changed in the file.
- **Lock**: new `tests/unit/test_corpus_no_duplicate_target.py` rglobs every `.oct.md` under repo root (excluding tooling artefact dirs), parses each, runs `Validator(schema=None).validate`, asserts no `W_DUPLICATE_TARGET` codes appear. Files that fail to parse for unrelated reasons are skipped — this test exclusively guards the structural duplicate-target invariant.

## Scope discipline

This PR does **not**:
- Convert `W_DUPLICATE_TARGET` warning → fatal `E_DUPLICATE_TARGET` error.
- Touch validator emit semantics, severity, or message text.
- Touch CLI/MCP tool schemas or add a `--resolve-duplicates` escape hatch.

All of the above remain part of parent **#372** (deep-tier work), deferred until SR1-T1 grammar core lands so the hard-fail can be designed at the unified parse boundary with the escape hatch as integrated design — per the implementation-lead STOP-and-report on the original SR1-T2 task and the HO sequencing decision documented in #387.

## Test plan

- [x] New corpus test passes locally (`pytest tests/unit/test_corpus_no_duplicate_target.py`).
- [x] Full pytest suite green: 2878 passed, 11 skipped, 9 xfailed.
- [x] `ruff check .` clean.
- [x] `black --check .` clean (180 files unchanged).
- [x] `mypy src/octave_mcp` clean (no issues, 48 source files).
- [ ] CI green on PR.

## Refs

- Closes #387
- Refs #372 (parent, remains open)
- ADR-0006 §70-84 (Sprint 1 SR1-T2 row, lines 78 + 116 + 133)

Closes #387

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the only `W_DUPLICATE_TARGET` collision in the corpus and locked the clean state with a regression test. Addresses #387; warning→error work stays in #372.

- **Bug Fixes**
  - Renamed `ROLE.TIER::deep` to `ROLE_TIER::deep` in `docs/research/02_benchmarking_and_generation/octave-write-test-outputs/stress-clink.oct.md` to remove the prefix collision; no other changes.
  - Strengthened `tests/unit/test_corpus_no_duplicate_target.py`: scans all `.oct.md` (excluding tooling dirs), parses via `octave_mcp.core.parser.parse`, validates with `Validator(schema=None)`, fails on `W_DUPLICATE_TARGET`; skips only tolerated lexer/parser/encoding errors; adds empty `INTENTIONAL_NEGATIVE_FIXTURES` allowlist; narrows exceptions to `(LexerError, ParserError, UnicodeDecodeError)`.

<sup>Written for commit 82018ddf92cf4464c568116aa6c534ea18b14237. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

