### PR TITLE
fix(write): hard-fail ambiguous Block.child paths per ADR-0006 SR1-T3 (#369)

### DIFF
--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -2153,17 +2153,50 @@ class WriteTool(BaseTool):
                     if parent_block is not None:
                         # PARENT exists as a top-level Block. Treat dot as path
                         # separator; CHILD must resolve inside the Block.
-                        if not any(isinstance(c, Assignment) and c.key == child_key for c in parent_block.children):
-                            # GH#370: Before rejecting, check if the literal dotted key
-                            # exists as a flat assignment (conflict scenario from GH#369).
-                            # If the flat key exists, applier will handle it; validator
-                            # must not reject to maintain contract with applier.
-                            flat_match = any(isinstance(s, Assignment) and s.key == key for s in doc.sections)
-                            if flat_match:
-                                # Conflicted document: Block + flat dotted assignment coexist.
-                                # Applier will route to flat assignment (GH#347 carve-out).
-                                # Tolerate here for consistency; validator will emit W_DUPLICATE_TARGET.
-                                continue
+                        flat_match = any(isinstance(s, Assignment) and s.key == key for s in doc.sections)
+                        block_child_match = any(
+                            isinstance(c, Assignment) and c.key == child_key for c in parent_block.children
+                        )
+                        if flat_match:
+                            # ADR-0006 SR1-T3 (closes GH#369): conflicted source
+                            # document — both Block(parent) and a flat top-level
+                            # Assignment(parent.child) exist. The change key is
+                            # genuinely ambiguous: should the update land inside
+                            # the Block, or on the flat assignment? Either choice
+                            # fabricates intent the caller did not declare, which
+                            # violates PROD-I3 (Mirror Constraint: reflect only
+                            # present, create nothing). Prior behaviour
+                            # (PR#370) silently routed to the flat assignment
+                            # and surfaced a W_DUPLICATE_TARGET warning; ADR-0006
+                            # supersedes that contract with a hard-fail so the
+                            # caller must disambiguate before the writer commits
+                            # to a target.
+                            candidates = [
+                                f"flat top-level Assignment('{key}')",
+                                (
+                                    f"child '{child_key}' inside top-level Block('{parent_key}')"
+                                    if block_child_match
+                                    else f"top-level Block('{parent_key}') (no child '{child_key}' present)"
+                                ),
+                            ]
+                            errors.append(
+                                {
+                                    "code": "E_AMBIGUOUS_PATH",
+                                    "message": (
+                                        f"Ambiguous change path '{key}': source document contains "
+                                        f"both a top-level Block('{parent_key}') and a flat "
+                                        f"top-level Assignment('{key}'). Candidate targets: "
+                                        f"{candidates[0]}; {candidates[1]}. Refusing to guess "
+                                        f"which to update. To resolve: (a) use the content= "
+                                        f"parameter with the full document to rewrite verbatim, "
+                                        f"or (b) clean up the source so only one of the two "
+                                        f"targets remains (this conflict is the W_DUPLICATE_TARGET "
+                                        f"corruption pattern tracked by GH#372 SR1-T2)."
+                                    ),
+                                }
+                            )
+                            continue
+                        if not block_child_match:
                             # No flat fallback; reject the unresolvable path.
                             errors.append(
                                 {
@@ -2177,8 +2210,8 @@ class WriteTool(BaseTool):
                                 }
                             )
                             continue
-                        # PARENT.CHILD resolves inside the block. _apply_changes
-                        # will route to _apply_block_change.
+                        # PARENT.CHILD resolves unambiguously inside the block.
+                        # _apply_changes will route to _apply_block_change.
                         continue
                     # PARENT is not a top-level Block. The key is acceptable
                     # only if it already exists as a flat top-level Assignment

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -5311,9 +5311,7 @@ class TestGH369NestedBlockChangePathResolution:
                 f"SR1-T3, got status={result.get('status')}"
             )
             codes = {e.get("code") for e in result.get("errors", [])}
-            assert "E_AMBIGUOUS_PATH" in codes, (
-                f"Expected E_AMBIGUOUS_PATH, got: {result.get('errors')}"
-            )
+            assert "E_AMBIGUOUS_PATH" in codes, f"Expected E_AMBIGUOUS_PATH, got: {result.get('errors')}"
             # File on disk must be untouched (fail-fast precludes partial write).
             with open(target_path) as f:
                 final = f.read()
@@ -5351,9 +5349,7 @@ class TestGH369NestedBlockChangePathResolution:
         validator = Validator()
         errors = validator.validate(doc)
         codes = {e.code for e in errors}
-        assert (
-            "W_DUPLICATE_TARGET" in codes
-        ), f"Expected W_DUPLICATE_TARGET in validator output, got: {codes}"
+        assert "W_DUPLICATE_TARGET" in codes, f"Expected W_DUPLICATE_TARGET in validator output, got: {codes}"
 
     @pytest.mark.asyncio
     async def test_gh370_delete_sentinel_on_conflicted_document_hard_fails(self):
@@ -5382,8 +5378,7 @@ class TestGH369NestedBlockChangePathResolution:
             assert result["status"] == "error"
             codes = {e.get("code") for e in result.get("errors", [])}
             assert "E_AMBIGUOUS_PATH" in codes, (
-                f"Expected E_AMBIGUOUS_PATH on DELETE against conflicted source, "
-                f"got: {result.get('errors')}"
+                f"Expected E_AMBIGUOUS_PATH on DELETE against conflicted source, " f"got: {result.get('errors')}"
             )
             # File untouched.
             with open(target_path) as f:
@@ -5454,9 +5449,7 @@ class TestSR1T3BlockChildAmbiguousPathHardFail:
                 f"{result.get('status')} errors={result.get('errors')}"
             )
             codes = {e.get("code") for e in result.get("errors", [])}
-            assert "E_AMBIGUOUS_PATH" in codes, (
-                f"Expected E_AMBIGUOUS_PATH in errors, got: {result.get('errors')}"
-            )
+            assert "E_AMBIGUOUS_PATH" in codes, f"Expected E_AMBIGUOUS_PATH in errors, got: {result.get('errors')}"
 
     @pytest.mark.asyncio
     async def test_ambiguous_path_error_message_lists_both_candidates(self):
@@ -5471,13 +5464,7 @@ class TestSR1T3BlockChildAmbiguousPathHardFail:
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = os.path.join(tmpdir, "test.oct.md")
             initial = (
-                "===TEST===\n"
-                "META:\n"
-                '  TYPE::"TEST"\n'
-                "P1:\n"
-                "  CHILD::value\n"
-                "P1.1::original\n"
-                "===END===\n"
+                "===TEST===\n" "META:\n" '  TYPE::"TEST"\n' "P1:\n" "  CHILD::value\n" "P1.1::original\n" "===END===\n"
             )
             with open(target_path, "w") as f:
                 f.write(initial)
@@ -5488,9 +5475,7 @@ class TestSR1T3BlockChildAmbiguousPathHardFail:
             )
 
             assert result["status"] == "error"
-            ambig = [
-                e for e in result.get("errors", []) if e.get("code") == "E_AMBIGUOUS_PATH"
-            ]
+            ambig = [e for e in result.get("errors", []) if e.get("code") == "E_AMBIGUOUS_PATH"]
             assert ambig, f"Expected E_AMBIGUOUS_PATH error, got: {result.get('errors')}"
             msg = ambig[0].get("message", "")
             assert "P1" in msg, f"Error message must name the parent block: {msg}"
@@ -5509,13 +5494,7 @@ class TestSR1T3BlockChildAmbiguousPathHardFail:
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = os.path.join(tmpdir, "test.oct.md")
             initial = (
-                "===TEST===\n"
-                "META:\n"
-                '  TYPE::"TEST"\n'
-                "P1:\n"
-                "  CHILD::value\n"
-                "P1.1::original\n"
-                "===END===\n"
+                "===TEST===\n" "META:\n" '  TYPE::"TEST"\n' "P1:\n" "  CHILD::value\n" "P1.1::original\n" "===END===\n"
             )
             with open(target_path, "w") as f:
                 f.write(initial)
@@ -5525,16 +5504,13 @@ class TestSR1T3BlockChildAmbiguousPathHardFail:
                 changes={"P1.1": "updated"},
             )
 
-            ambig = [
-                e for e in result.get("errors", []) if e.get("code") == "E_AMBIGUOUS_PATH"
-            ]
+            ambig = [e for e in result.get("errors", []) if e.get("code") == "E_AMBIGUOUS_PATH"]
             assert ambig
             msg = ambig[0].get("message", "")
             # Must mention the content= escape hatch so the caller has a path
             # forward without guessing.
             assert "content=" in msg or "content parameter" in msg, (
-                f"Error message must guide caller to content= disambiguation, "
-                f"got: {msg}"
+                f"Error message must guide caller to content= disambiguation, " f"got: {msg}"
             )
 
     @pytest.mark.asyncio
@@ -5567,12 +5543,9 @@ class TestSR1T3BlockChildAmbiguousPathHardFail:
             )
 
             assert result["status"] == "success", (
-                f"Unambiguous Block.child must still succeed, got errors: "
-                f"{result.get('errors')}"
+                f"Unambiguous Block.child must still succeed, got errors: " f"{result.get('errors')}"
             )
             with open(target_path) as f:
                 final = f.read()
             assert "NAV:" in final
-            assert "NAV.OPERATIONAL_CONVENTIONS::" not in final, (
-                f"flat duplicate leaked into file:\n{final}"
-            )
+            assert "NAV.OPERATIONAL_CONVENTIONS::" not in final, f"flat duplicate leaked into file:\n{final}"

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -5276,12 +5276,18 @@ class TestGH369NestedBlockChangePathResolution:
         assert dup.severity == "warning"
 
     @pytest.mark.asyncio
-    async def test_gh370_conflicted_document_block_plus_flat_dotted_allowed(self):
-        """GH#370: A document with both Block(K) and flat Assignment(K.X) is
-        conflicted but should be editable via changes-mode. The validator must
-        tolerate this because the applier will handle it via the flat assignment.
-        This happens when a writer regression created the corruption pattern but
-        the file still needs cleanup."""
+    async def test_gh370_conflicted_document_block_plus_flat_dotted_hard_fails(self):
+        """ADR-0006 SR1-T3 (GH#369): document containing both Block(K) and
+        flat Assignment(K.X) is conflicted; changes-mode targeting K.X must
+        hard-fail with E_AMBIGUOUS_PATH instead of routing to the flat
+        assignment.
+
+        Supersedes the prior PR#370 "tolerate-and-warn" contract: warning
+        was insufficient because the writer still committed an edit to one
+        of two candidate targets without the caller's consent. Cleanup of
+        such documents is tracked by GH#372 SR1-T2 migration sweep using
+        ``content=`` mode.
+        """
         from octave_mcp.mcp.write import WriteTool
 
         tool = WriteTool()
@@ -5295,35 +5301,136 @@ class TestGH369NestedBlockChangePathResolution:
             with open(target_path, "w") as f:
                 f.write(initial)
 
-            # Should allow editing the flat assignment
             result = await tool.execute(
                 target_path=target_path,
                 changes={"P1.1": "updated"},
             )
 
-            assert result["status"] == "success", f"errors: {result.get('errors')}"
-            # Verify the W_DUPLICATE_TARGET warning surfaces
-            correction_codes = {c.get("code") for c in result.get("corrections", [])}
-            assert (
-                "W_DUPLICATE_TARGET" in correction_codes
-            ), f"Expected W_DUPLICATE_TARGET warning in corrections, got: {correction_codes}"
+            assert result["status"] == "error", (
+                f"Conflicted Block(P1)+flat P1.1 must hard-fail per ADR-0006 "
+                f"SR1-T3, got status={result.get('status')}"
+            )
+            codes = {e.get("code") for e in result.get("errors", [])}
+            assert "E_AMBIGUOUS_PATH" in codes, (
+                f"Expected E_AMBIGUOUS_PATH, got: {result.get('errors')}"
+            )
+            # File on disk must be untouched (fail-fast precludes partial write).
             with open(target_path) as f:
                 final = f.read()
-            assert "P1.1::updated" in final
+            assert "P1.1::original" in final
 
     @pytest.mark.asyncio
-    async def test_gh370_duplicate_target_warning_surfaces_in_default_flow(self):
-        """GH#370: W_DUPLICATE_TARGET warning must surface in default changes-mode
-        flow without requiring schema validation. This is Problem 2: the warning
-        only fired when schema_name was set, so corrupted files couldn't be
-        detected during normal editing."""
+    async def test_gh370_duplicate_target_warning_surfaces_on_validate_only(self):
+        """ADR-0006 SR1-T3: changes-mode against a conflicted document hard-
+        fails (see test_gh370_conflicted_document_block_plus_flat_dotted_hard_fails),
+        but the W_DUPLICATE_TARGET validator warning still serves as the
+        diagnostic tripwire when the document is read or validated without
+        an active changes payload (covers the migration-sweep visibility
+        path of GH#372).
+        """
+        from octave_mcp.core.ast_nodes import Assignment, Block, Document, ListValue
+        from octave_mcp.core.validator import Validator
+
+        doc = Document(
+            name="NAV_TEST",
+            meta={"TYPE": "TEST"},
+            sections=[
+                Block(
+                    key="NAV",
+                    children=[
+                        Assignment(key="FOUNDATIONAL", value=ListValue(items=["A", "B"])),
+                    ],
+                ),
+                Assignment(
+                    key="NAV.OPERATIONAL_CONVENTIONS",
+                    value=ListValue(items=["SEARCH_PATH_CONVENTION"]),
+                ),
+            ],
+        )
+
+        validator = Validator()
+        errors = validator.validate(doc)
+        codes = {e.code for e in errors}
+        assert (
+            "W_DUPLICATE_TARGET" in codes
+        ), f"Expected W_DUPLICATE_TARGET in validator output, got: {codes}"
+
+    @pytest.mark.asyncio
+    async def test_gh370_delete_sentinel_on_conflicted_document_hard_fails(self):
+        """ADR-0006 SR1-T3 (GH#369): even DELETE on a flat K.X in a conflicted
+        document is ambiguous (delete which target?). Must hard-fail with
+        E_AMBIGUOUS_PATH; cleanup must use ``content=`` mode (or the
+        forthcoming GH#372 migration sweep tooling).
+        """
         from octave_mcp.mcp.write import WriteTool
 
         tool = WriteTool()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = os.path.join(tmpdir, "test.oct.md")
-            # Corrupted document: Block NAV + flat NAV.OPERATIONAL_CONVENTIONS
+            initial = (
+                "===TEST===\n" "META:\n" '  TYPE::"TEST"\n' "P1:\n" "  CHILD::value\n" "P1.1::to_delete\n" "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"P1.1": {"$op": "DELETE"}},
+            )
+
+            assert result["status"] == "error"
+            codes = {e.get("code") for e in result.get("errors", [])}
+            assert "E_AMBIGUOUS_PATH" in codes, (
+                f"Expected E_AMBIGUOUS_PATH on DELETE against conflicted source, "
+                f"got: {result.get('errors')}"
+            )
+            # File untouched.
+            with open(target_path) as f:
+                final = f.read()
+            assert "P1.1::to_delete" in final
+            assert "P1:" in final
+
+
+class TestSR1T3BlockChildAmbiguousPathHardFail:
+    """ADR-0006 SR1-T3 (closes GH#369): when a single-dot change key K.X is
+    ambiguous between (a) a child of top-level Block(K) and (b) a flat
+    top-level Assignment("K.X") that already coexists with Block(K), the
+    writer MUST hard-fail with E_AMBIGUOUS_PATH rather than silently route
+    the update to one candidate.
+
+    PROD-I3 (Mirror Constraint): reflect only present, create nothing.
+    Routing an ambiguous reference picks one of two extant targets, which
+    is itself a fabrication of intent — the agent did not declare which
+    target it meant. Hard-fail forces the caller to disambiguate.
+
+    Disambiguation guidance surfaced by the error message:
+      * Use ``content=`` mode with the full document to rewrite verbatim,
+        OR
+      * Resolve the source document so that only one of {Block(K),
+        flat K.X} remains (cleanup of the corruption pattern detected
+        and tracked by GH#372 SR1-T2 migration sweep).
+
+    NOTE: Unambiguous Block.child paths (Block(K) present without a
+    coexisting flat K.X) MUST continue to resolve into the Block — that
+    is the GH#369/PR#370 fix preserved here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_conflicted_document_hard_fails_with_ambiguous_path(self):
+        """Conflicted source document (Block(K) + flat K.X coexisting) plus
+        a changes={K.X: ...} request must hard-fail with E_AMBIGUOUS_PATH.
+
+        This replaces the prior GH#370 "tolerate-and-warn" behaviour. The
+        warning was insufficient because the writer still committed an edit
+        to one of two candidate targets without the caller's consent.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
             initial = (
                 "===NAV_TEST===\n"
                 "META:\n"
@@ -5336,46 +5443,136 @@ class TestGH369NestedBlockChangePathResolution:
             with open(target_path, "w") as f:
                 f.write(initial)
 
-            # Execute without schema (default flow)
             result = await tool.execute(
                 target_path=target_path,
                 changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
             )
 
-            assert result["status"] == "success"
-            # W_DUPLICATE_TARGET must surface in corrections
-            correction_codes = {c.get("code") for c in result.get("corrections", [])}
-            assert (
-                "W_DUPLICATE_TARGET" in correction_codes
-            ), f"Expected W_DUPLICATE_TARGET in default flow, got: {correction_codes}"
+            assert result["status"] == "error", (
+                f"Conflicted Block(NAV) + flat NAV.OPERATIONAL_CONVENTIONS source "
+                f"must hard-fail under ADR-0006 SR1-T3, got status="
+                f"{result.get('status')} errors={result.get('errors')}"
+            )
+            codes = {e.get("code") for e in result.get("errors", [])}
+            assert "E_AMBIGUOUS_PATH" in codes, (
+                f"Expected E_AMBIGUOUS_PATH in errors, got: {result.get('errors')}"
+            )
 
     @pytest.mark.asyncio
-    async def test_gh370_delete_sentinel_on_conflicted_document(self):
-        """GH#370: DELETE sentinel on a flat K.X assignment in a conflicted
-        document (where Block(K) also exists) should work. This ensures both
-        reading and writing operations can handle the corruption pattern."""
+    async def test_ambiguous_path_error_message_lists_both_candidates(self):
+        """E_AMBIGUOUS_PATH message must enumerate the conflicting targets
+        (the Block-child and the flat assignment) so the agent can act on
+        the diagnosis without re-reading the source.
+        """
         from octave_mcp.mcp.write import WriteTool
 
         tool = WriteTool()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             target_path = os.path.join(tmpdir, "test.oct.md")
-            # Corrupted document: Block P1 + flat P1.1
             initial = (
-                "===TEST===\n" "META:\n" '  TYPE::"TEST"\n' "P1:\n" "  CHILD::value\n" "P1.1::to_delete\n" "===END===\n"
+                "===TEST===\n"
+                "META:\n"
+                '  TYPE::"TEST"\n'
+                "P1:\n"
+                "  CHILD::value\n"
+                "P1.1::original\n"
+                "===END===\n"
             )
             with open(target_path, "w") as f:
                 f.write(initial)
 
             result = await tool.execute(
                 target_path=target_path,
-                changes={"P1.1": {"$op": "DELETE"}},
+                changes={"P1.1": "updated"},
             )
 
-            assert result["status"] == "success", f"errors: {result.get('errors')}"
+            assert result["status"] == "error"
+            ambig = [
+                e for e in result.get("errors", []) if e.get("code") == "E_AMBIGUOUS_PATH"
+            ]
+            assert ambig, f"Expected E_AMBIGUOUS_PATH error, got: {result.get('errors')}"
+            msg = ambig[0].get("message", "")
+            assert "P1" in msg, f"Error message must name the parent block: {msg}"
+            assert "P1.1" in msg, f"Error message must name the flat key: {msg}"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_path_error_message_guides_disambiguation(self):
+        """The error message must point the caller at the disambiguating
+        workaround (``content=`` mode and/or source cleanup), so the agent
+        is not stranded after the hard-fail.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
+            initial = (
+                "===TEST===\n"
+                "META:\n"
+                '  TYPE::"TEST"\n'
+                "P1:\n"
+                "  CHILD::value\n"
+                "P1.1::original\n"
+                "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"P1.1": "updated"},
+            )
+
+            ambig = [
+                e for e in result.get("errors", []) if e.get("code") == "E_AMBIGUOUS_PATH"
+            ]
+            assert ambig
+            msg = ambig[0].get("message", "")
+            # Must mention the content= escape hatch so the caller has a path
+            # forward without guessing.
+            assert "content=" in msg or "content parameter" in msg, (
+                f"Error message must guide caller to content= disambiguation, "
+                f"got: {msg}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_unambiguous_block_child_still_resolves(self):
+        """Regression guard: when Block(K) exists WITHOUT a coexisting flat
+        K.X, K.X is unambiguous and must continue to resolve into the Block
+        (GH#369/PR#370 behaviour preserved).
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
+            initial = (
+                "===NAV_TEST===\n"
+                "META:\n"
+                '  TYPE::"TEST"\n'
+                "NAV:\n"
+                "  FOUNDATIONAL::[A,B]\n"
+                "  OPERATIONAL_CONVENTIONS::[OLD]\n"
+                "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
+            )
+
+            assert result["status"] == "success", (
+                f"Unambiguous Block.child must still succeed, got errors: "
+                f"{result.get('errors')}"
+            )
             with open(target_path) as f:
                 final = f.read()
-            # P1.1 should be deleted but P1 block remains
-            assert "P1.1" not in final
-            assert "P1:" in final
-            assert "CHILD" in final
+            assert "NAV:" in final
+            assert "NAV.OPERATIONAL_CONVENTIONS::" not in final, (
+                f"flat duplicate leaked into file:\n{final}"
+            )


### PR DESCRIPTION
## Summary

ADR-0006 SR1-T3 (closes #369). When a single-dot change key `K.X` is genuinely ambiguous between (a) a child of top-level `Block(K)` and (b) a coexisting flat top-level `Assignment("K.X")`, `octave_write` changes-mode now hard-fails with `E_AMBIGUOUS_PATH` listing both candidate targets and pointing the caller at the `content=` disambiguation hatch.

Prior behaviour (PR#370) silently routed the update to the flat assignment and surfaced a `W_DUPLICATE_TARGET` correction. The warning proved insufficient because the writer still committed an edit to one of two candidate targets without the caller's consent — a fabrication of intent that violates PROD-I3 (Mirror Constraint: reflect only present, create nothing).

## Scope discipline (parallel SR1 tracks)

- **SR1-T1 (grammar core)** — not touched. Hard-fail is implemented at the existing `_validate_change_paths` resolver layer; no new grammar surface introduced.
- **SR1-T2 (#372 W_DUPLICATE_TARGET sweep)** — not touched. The validator-side `W_DUPLICATE_TARGET` warning is retained as the read-side detection signal for the migration sweep, which uses `content=` mode (not changes-mode) and is therefore unaffected by this hard-fail.
- **GH#347 single-identifier dotted keys** (`P1.1`, `v2.0`) remain accepted when no `Block(parent)` exists.
- **Unambiguous `Block.child` paths** (`Block(K)` present without coexisting flat `K.X`) keep resolving into the Block (GH#369/PR#370 nesting fix preserved).

## Commits

1. `d909c40` — `test(write): add Block.child ambiguous-path hard-fail spec` (RED)
2. `2afeaab` — `fix(write): hard-fail ambiguous Block.child paths per ADR-0006 SR1-T3 (#369)` (GREEN)
3. `46c6ab1` — `style(tests): black-format SR1-T3 ambiguous-path spec`

## Test plan

- [x] New `TestSR1T3BlockChildAmbiguousPathHardFail` (4 tests): conflicted source hard-fails, error message lists both candidates, error message guides to `content=` disambiguation, unambiguous Block.child still resolves.
- [x] Three pre-existing GH#370 tests updated from "tolerate-and-warn" → "hard-fail" contract per ADR-0006 SR1-T3.
- [x] Pre-existing `TestGH369NestedBlockChangePathResolution` (deliverables A/B/C) — all green.
- [x] Full suite: `2881 passed, 11 skipped, 9 xfailed`.
- [x] `ruff check src/ tests/` — clean.
- [x] `black --check src/ tests/` — clean.
- [x] `mypy src/` — clean (48 files).

## Downstream gates

T2 tier: TMG → CRS → CE chain expected to follow this PR per ADR-0006 cadence.

Closes #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changes-mode now hard-fails with E_AMBIGUOUS_PATH when a dotted key (e.g., K.X) is ambiguous between a Block(K) child and a flat Assignment("K.X"). This replaces the prior tolerate-and-warn behavior to prevent unintended edits.

- **Bug Fixes**
  - In `octave_mcp.mcp.write._validate_change_paths`, detect coexisting Block(parent) and flat `parent.child`; return `E_AMBIGUOUS_PATH` with both candidates in the message. Closes #369.
  - Preserve behavior: unambiguous Block.child paths still resolve into the Block; single-identifier dotted keys remain valid when no `Block(parent)` exists.
  - Keep `W_DUPLICATE_TARGET` on read/validate-only flows to support the GH#372 migration sweep.
  - Updated and added tests to cover hard-fail, error messaging, and no file mutations on error.

- **Migration**
  - If you hit `E_AMBIGUOUS_PATH`: use the `content=` parameter to rewrite the file, or clean the source so only one target remains.

<sup>Written for commit 46c6ab12fb27994166eb122a16d0b088602e866b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

