### PR TITLE
feat(adr-0006): SR1 #385 — expand HARD_SYMMETRY corpus with corner-case fixtures

### DIFF
--- a/tests/fixtures/symmetry/deeply_nested_keys.oct.md
+++ b/tests/fixtures/symmetry/deeply_nested_keys.oct.md
@@ -1,0 +1,9 @@
+===DEEPLY_NESTED_KEYS===
+META:
+  TYPE::TEST
+LEVEL_A:
+  LEVEL_B:
+    LEVEL_C:
+      LEVEL_D:
+        LEVEL_E::"leaf_value"
+===END===

--- a/tests/fixtures/symmetry/empty_meta_only.oct.md
+++ b/tests/fixtures/symmetry/empty_meta_only.oct.md
@@ -1,0 +1,4 @@
+===EMPTY_META_ONLY===
+META:
+  TYPE::TEST
+===END===

--- a/tests/fixtures/symmetry/numeric_key_warning_trigger.oct.md
+++ b/tests/fixtures/symmetry/numeric_key_warning_trigger.oct.md
@@ -1,0 +1,7 @@
+===NUMERIC_KEY_WARNING_TRIGGER===
+META:
+  TYPE::TEST
+ITEMS:
+  1::"first_value"
+  2::"second_value"
+===END===

--- a/tests/unit/test_writer_reader_symmetry.py
+++ b/tests/unit/test_writer_reader_symmetry.py
@@ -89,6 +89,29 @@ _AUDIT_CARDINALITY_XFAIL_REASON = (
     "flip to expected pass when SR1-T4 lands"
 )
 
+# GH#385 corpus expansion (ADR-0006 SR1): explicit corner-case fixtures
+# enlarging the surface SR1-T1 Step 3 must clear. Each fixture is the minimal
+# input isolating exactly one HARD_SYMMETRY axis. The deeply-nested fixture
+# triggers the SAME audit-cardinality breach class as the existing nine, but
+# via a different normalisation path (deep KEY-chain re-emit). It is tracked
+# separately so Step 3's audit-completeness fix is validated against deep
+# nesting explicitly, not as a side-effect of the shallow corpus.
+_GH385_DEEP_NESTING_XFAILS: frozenset[str] = frozenset(
+    {
+        "tests/fixtures/symmetry/deeply_nested_keys.oct.md",
+    }
+)
+
+_GH385_DEEP_NESTING_XFAIL_REASON = (
+    "audit-cardinality breach on deep KEY::KEY::KEY re-emit: canonical "
+    "writer mutates whitespace/structure beyond one level of nesting but "
+    "emits zero corrections, so diff_unified is non-empty while the "
+    "corrections list is empty (I4 / HARD_SYMMETRY conjunct 3). "
+    "Tracked at GH#385 corpus expansion; SR1-T1 Step 3 (TIER_NORMALIZATION "
+    "centralisation) will fix the audit-completeness gap. Flip to expected "
+    "pass when Step 3 lands."
+)
+
 
 def _build_fixture_params() -> list[Any]:
     """Build the parametrize argument list, applying strict xfail to the
@@ -105,6 +128,17 @@ def _build_fixture_params() -> list[Any]:
                     marks=pytest.mark.xfail(
                         strict=True,
                         reason=_AUDIT_CARDINALITY_XFAIL_REASON,
+                    ),
+                )
+            )
+        elif fid in _GH385_DEEP_NESTING_XFAILS:
+            params.append(
+                pytest.param(
+                    path,
+                    id=fid,
+                    marks=pytest.mark.xfail(
+                        strict=True,
+                        reason=_GH385_DEEP_NESTING_XFAIL_REASON,
                     ),
                 )
             )


### PR DESCRIPTION
## Summary

- Adds three minimal corner-case fixtures under `tests/fixtures/symmetry/`, each isolating exactly one HARD_SYMMETRY axis (ADR-0006 §4.3), parametrized into the existing `test_writer_reader_symmetry.py` via auto-discovery.
- Enlarges the target surface SR1-T1 Step 3 (TIER_NORMALIZATION centralisation) must clear, per ho-liaison advisory — Step 3's audit-completeness fix is validated against the widest possible fixture set BEFORE it lands. The one new strict-xfail this PR introduces becomes an explicit Step 3 acceptance criterion.
- Strictly test-corpus only. No production code touched; no existing xfail flipped; no HARD_SYMMETRY conjunct relaxed.

Closes (partially) #385.

## Fixtures

| Fixture | HARD_SYMMETRY status | Probes | Tracking |
|---|---|---|---|
| `tests/fixtures/symmetry/empty_meta_only.oct.md` | **PASS** (0 corrections, empty diff, validate-success) | I2 DETERMINISTIC_ABSENCE (presence-of-empty ≠ absence); I5 SCHEMA_SOVEREIGNTY | n/a — passes |
| `tests/fixtures/symmetry/deeply_nested_keys.oct.md` | **strict-xfail** (audit-cardinality breach: diff non-empty, corrections empty) | I1 SYNTACTIC_FIDELITY (round-trip bijectivity under nesting); I4 TRANSFORM_AUDITABILITY (audit-completeness gap) | `_GH385_DEEP_NESTING_XFAILS` frozenset; reason cites GH#385 + SR1-T1 Step 3 (`TIER_NORMALIZATION centralisation will fix the audit-completeness gap`). Flip to expected pass when Step 3 lands. |
| `tests/fixtures/symmetry/numeric_key_warning_trigger.oct.md` | **PASS** (2 corrections, non-empty diff — IFF holds) | I4 TRANSFORM_AUDITABILITY beyond W002 — exercises the `W_NUMERIC_KEY_DROPPED` parse-warning → correction → `diff_unified` pipeline behaviourally | n/a — passes; behavioural witness for the non-W002 audit path |

## Strategic role

ho-liaison advised, and HO confirmed, that this corpus expansion MUST land before SR1-T1 Step 3 so that Step 3's `TIER_NORMALIZATION` centralisation is validated against an enlarged fixture set rather than the original shallow corpus. The new `deeply_nested_keys` strict-xfail is therefore not a regression — it is a deliberate, tracked Step 3 acceptance criterion.

## Scope fence (strict)

- Production files untouched: `core/lexer.py`, `core/parser.py`, `core/emitter.py`, `core/grammar/**`, `core/repair_log.py`, `core/validator.py`.
- Existing nine audit-cardinality xfails behave identically — they sit in the unchanged `_AUDIT_CARDINALITY_XFAILS` set with the unchanged `_AUDIT_CARDINALITY_XFAIL_REASON` string.
- The new `_GH385_DEEP_NESTING_XFAILS` frozenset + `_GH385_DEEP_NESTING_XFAIL_REASON` are additive only.
- HARD_SYMMETRY conjuncts (status==success, no empty `after`, `corrections` IFF `diff_unified`) are unchanged.

## Quality gates (all green, local)

- `pytest`: **2909 passed, 11 skipped, 10 xfailed** (delta from baseline `bd53708`: +2 pass, +1 xfail; matches design)
- `mypy src/`: clean (51 source files)
- `ruff check src/ tests/`: clean
- `black --check src/ tests/`: 178 files unchanged

## New xfails created (Step 3 acceptance criteria)

- `tests/fixtures/symmetry/deeply_nested_keys.oct.md` — audit-cardinality breach on deep `KEY::KEY::KEY` re-emit; tracked at GH#385; SR1-T1 Step 3 will flip to expected pass.

## References

- ADR-0006 design doc §4.3 — HARD_SYMMETRY invariant
- ho-liaison advisory (HO-confirmed): corpus expansion precedes SR1-T1 Step 3
- Predecessor: PR #394 (SR1-T1 Step 2) merged at `bd53708`

## Test plan

- [x] `pytest` full suite green with new fixtures
- [x] `mypy src/` clean
- [x] `ruff check src/ tests/` clean
- [x] `black --check src/ tests/` clean
- [x] Baseline 2907 pass / 9 xfail preserved; deltas explained
- [x] No production code modified
- [x] No existing xfail flipped
- [x] T2 review chain (TMG ⊕ CRS ⊕ CE) — to dispatch after PR open
- [x] cubic AI review — runs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the ADR-0006 HARD_SYMMETRY test corpus with three corner-case fixtures and wires them into the symmetry suite. Introduces a strict xfail for deep nesting as an explicit SR1-T1 Step 3 acceptance check for #385; no production code changes.

- **New Features**
  - Added fixtures: `empty_meta_only.oct.md` (valid empty META, passes), `numeric_key_warning_trigger.oct.md` (numeric keys, passes, exercises warning→correction→diff path), `deeply_nested_keys.oct.md` (five-level nesting, strict xfail tracked to #385; expected to pass after SR1-T1 Step 3 TIER_NORMALIZATION centralization).
  - Integrated via auto-discovery in `test_writer_reader_symmetry.py`; added `_GH385_DEEP_NESTING_XFAILS` with reason; existing xfails unchanged.
  - Results: 2909 passed, 11 skipped, 10 xfailed; `mypy`, `ruff`, and `black` all clean.

<sup>Written for commit 53351af30e976d53aaf7b7dd6f44e5414363e451. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

