### PR TITLE
feat(write): SR1-T3a ambiguous-path deprecation warning per ADR-0006 split

### DIFF
--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -3407,16 +3407,25 @@ class WriteTool(BaseTool):
             # failures. MUST appear BEFORE the broad ``except Exception``
             # below — OctaveASTCycleError is a ValueError subclass and would
             # otherwise be swallowed into the generic E_EMIT envelope.
+            #
+            # CE follow-up to #392: change_warnings (e.g. W_AMBIGUOUS_PATH)
+            # captured by _validate_change_paths during the changes-mode pass
+            # are merged into the error envelope here. Without this drain the
+            # success-path drain at line ~3519 would never run on emit failure
+            # and the deprecation signal would be silently dropped.
             return self._error_envelope(
                 target_path,
                 [{"code": OctaveASTCycleError.code, "message": str(cyc)}],
-                corrections,
+                corrections + list(change_warnings),
             )
         except Exception as e:
+            # CE follow-up to #392: same change_warnings drain as the
+            # E_AST_CYCLE branch above — emit failure must not lose
+            # W_AMBIGUOUS_PATH (or any future change-path warning).
             return self._error_envelope(
                 target_path,
                 [{"code": "E_EMIT", "message": f"Emit error: {str(e)}"}],
-                corrections,
+                corrections + list(change_warnings),
             )
 
         result["corrections"] = corrections

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1124,13 +1124,6 @@ class WriteTool(BaseTool):
     # Security: allowed file extensions
     ALLOWED_EXTENSIONS = {".oct.md", ".octave", ".md"}
 
-    # ADR-0006 SR1-T3a (#391): per-invocation buffer for non-fatal change-path
-    # warnings emitted by _validate_change_paths and drained into corrections
-    # by execute(). Declared at class scope so mypy treats reassignments in
-    # execute() and the defensive guard inside _validate_change_paths as the
-    # same attribute (no-redef silenced).
-    _pending_change_warnings: list[dict[str, Any]]
-
     def _repair_curly_brace_annotations(self, content: str) -> tuple[str, list[dict[str, Any]]]:
         """GH#263: Pre-process content to repair NAME{qualifier} -> NAME<qualifier>.
 
@@ -2025,7 +2018,13 @@ class WriteTool(BaseTool):
 
         return corrections
 
-    def _validate_change_paths(self, changes: dict[str, Any], doc: Any | None = None) -> list[dict[str, Any]]:
+    def _validate_change_paths(
+        self,
+        changes: dict[str, Any],
+        doc: Any | None = None,
+        *,
+        change_warnings: list[dict[str, Any]] | None = None,
+    ) -> list[dict[str, Any]]:
         """GH#335/GH#353: Validate change paths are resolvable before applying.
 
         Detects paths that _apply_changes cannot resolve to AST nodes and
@@ -2052,6 +2051,11 @@ class WriteTool(BaseTool):
             changes: Dictionary of change paths to validate
             doc: Optional parsed AST document for section existence validation.
                 When provided, section paths are verified against actual sections.
+            change_warnings: Optional caller-owned list that this method appends
+                non-fatal change-path warnings to (currently W_AMBIGUOUS_PATH on
+                the conflicted-document case). Per-call ownership eliminates the
+                singleton race of an instance-attribute buffer (CE follow-up to
+                #392). When None, warnings are suppressed.
 
         Returns:
             List of error dicts for unresolvable paths (empty if all paths are valid)
@@ -2191,35 +2195,38 @@ class WriteTool(BaseTool):
                                 if block_child_match
                                 else (f"top-level Block('{parent_key}') (no child " f"'{child_key}' present)")
                             )
-                            # Defensive: _validate_change_paths may be invoked
-                            # outside execute() in tests; ensure the buffer exists.
-                            buffer = getattr(self, "_pending_change_warnings", None)
-                            if buffer is None:
-                                buffer = []
-                                self._pending_change_warnings = buffer
-                            buffer.append(
-                                {
-                                    "code": W_AMBIGUOUS_PATH,
-                                    "tier": "STRUCTURAL_CHECK",
-                                    "message": (
-                                        f"Ambiguous change path '{key}': source document contains "
-                                        f"both a top-level Block('{parent_key}') and a flat "
-                                        f"top-level Assignment('{key}'). Candidate targets: "
-                                        f"flat top-level Assignment('{key}'); "
-                                        f"{block_candidate_desc}. Applier currently routes to the "
-                                        f"flat assignment per the PR#370 repair-corridor contract; "
-                                        f"this case will hard-fail with E_AMBIGUOUS_PATH after the "
-                                        f"SR1-T1 grammar core lands. To resolve now: (a) use the "
-                                        f"content= parameter with the full document to rewrite "
-                                        f"verbatim, or (b) clean up the source so only one of the "
-                                        f"two targets remains (this is the W_DUPLICATE_TARGET "
-                                        f"corruption pattern tracked by GH#372 SR1-T2)."
-                                    ),
-                                    "field": key,
-                                    "safe": True,
-                                    "semantics_changed": False,
-                                }
-                            )
+                            # CE follow-up to #392: warning attaches to the
+                            # caller-owned per-invocation list passed in via
+                            # ``change_warnings``. When the kwarg is None
+                            # (direct/legacy callers), the warning is silently
+                            # dropped — the validator's PRIMARY contract is
+                            # error reporting, not warning surfacing; warnings
+                            # only matter when execute() drains them into
+                            # corrections.
+                            if change_warnings is not None:
+                                change_warnings.append(
+                                    {
+                                        "code": W_AMBIGUOUS_PATH,
+                                        "tier": "STRUCTURAL_CHECK",
+                                        "message": (
+                                            f"Ambiguous change path '{key}': source document contains "
+                                            f"both a top-level Block('{parent_key}') and a flat "
+                                            f"top-level Assignment('{key}'). Candidate targets: "
+                                            f"flat top-level Assignment('{key}'); "
+                                            f"{block_candidate_desc}. Applier currently routes to the "
+                                            f"flat assignment per the PR#370 repair-corridor contract; "
+                                            f"this case will hard-fail with E_AMBIGUOUS_PATH after the "
+                                            f"SR1-T1 grammar core lands. To resolve now: (a) use the "
+                                            f"content= parameter with the full document to rewrite "
+                                            f"verbatim, or (b) clean up the source so only one of the "
+                                            f"two targets remains (this is the W_DUPLICATE_TARGET "
+                                            f"corruption pattern tracked by GH#372 SR1-T2)."
+                                        ),
+                                        "field": key,
+                                        "safe": True,
+                                        "semantics_changed": False,
+                                    }
+                                )
                             # Tolerate here per PR#370 contract; applier handles the
                             # flat assignment via the GH#347 carve-out.
                             continue
@@ -2388,6 +2395,25 @@ class WriteTool(BaseTool):
         if "." in key and key.count(".") == 1:
             parent_key, _, child_key = key.partition(".")
             parent_block = self._find_block(doc, parent_key)
+            # SR1-T3a CRS follow-up to #392: on the conflicted-document case
+            # (Block(parent) coexists with flat top-level Assignment(parent.child))
+            # _apply_changes routes the update to the FLAT assignment, not into
+            # the Block (see line ~2741 elif guard: only routes to block when
+            # `not any(...s.key == key)`). The validator's $op/target-type
+            # post-pass MUST consult the same target the applier will hit,
+            # otherwise APPEND/PREPEND/MERGE on conflicted documents validates
+            # against the block child but mutates the flat — causing silent
+            # type-mismatch corruption or runtime safety-net raises. So when a
+            # flat top-level Assignment with the literal dotted key exists,
+            # prefer it over any block child here.
+            flat_node: Assignment | None = None
+            for node in doc.sections:
+                if isinstance(node, Assignment) and node.key == key:
+                    flat_node = node
+                    break
+            if flat_node is not None:
+                kind = _target_type_for_assignment(flat_node.value)
+                return (kind, flat_node)
             if parent_block is not None:
                 for child in parent_block.children:
                     if isinstance(child, Assignment) and child.key == child_key:
@@ -2395,14 +2421,6 @@ class WriteTool(BaseTool):
                         return (kind, child)
                     if isinstance(child, Block) and child.key == child_key:
                         return ("block", child)
-                # PARENT is a Block but CHILD missing inside it.
-                # Fall through to flat-key lookup (GH#370 conflicted-doc carve-out).
-            # Either PARENT is not a Block, or CHILD missing inside PARENT block.
-            # Try literal flat top-level Assignment (GH#347 dotted identifiers).
-            for node in doc.sections:
-                if isinstance(node, Assignment) and node.key == key:
-                    kind = _target_type_for_assignment(node.value)
-                    return (kind, node)
             return ("missing", None)
 
         # Bare top-level KEY.
@@ -2661,7 +2679,13 @@ class WriteTool(BaseTool):
             new_assignment = Assignment(key=child_key, value=normalized_value)
             section.children.append(new_assignment)
 
-    def _apply_changes(self, doc: Any, changes: dict[str, Any]) -> Any:
+    def _apply_changes(
+        self,
+        doc: Any,
+        changes: dict[str, Any],
+        *,
+        change_warnings: list[dict[str, Any]] | None = None,
+    ) -> Any:
         """Apply changes to AST document with tri-state and dot-notation semantics.
 
         Args:
@@ -2688,7 +2712,7 @@ class WriteTool(BaseTool):
         # GH#335: Validate all paths before applying any changes.
         # Fail-fast: if ANY path is unresolvable, reject the entire batch
         # to prevent partial application with silent corruption.
-        path_errors = self._validate_change_paths(changes, doc)
+        path_errors = self._validate_change_paths(changes, doc, change_warnings=change_warnings)
         if path_errors:
             raise ValueError(path_errors)
 
@@ -2963,12 +2987,13 @@ class WriteTool(BaseTool):
             - validation_errors: List of schema validation errors (when INVALID)
             - debug_info: Constraint grammar debug information (when debug_grammar=True)
         """
-        # ADR-0006 SR1-T3a (#391): per-invocation buffer for non-fatal change-path
-        # warnings (currently only W_AMBIGUOUS_PATH) emitted by
-        # _validate_change_paths. Drained into result["corrections"] after
-        # _apply_changes returns so the warnings ride out alongside the
-        # structural-validator corrections (W_DUPLICATE_TARGET et al.).
-        self._pending_change_warnings: list[dict[str, Any]] = []
+        # ADR-0006 SR1-T3a (#391, CE follow-up to #392): per-call local list
+        # for non-fatal change-path warnings (currently only W_AMBIGUOUS_PATH)
+        # emitted by _validate_change_paths. Local-scope ownership eliminates
+        # the singleton race that an instance attribute would cause across
+        # concurrent MCP invocations on the shared WriteTool() instance held
+        # by server.py / http_transport.py.
+        change_warnings: list[dict[str, Any]] = []
 
         # Validate and extract parameters
         params = self.validate_parameters(kwargs)
@@ -3134,23 +3159,37 @@ class WriteTool(BaseTool):
                     [{"code": "E_PARSE", "message": f"Parse error: {str(e)}"}],
                 )
 
-            # Apply changes with tri-state semantics
+            # Apply changes with tri-state semantics. CE follow-up to #392:
+            # change_warnings is owned by this scope and threaded through; the
+            # error envelope branches below ALSO drain it via _error_envelope's
+            # corrections argument so deprecation warnings remain visible even
+            # when validation fails the request.
             try:
-                doc = self._apply_changes(doc, changes)
+                doc = self._apply_changes(doc, changes, change_warnings=change_warnings)
             except ValueError as e:
                 # GH#335: _validate_change_paths raises ValueError with
                 # structured error list for unresolvable paths.
+                # CE follow-up to #392: drain change_warnings into the error
+                # envelope so deprecation warnings remain visible even when the
+                # request fails (no warning leaks across calls; buffer is
+                # function-local).
                 error_list = e.args[0] if e.args and isinstance(e.args[0], list) else []
                 if error_list:
-                    return self._error_envelope(target_path, error_list)
+                    return self._error_envelope(
+                        target_path,
+                        error_list,
+                        corrections=list(change_warnings),
+                    )
                 return self._error_envelope(
                     target_path,
                     [{"code": "E_APPLY", "message": f"Apply changes error: {str(e)}"}],
+                    corrections=list(change_warnings),
                 )
             except Exception as e:
                 return self._error_envelope(
                     target_path,
                     [{"code": "E_APPLY", "message": f"Apply changes error: {str(e)}"}],
+                    corrections=list(change_warnings),
                 )
 
             # Apply META mutations (if any)
@@ -3472,13 +3511,13 @@ class WriteTool(BaseTool):
                     }
                 )
 
-        # ADR-0006 SR1-T3a (#391): drain non-fatal change-path warnings
-        # captured during _validate_change_paths (currently W_AMBIGUOUS_PATH on
-        # the conflicted-document case). These ride alongside the structural
-        # validator warnings above so callers see one unified corrections list.
-        if self._pending_change_warnings:
-            result["corrections"].extend(self._pending_change_warnings)
-            self._pending_change_warnings = []
+        # ADR-0006 SR1-T3a (#391, CE follow-up to #392): drain the per-call
+        # change_warnings local (currently W_AMBIGUOUS_PATH on the conflicted-
+        # document case) into the unified corrections list, alongside the
+        # structural-validator warnings above. Local-scope ownership ensures no
+        # cross-invocation leakage on the shared WriteTool() singleton.
+        if change_warnings:
+            result["corrections"].extend(change_warnings)
 
         # Schema Validation (I5 Schema Sovereignty)
         if schema_name:

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -67,6 +67,17 @@ W_UNQUOTED_SECTION_IN_VALUE = "W_UNQUOTED_SECTION_IN_VALUE"
 # GH#349: Data loss warning for bare lines dropped during lenient parsing (I4)
 W_BARE_LINE_DROPPED = "W_BARE_LINE_DROPPED"
 
+# ADR-0006 SR1-T3a (#391, split from #369): deprecation warning for the
+# conflicted-document case where a single-dot change key K.X resolves to
+# BOTH a top-level Block(K) and a coexisting flat top-level Assignment("K.X").
+# Surfaces as a non-fatal correction so the PR#370 tolerate-and-warn applier
+# path is preserved (existing GH#372 migration sweep + repair-corridor traffic
+# remain unaffected). The companion E_AMBIGUOUS_PATH constant below is
+# scaffolding for the SR1-T3 hard-fail conversion that lands after SR1-T1
+# grammar core (#382) provides unambiguous block-scoped accessor syntax.
+W_AMBIGUOUS_PATH = "W_AMBIGUOUS_PATH"
+E_AMBIGUOUS_PATH = "E_AMBIGUOUS_PATH"
+
 # GH#376 PR-A: format_style parameter constants.
 # Three modes are projections of one canonical AST→bytes function (I1
 # Single-Canon Discipline). They are NOT parallel emitters.
@@ -1113,6 +1124,13 @@ class WriteTool(BaseTool):
     # Security: allowed file extensions
     ALLOWED_EXTENSIONS = {".oct.md", ".octave", ".md"}
 
+    # ADR-0006 SR1-T3a (#391): per-invocation buffer for non-fatal change-path
+    # warnings emitted by _validate_change_paths and drained into corrections
+    # by execute(). Declared at class scope so mypy treats reassignments in
+    # execute() and the defensive guard inside _validate_change_paths as the
+    # same attribute (no-redef silenced).
+    _pending_change_warnings: list[dict[str, Any]]
+
     def _repair_curly_brace_annotations(self, content: str) -> tuple[str, list[dict[str, Any]]]:
         """GH#263: Pre-process content to repair NAME{qualifier} -> NAME<qualifier>.
 
@@ -2153,17 +2171,59 @@ class WriteTool(BaseTool):
                     if parent_block is not None:
                         # PARENT exists as a top-level Block. Treat dot as path
                         # separator; CHILD must resolve inside the Block.
-                        if not any(isinstance(c, Assignment) and c.key == child_key for c in parent_block.children):
-                            # GH#370: Before rejecting, check if the literal dotted key
-                            # exists as a flat assignment (conflict scenario from GH#369).
-                            # If the flat key exists, applier will handle it; validator
-                            # must not reject to maintain contract with applier.
-                            flat_match = any(isinstance(s, Assignment) and s.key == key for s in doc.sections)
-                            if flat_match:
-                                # Conflicted document: Block + flat dotted assignment coexist.
-                                # Applier will route to flat assignment (GH#347 carve-out).
-                                # Tolerate here for consistency; validator will emit W_DUPLICATE_TARGET.
-                                continue
+                        flat_match = any(isinstance(s, Assignment) and s.key == key for s in doc.sections)
+                        block_child_match = any(
+                            isinstance(c, Assignment) and c.key == child_key for c in parent_block.children
+                        )
+                        if flat_match:
+                            # ADR-0006 SR1-T3a (#391, split from #369):
+                            # conflicted source document — both Block(parent) and a
+                            # flat top-level Assignment(parent.child) coexist. The
+                            # change key is genuinely ambiguous (which target should
+                            # the update land on?). PR#370 tolerate-and-warn applier
+                            # path is preserved (status=success; the existing
+                            # GH#347 carve-out routes to the flat assignment), but
+                            # we additionally surface a deprecation warning so
+                            # callers can migrate ahead of the post-SR1-T1 hard-fail
+                            # conversion (E_AMBIGUOUS_PATH).
+                            block_candidate_desc = (
+                                f"child '{child_key}' inside top-level Block('{parent_key}')"
+                                if block_child_match
+                                else (f"top-level Block('{parent_key}') (no child " f"'{child_key}' present)")
+                            )
+                            # Defensive: _validate_change_paths may be invoked
+                            # outside execute() in tests; ensure the buffer exists.
+                            buffer = getattr(self, "_pending_change_warnings", None)
+                            if buffer is None:
+                                buffer = []
+                                self._pending_change_warnings = buffer
+                            buffer.append(
+                                {
+                                    "code": W_AMBIGUOUS_PATH,
+                                    "tier": "STRUCTURAL_CHECK",
+                                    "message": (
+                                        f"Ambiguous change path '{key}': source document contains "
+                                        f"both a top-level Block('{parent_key}') and a flat "
+                                        f"top-level Assignment('{key}'). Candidate targets: "
+                                        f"flat top-level Assignment('{key}'); "
+                                        f"{block_candidate_desc}. Applier currently routes to the "
+                                        f"flat assignment per the PR#370 repair-corridor contract; "
+                                        f"this case will hard-fail with E_AMBIGUOUS_PATH after the "
+                                        f"SR1-T1 grammar core lands. To resolve now: (a) use the "
+                                        f"content= parameter with the full document to rewrite "
+                                        f"verbatim, or (b) clean up the source so only one of the "
+                                        f"two targets remains (this is the W_DUPLICATE_TARGET "
+                                        f"corruption pattern tracked by GH#372 SR1-T2)."
+                                    ),
+                                    "field": key,
+                                    "safe": True,
+                                    "semantics_changed": False,
+                                }
+                            )
+                            # Tolerate here per PR#370 contract; applier handles the
+                            # flat assignment via the GH#347 carve-out.
+                            continue
+                        if not block_child_match:
                             # No flat fallback; reject the unresolvable path.
                             errors.append(
                                 {
@@ -2177,8 +2237,8 @@ class WriteTool(BaseTool):
                                 }
                             )
                             continue
-                        # PARENT.CHILD resolves inside the block. _apply_changes
-                        # will route to _apply_block_change.
+                        # PARENT.CHILD resolves unambiguously inside the block.
+                        # _apply_changes will route to _apply_block_change.
                         continue
                     # PARENT is not a top-level Block. The key is acceptable
                     # only if it already exists as a flat top-level Assignment
@@ -2903,6 +2963,13 @@ class WriteTool(BaseTool):
             - validation_errors: List of schema validation errors (when INVALID)
             - debug_info: Constraint grammar debug information (when debug_grammar=True)
         """
+        # ADR-0006 SR1-T3a (#391): per-invocation buffer for non-fatal change-path
+        # warnings (currently only W_AMBIGUOUS_PATH) emitted by
+        # _validate_change_paths. Drained into result["corrections"] after
+        # _apply_changes returns so the warnings ride out alongside the
+        # structural-validator corrections (W_DUPLICATE_TARGET et al.).
+        self._pending_change_warnings: list[dict[str, Any]] = []
+
         # Validate and extract parameters
         params = self.validate_parameters(kwargs)
         target_path = params["target_path"]
@@ -3404,6 +3471,14 @@ class WriteTool(BaseTool):
                         "semantics_changed": False,
                     }
                 )
+
+        # ADR-0006 SR1-T3a (#391): drain non-fatal change-path warnings
+        # captured during _validate_change_paths (currently W_AMBIGUOUS_PATH on
+        # the conflicted-document case). These ride alongside the structural
+        # validator warnings above so callers see one unified corrections list.
+        if self._pending_change_warnings:
+            result["corrections"].extend(self._pending_change_warnings)
+            self._pending_change_warnings = []
 
         # Schema Validation (I5 Schema Sovereignty)
         if schema_name:

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -5841,3 +5841,67 @@ class TestSR1T3aChangeWarningsBufferIsPerCall:
                     f"Unambiguous call #{i} picked up W_AMBIGUOUS_PATH from a "
                     f"sibling — singleton-race regression. Codes: {codes}"
                 )
+
+    @pytest.mark.asyncio
+    async def test_w_ambiguous_path_survives_emit_failure(self, monkeypatch):
+        """CE follow-up to PR #392: change_warnings (W_AMBIGUOUS_PATH) captured
+        by _validate_change_paths during the changes-mode pass MUST survive a
+        downstream emit failure. The success-path drain at the bottom of
+        execute() never runs when _emit_with_style raises; without explicit
+        per-error-site draining the deprecation warning would be silently
+        dropped on E_EMIT / E_AST_CYCLE returns.
+
+        Reproduces the medium-severity finding by monkeypatching
+        ``octave_mcp.mcp.write._emit_with_style`` to raise, then asserts the
+        E_EMIT error envelope still carries W_AMBIGUOUS_PATH in corrections.
+        """
+        from octave_mcp.mcp import write as write_module
+        from octave_mcp.mcp.write import WriteTool
+
+        original_emit = write_module._emit_with_style
+
+        def _raising_emit(*args, **kwargs):
+            raise RuntimeError("forced emit failure for CE regression test")
+
+        monkeypatch.setattr(write_module, "_emit_with_style", _raising_emit)
+
+        tool = WriteTool()
+
+        # Conflicted source: triggers W_AMBIGUOUS_PATH during validation.
+        conflicted = (
+            "===NAV_TEST===\n"
+            "META:\n"
+            '  TYPE::"TEST"\n'
+            "NAV:\n"
+            "  FOUNDATIONAL::[A,B]\n"
+            "NAV.OPERATIONAL_CONVENTIONS::[X,Y]\n"
+            "===END===\n"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "t.oct.md")
+            with open(target_path, "w") as f:
+                f.write(conflicted)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
+            )
+
+            # Sanity: the emit-failure error is what we forced, not something
+            # else upstream that would mask the test's intent.
+            assert result["status"] == "error", f"Expected error, got: {result}"
+            err_codes = {e.get("code") for e in result.get("errors", [])}
+            assert "E_EMIT" in err_codes, f"Expected E_EMIT from forced emit failure, got: {result.get('errors')}"
+
+            # The actual contract under test: deprecation warning survives.
+            corr_codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in corr_codes, (
+                f"W_AMBIGUOUS_PATH was dropped on emit failure path — CE "
+                f"follow-up regression. Got corrections: {result.get('corrections')}"
+            )
+
+        # Restore for hygiene (monkeypatch already does this on teardown,
+        # but the assignment makes the intent explicit if the fixture is
+        # ever refactored).
+        monkeypatch.setattr(write_module, "_emit_with_style", original_emit)

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -5379,3 +5379,191 @@ class TestGH369NestedBlockChangePathResolution:
             assert "P1.1" not in final
             assert "P1:" in final
             assert "CHILD" in final
+
+
+class TestSR1T3aAmbiguousPathDeprecationWarning:
+    """ADR-0006 SR1-T3a (issue #391, split from #369): when a single-dot
+    change key K.X is ambiguous between (a) a child of top-level Block(K)
+    and (b) a coexisting flat top-level Assignment("K.X"), the writer
+    emits a non-fatal W_AMBIGUOUS_PATH deprecation warning that names
+    both candidate targets and references the future hard-fail.
+
+    Scope contract for this sprint:
+    - PR#370 tolerate-and-warn applier path is PRESERVED (the existing
+      test_gh370_* tests in TestGH369NestedBlockChangePathResolution
+      continue to pass unchanged) so corrupted documents in the wild
+      remain repairable through changes-mode while the GH#372 SR1-T2
+      migration sweep proceeds.
+    - W_AMBIGUOUS_PATH surfaces as a correction (severity=warning) in
+      the result envelope alongside (or in lieu of) W_DUPLICATE_TARGET.
+    - E_AMBIGUOUS_PATH error code is scaffolded as an exported symbol
+      with no emit site yet. Conversion of the warning to a hard-fail
+      via E_AMBIGUOUS_PATH lands after SR1-T1 grammar core (#382)
+      provides unambiguous block-scoped accessor syntax.
+    """
+
+    @pytest.mark.asyncio
+    async def test_w_ambiguous_path_warning_surfaces_on_conflicted_source(self):
+        """Conflicted source document (Block(K) + flat K.X coexisting)
+        targeted by changes={K.X: ...} must surface a W_AMBIGUOUS_PATH
+        correction. The applier still completes (status=success) per the
+        preserved PR#370 contract; the warning is purely diagnostic.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
+            initial = (
+                "===NAV_TEST===\n"
+                "META:\n"
+                '  TYPE::"TEST"\n'
+                "NAV:\n"
+                "  FOUNDATIONAL::[A,B]\n"
+                "NAV.OPERATIONAL_CONVENTIONS::[SEARCH_PATH_CONVENTION]\n"
+                "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
+            )
+
+            # PR#370 contract preserved: applier completes successfully.
+            assert result["status"] == "success", (
+                f"PR#370 tolerate-and-warn contract must be preserved under "
+                f"SR1-T3a; got status={result.get('status')} errors={result.get('errors')}"
+            )
+            correction_codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in correction_codes, (
+                f"Expected W_AMBIGUOUS_PATH deprecation warning in corrections, " f"got: {correction_codes}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_w_ambiguous_path_message_lists_both_candidates(self):
+        """W_AMBIGUOUS_PATH message must enumerate both candidate targets
+        (the Block-child slot and the flat assignment) so the agent can
+        diagnose without re-reading the source.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
+            initial = (
+                "===TEST===\n" "META:\n" '  TYPE::"TEST"\n' "P1:\n" "  CHILD::value\n" "P1.1::original\n" "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"P1.1": "updated"},
+            )
+
+            warns = [c for c in result.get("corrections", []) if c.get("code") == "W_AMBIGUOUS_PATH"]
+            assert warns, f"Expected W_AMBIGUOUS_PATH correction, got: {result.get('corrections')}"
+            msg = warns[0].get("message", "")
+            assert "P1" in msg, f"Warning must name parent block, got: {msg}"
+            assert "P1.1" in msg, f"Warning must name flat key, got: {msg}"
+
+    @pytest.mark.asyncio
+    async def test_w_ambiguous_path_message_announces_future_hard_fail(self):
+        """W_AMBIGUOUS_PATH is a deprecation warning: the message must
+        signpost that this case will hard-fail in a future release once
+        SR1-T1 grammar core lands. This gives agents lead time to migrate
+        to ``content=`` mode or unambiguous syntax.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
+            initial = (
+                "===TEST===\n" "META:\n" '  TYPE::"TEST"\n' "P1:\n" "  CHILD::value\n" "P1.1::original\n" "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"P1.1": "updated"},
+            )
+
+            warns = [c for c in result.get("corrections", []) if c.get("code") == "W_AMBIGUOUS_PATH"]
+            assert warns
+            msg = warns[0].get("message", "")
+            # Deprecation signposting: caller must learn the warning will
+            # become a hard-fail post-SR1-T1.
+            assert "E_AMBIGUOUS_PATH" in msg, f"Warning must announce future E_AMBIGUOUS_PATH hard-fail, got: {msg}"
+            # Must point at content= disambiguation hatch.
+            assert (
+                "content=" in msg or "content parameter" in msg
+            ), f"Warning must guide caller to content= disambiguation, got: {msg}"
+
+    @pytest.mark.asyncio
+    async def test_unambiguous_block_child_emits_no_w_ambiguous_path(self):
+        """Regression guard: when Block(K) exists WITHOUT a coexisting flat
+        K.X, K.X is unambiguous and W_AMBIGUOUS_PATH must NOT fire (the
+        warning is reserved for the genuine conflict pattern only).
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "test.oct.md")
+            initial = (
+                "===NAV_TEST===\n"
+                "META:\n"
+                '  TYPE::"TEST"\n'
+                "NAV:\n"
+                "  FOUNDATIONAL::[A,B]\n"
+                "  OPERATIONAL_CONVENTIONS::[OLD]\n"
+                "===END===\n"
+            )
+            with open(target_path, "w") as f:
+                f.write(initial)
+
+            result = await tool.execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
+            )
+
+            assert result["status"] == "success"
+            correction_codes = {c.get("code") for c in result.get("corrections", [])}
+            assert (
+                "W_AMBIGUOUS_PATH" not in correction_codes
+            ), f"W_AMBIGUOUS_PATH must not fire on unambiguous path, got: {correction_codes}"
+
+    def test_e_ambiguous_path_symbol_is_scaffolded(self):
+        """E_AMBIGUOUS_PATH error code symbol must exist as an exported
+        constant on octave_mcp.mcp.write so the future SR1-T3 hard-fail
+        wiring (post-SR1-T1) has a stable target without breaking the
+        public error-code vocabulary at conversion time.
+
+        No emit site is required yet; this test only asserts the symbol
+        is defined and equals the canonical "E_AMBIGUOUS_PATH" string.
+        """
+        from octave_mcp.mcp import write as write_module
+
+        assert hasattr(write_module, "E_AMBIGUOUS_PATH"), (
+            "E_AMBIGUOUS_PATH constant must be exported from octave_mcp.mcp.write "
+            "as scaffolding for the SR1-T3 hard-fail conversion (post-SR1-T1)."
+        )
+        assert write_module.E_AMBIGUOUS_PATH == "E_AMBIGUOUS_PATH"
+
+    def test_w_ambiguous_path_symbol_is_exported(self):
+        """W_AMBIGUOUS_PATH constant must also be exported so callers and
+        downstream tooling can reference the warning code by symbol rather
+        than literal string.
+        """
+        from octave_mcp.mcp import write as write_module
+
+        assert hasattr(write_module, "W_AMBIGUOUS_PATH")
+        assert write_module.W_AMBIGUOUS_PATH == "W_AMBIGUOUS_PATH"

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -5567,3 +5567,277 @@ class TestSR1T3aAmbiguousPathDeprecationWarning:
 
         assert hasattr(write_module, "W_AMBIGUOUS_PATH")
         assert write_module.W_AMBIGUOUS_PATH == "W_AMBIGUOUS_PATH"
+
+
+class TestSR1T3aDollarOpsOnAmbiguousPaths:
+    """CRS follow-up to PR #392: pin the actual $op behaviour on conflicted
+    documents (Block(K) coexisting with flat top-level Assignment(K.X)).
+
+    Findings empirically verified and now codified:
+    - bare replacement → modifies the FLAT assignment in place
+      (PR#370 contract preserved). W_AMBIGUOUS_PATH always surfaces;
+      W_DUPLICATE_TARGET surfaces when the conflict survives the edit.
+    - DELETE sentinel → removes the FLAT assignment; the Block child (if
+      any) is left untouched. W_AMBIGUOUS_PATH always surfaces.
+    - APPEND/PREPEND → validator now resolves to the FLAT target (CRS
+      follow-up: _resolve_target_type prefers the flat assignment in the
+      conflict, matching what _apply_changes will modify). Succeeds when
+      the flat is array-valued; rejected with E_OP_TARGET_MISMATCH when
+      the flat is non-array — the historical bug was that the validator
+      consulted the block child and let mismatches through to the
+      applier's defensive raise. W_AMBIGUOUS_PATH surfaces in both
+      success and error envelopes.
+    - MERGE → rejected with E_OP_TARGET_MISMATCH because the flat target
+      is an Assignment (array/scalar/map value), never a Block/Section/
+      META. W_AMBIGUOUS_PATH surfaces in the error envelope.
+
+    These tests pin the actual contract so any future regression that
+    diverges validator and applier resolution surfaces immediately.
+    """
+
+    @staticmethod
+    def _conflicted_array_doc() -> str:
+        """Block has no OPERATIONAL_CONVENTIONS child; flat is array."""
+        return (
+            "===NAV_TEST===\n"
+            "META:\n"
+            '  TYPE::"TEST"\n'
+            "NAV:\n"
+            "  FOUNDATIONAL::[A,B]\n"
+            "NAV.OPERATIONAL_CONVENTIONS::[X,Y]\n"
+            "===END===\n"
+        )
+
+    @staticmethod
+    def _conflicted_typemix_doc() -> str:
+        """Block child FOUNDATIONAL is array; flat NAV.FOUNDATIONAL is scalar.
+        Pre-fix this would mis-validate $op against the block child's array
+        type and reach the applier's defensive raise."""
+        return (
+            "===NAV_TEST===\n"
+            "META:\n"
+            '  TYPE::"TEST"\n'
+            "NAV:\n"
+            "  FOUNDATIONAL::[A,B]\n"
+            "NAV.FOUNDATIONAL::scalar_value\n"
+            "===END===\n"
+        )
+
+    @pytest.mark.asyncio
+    async def test_append_on_array_flat_succeeds_and_mutates_flat(self):
+        from octave_mcp.mcp.write import WriteTool
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "t.oct.md")
+            with open(target_path, "w") as f:
+                f.write(self._conflicted_array_doc())
+            result = await WriteTool().execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": {"$op": "APPEND", "value": ["Z"]}},
+            )
+            assert result["status"] == "success", f"errors: {result.get('errors')}"
+            codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in codes
+            with open(target_path) as f:
+                final = f.read()
+            # Flat assignment was mutated; Block left intact.
+            assert "FOUNDATIONAL::[A,B]" in final
+            assert "Z" in final
+
+    @pytest.mark.asyncio
+    async def test_prepend_on_array_flat_succeeds_and_mutates_flat(self):
+        from octave_mcp.mcp.write import WriteTool
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "t.oct.md")
+            with open(target_path, "w") as f:
+                f.write(self._conflicted_array_doc())
+            result = await WriteTool().execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": {"$op": "PREPEND", "value": ["Z"]}},
+            )
+            assert result["status"] == "success", f"errors: {result.get('errors')}"
+            codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in codes
+            with open(target_path) as f:
+                final = f.read()
+            assert "FOUNDATIONAL::[A,B]" in final
+            assert "Z" in final
+
+    @pytest.mark.asyncio
+    async def test_append_on_scalar_flat_rejected_at_validate(self):
+        """Block child is array but flat is scalar. Validator must consult
+        the FLAT (the target the applier will modify) and reject with
+        E_OP_TARGET_MISMATCH at validate time, not let the request reach
+        the applier's defensive raise.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "t.oct.md")
+            with open(target_path, "w") as f:
+                f.write(self._conflicted_typemix_doc())
+            result = await WriteTool().execute(
+                target_path=target_path,
+                changes={"NAV.FOUNDATIONAL": {"$op": "APPEND", "value": ["Z"]}},
+            )
+            assert result["status"] == "error"
+            err_codes = {e.get("code") for e in result.get("errors", [])}
+            assert "E_OP_TARGET_MISMATCH" in err_codes, (
+                f"Expected E_OP_TARGET_MISMATCH at validate time (validator must "
+                f"resolve to flat scalar, not block array), got: {result.get('errors')}"
+            )
+            # Deprecation warning still surfaces on the error envelope (CE
+            # follow-up to #392 ensures change_warnings drain on the error path).
+            corr_codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in corr_codes, (
+                f"W_AMBIGUOUS_PATH must surface even when validation fails, " f"got: {result.get('corrections')}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_merge_on_conflicted_path_rejected(self):
+        """MERGE requires block/section/meta target. The flat assignment is
+        always an Assignment value — MERGE on it must always be rejected.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "t.oct.md")
+            with open(target_path, "w") as f:
+                f.write(self._conflicted_array_doc())
+            result = await WriteTool().execute(
+                target_path=target_path,
+                changes={"NAV.OPERATIONAL_CONVENTIONS": {"$op": "MERGE", "value": {"k": "v"}}},
+            )
+            assert result["status"] == "error"
+            err_codes = {e.get("code") for e in result.get("errors", [])}
+            assert (
+                "E_OP_TARGET_MISMATCH" in err_codes
+            ), f"MERGE on conflicted flat must reject; got: {result.get('errors')}"
+            corr_codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in corr_codes
+
+    @pytest.mark.asyncio
+    async def test_delete_on_conflicted_path_removes_flat_only(self):
+        """DELETE sentinel removes the flat assignment; the Block child (if
+        any) is preserved. PR#370 contract intact.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target_path = os.path.join(tmpdir, "t.oct.md")
+            with open(target_path, "w") as f:
+                f.write(self._conflicted_typemix_doc())
+            result = await WriteTool().execute(
+                target_path=target_path,
+                changes={"NAV.FOUNDATIONAL": {"$op": "DELETE"}},
+            )
+            assert result["status"] == "success", f"errors: {result.get('errors')}"
+            with open(target_path) as f:
+                final = f.read()
+            # Flat NAV.FOUNDATIONAL gone; Block's FOUNDATIONAL child remains.
+            assert "NAV.FOUNDATIONAL::scalar_value" not in final
+            assert "FOUNDATIONAL::[A,B]" in final
+            corr_codes = {c.get("code") for c in result.get("corrections", [])}
+            assert "W_AMBIGUOUS_PATH" in corr_codes
+
+
+class TestSR1T3aChangeWarningsBufferIsPerCall:
+    """CE follow-up to PR #392: the W_AMBIGUOUS_PATH warning buffer must be
+    per-call local state, not a class/instance attribute on the shared
+    WriteTool() singleton (server.py / http_transport.py instantiate once).
+
+    These tests pin the no-singleton-race contract so any future refactor
+    that re-introduces shared mutable state surfaces immediately.
+    """
+
+    def test_no_pending_change_warnings_attribute_on_instance(self):
+        """The legacy ``_pending_change_warnings`` instance attribute MUST NOT
+        exist on a fresh WriteTool() — its presence would indicate the
+        singleton-race regression has returned.
+        """
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()
+        assert not hasattr(tool, "_pending_change_warnings"), (
+            "WriteTool must not carry a _pending_change_warnings instance "
+            "buffer; warnings are per-call locals (CE follow-up to #392)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_executes_do_not_leak_warnings(self):
+        """Two concurrent execute() calls on the SAME WriteTool() instance,
+        one against a conflicted doc (W_AMBIGUOUS_PATH expected) and one
+        against an unambiguous doc (no warning expected), must not
+        cross-pollinate warnings via shared state.
+        """
+        import asyncio as _asyncio
+
+        from octave_mcp.mcp.write import WriteTool
+
+        tool = WriteTool()  # SAME singleton across both calls.
+
+        conflicted = (
+            "===NAV_TEST===\n"
+            "META:\n"
+            '  TYPE::"TEST"\n'
+            "NAV:\n"
+            "  FOUNDATIONAL::[A,B]\n"
+            "NAV.OPERATIONAL_CONVENTIONS::[X,Y]\n"
+            "===END===\n"
+        )
+        unambiguous = (
+            "===NAV_TEST===\n"
+            "META:\n"
+            '  TYPE::"TEST"\n'
+            "NAV:\n"
+            "  FOUNDATIONAL::[A,B]\n"
+            "  OPERATIONAL_CONVENTIONS::[OLD]\n"
+            "===END===\n"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            p_conf = os.path.join(tmpdir, "conflicted.oct.md")
+            p_unamb = os.path.join(tmpdir, "unambiguous.oct.md")
+            with open(p_conf, "w") as f:
+                f.write(conflicted)
+            with open(p_unamb, "w") as f:
+                f.write(unambiguous)
+
+            # Run a batch where the unambiguous call is interleaved with
+            # several conflicted calls, then assert each result envelope only
+            # reports warnings appropriate to its own input.
+            async def call_conflicted():
+                return await tool.execute(
+                    target_path=p_conf,
+                    changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
+                )
+
+            async def call_unambiguous():
+                return await tool.execute(
+                    target_path=p_unamb,
+                    changes={"NAV.OPERATIONAL_CONVENTIONS": ["A", "B", "C"]},
+                )
+
+            results = await _asyncio.gather(
+                call_conflicted(),
+                call_unambiguous(),
+                call_conflicted(),
+                call_unambiguous(),
+                call_conflicted(),
+            )
+
+        for i, r in enumerate(results):
+            codes = {c.get("code") for c in r.get("corrections", [])}
+            if i % 2 == 0:
+                # Conflicted calls: must carry W_AMBIGUOUS_PATH.
+                assert "W_AMBIGUOUS_PATH" in codes, (
+                    f"Conflicted call #{i} lost its W_AMBIGUOUS_PATH " f"(possible buffer race), got: {codes}"
+                )
+            else:
+                # Unambiguous calls: must NOT carry W_AMBIGUOUS_PATH (would
+                # indicate leakage from a sibling conflicted call).
+                assert "W_AMBIGUOUS_PATH" not in codes, (
+                    f"Unambiguous call #{i} picked up W_AMBIGUOUS_PATH from a "
+                    f"sibling — singleton-race regression. Codes: {codes}"
+                )


### PR DESCRIPTION
## Summary

ADR-0006 SR1-T3a (closes #391, split from #369). When a single-dot change key `K.X` resolves to BOTH a top-level `Block(K)` and a coexisting flat top-level `Assignment("K.X")`, `octave_write` changes-mode now emits a non-fatal `W_AMBIGUOUS_PATH` deprecation warning that names both candidate targets and announces the future `E_AMBIGUOUS_PATH` hard-fail conversion.

## PR#370 contract preserved

Per ho-liaison + HO concurrence (the hard-fail half of #369 broke the PR#370 repair-corridor contract), the applier path is unchanged here:
- status remains `success`
- the GH#347 carve-out still routes the update to the flat assignment
- corrupted documents in the wild remain repairable through changes-mode while the GH#372 SR1-T2 migration sweep proceeds
- the pre-existing `test_gh370_*` suite under `TestGH369NestedBlockChangePathResolution` continues to pass **unchanged**

## Implementation

- New module-level constants `W_AMBIGUOUS_PATH` and `E_AMBIGUOUS_PATH` in `src/octave_mcp/mcp/write.py`. `E_AMBIGUOUS_PATH` is exported scaffolding only — no emit site yet. Conversion of the warning to a hard-fail via `E_AMBIGUOUS_PATH` lands after SR1-T1 grammar core (#382) provides unambiguous block-scoped accessor syntax.
- `WriteTool` gains a class-level `_pending_change_warnings: list[dict[str, Any]]` buffer. `_validate_change_paths` appends `W_AMBIGUOUS_PATH` entries (defensive `getattr` for direct-call test paths); `execute()` resets the buffer at the top and drains it into `result[\"corrections\"]` alongside the structural-validator warnings (`W_DUPLICATE_TARGET` et al.) after `_apply_changes` returns.
- The `W_AMBIGUOUS_PATH` message lists both candidate targets, references the future `E_AMBIGUOUS_PATH` hard-fail, and points callers at the `content=` disambiguation hatch.

## Scope discipline

- No grammar-surface changes (independent of SR1-T1 in design).
- No changes to GH#372 SR1-T2 sweep (separate branch).
- No skill-file or ADR-text edits.
- The previously-attempted hard-fail PR (#390, `feat/sr1-t3-block-child-hardfail`) has been closed; commits there are abandoned, not cherry-picked.

## Commits

1. `f87333d` — `test(write): assert W_AMBIGUOUS_PATH surface + E_AMBIGUOUS_PATH symbol` (RED)
2. `dbfdadc` — `feat(write): SR1-T3a W_AMBIGUOUS_PATH deprecation warning + E_AMBIGUOUS_PATH scaffolding (#391)` (GREEN)

## Test plan

- [x] New `TestSR1T3aAmbiguousPathDeprecationWarning` (6 tests): warning surfaces on conflicted source, message lists both candidates, message announces future hard-fail and points at `content=`, unambiguous Block.child does NOT trigger the warning, both `E_AMBIGUOUS_PATH` and `W_AMBIGUOUS_PATH` symbols are exported.
- [x] Pre-existing `test_gh370_*` tolerate-and-warn tests untouched and green.
- [x] Pre-existing `TestGH369NestedBlockChangePathResolution` deliverables A/B/C green.
- [x] Full suite: `2883 passed, 11 skipped, 9 xfailed`.
- [x] `ruff check src/ tests/` — clean.
- [x] `black --check src/ tests/` — clean (172 files).
- [x] `mypy src/` — clean (48 files).

## References

- Parent issue: #369 (hard-fail conversion deferred until post-SR1-T1)
- Sister track: #372 SR1-T2 (W_DUPLICATE_TARGET migration sweep, separate branch)
- Superseded PR: #390 (closed; commits abandoned)
- ADR: `docs/adr/adr-0006-writer-reader-symmetry.md` Sprint 1

Closes #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a non-fatal `W_AMBIGUOUS_PATH` warning when a single-dot key (e.g., K.X) matches both a top-level Block and a flat assignment; behavior is unchanged and still routes to the flat assignment. Warnings are per-call and included in results on success and all error paths, including emit failures, per ADR-0006 SR1‑T3a.

- **New Features**
  - Emit `W_AMBIGUOUS_PATH` listing both candidate targets; included in `result.corrections` on success and error.
  - Add `E_AMBIGUOUS_PATH` constant for the future hard-fail.

- **Bug Fixes**
  - `_resolve_target_type` now prefers the flat `K.X` when both exist, matching the applier; `$op` validates against that target (APPEND/PREPEND only on arrays; mismatches reject with `E_OP_TARGET_MISMATCH`; MERGE on flat rejects).
  - Warning buffer is per-call (no shared state); no cross-request leakage.
  - Drain change-path warnings into validation and emit error envelopes (`E_EMIT`/`E_AST_CYCLE`) so they aren’t lost on failures.

<sup>Written for commit 2f6595185a0373ce261c185d045cf2b7c93861f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

