### PR TITLE
feat(adr-0006): SR1-T1 Step 4 — promote ast_nodes to grammar/cst with NodeKind + visitor + reserved fields

### DIFF
--- a/src/octave_mcp/__init__.py
+++ b/src/octave_mcp/__init__.py
@@ -19,8 +19,8 @@ Public API exports:
 
 from importlib.metadata import version
 
-from octave_mcp.core.ast_nodes import Absent, Assignment, Block, Document, InlineMap, ListValue, Section
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Absent, Assignment, Block, Document, InlineMap, ListValue, Section
 from octave_mcp.core.hydrator import (
     CollisionError,
     CycleDetectionError,

--- a/src/octave_mcp/cli/main.py
+++ b/src/octave_mcp/cli/main.py
@@ -17,7 +17,7 @@ def cli():
 
 def _ast_to_dict(doc):
     """Convert AST Document to dictionary for JSON/YAML export."""
-    from octave_mcp.core.ast_nodes import Assignment, Block, InlineMap, ListValue
+    from octave_mcp.core.grammar.cst import Assignment, Block, InlineMap, ListValue
 
     def convert_value(value):
         if isinstance(value, ListValue):
@@ -56,7 +56,7 @@ def _block_to_markdown(block, lines, level=3):
         lines: Output lines list (mutated)
         level: Heading level
     """
-    from octave_mcp.core.ast_nodes import Assignment, Block
+    from octave_mcp.core.grammar.cst import Assignment, Block
 
     for child in block.children:
         if isinstance(child, Assignment):
@@ -73,7 +73,7 @@ def _ast_to_markdown(doc):
     CRS-FIX #2: Complete implementation that processes nested block children,
     matching the MCP octave_eject tool behavior.
     """
-    from octave_mcp.core.ast_nodes import Assignment, Block
+    from octave_mcp.core.grammar.cst import Assignment, Block
 
     lines = [f"# {doc.name}", ""]
 
@@ -125,7 +125,7 @@ def _compute_allowed_root_for_check(doc, base_path):
     """
     from pathlib import Path
 
-    from octave_mcp.core.ast_nodes import Assignment, Section
+    from octave_mcp.core.grammar.cst import Assignment, Section
 
     # Collect all resolved SOURCE_URI paths
     resolved_paths = [base_path]  # Start with document's directory
@@ -433,9 +433,9 @@ def write(
     import json as json_module
     import sys
 
-    from octave_mcp.core.ast_nodes import Assignment
     from octave_mcp.core.emitter import emit  # noqa: F401 -- kept for backwards-compatible imports
     from octave_mcp.core.file_ops import atomic_write_octave, validate_octave_path
+    from octave_mcp.core.grammar.cst import Assignment
     from octave_mcp.core.parser import parse
     from octave_mcp.core.validator import Validator
     from octave_mcp.mcp.write import OctaveASTCycleError, _emit_with_style
@@ -1133,7 +1133,7 @@ def _extract_vocabulary_entries_from_registry(doc) -> list[dict]:
     Returns:
         List of vocabulary entry dictionaries
     """
-    from octave_mcp.core.ast_nodes import Assignment, ListValue, Section
+    from octave_mcp.core.grammar.cst import Assignment, ListValue, Section
 
     vocabularies = []
 

--- a/src/octave_mcp/core/ast_nodes.py
+++ b/src/octave_mcp/core/ast_nodes.py
@@ -1,237 +1,99 @@
-"""AST node definitions for OCTAVE parser.
+"""Deprecation shim for the legacy AST node module (ADR-0006 SR1-T1 Step 4).
 
-Implements data structures for the abstract syntax tree.
+History
+-------
 
-I2 (Deterministic Absence) Support:
-The Absent sentinel type distinguishes between:
-- Absent: Field not provided (should NOT be emitted)
-- None: Field explicitly set to null (`KEY::null`)
-- Value: Field has an actual value
+SR1-T1 Step 4 promotes the AST node definitions from this flat module to
+``octave_mcp.core.grammar.cst``. The canonical module is the new path;
+this module remains as a backwards-compatibility shim so external
+consumers (PyPI users on v1.11.x or earlier) keep working through the
+deprecation window.
+
+All ~62 internal call sites were rewritten in the Step-4 PR to import
+from ``octave_mcp.core.grammar.cst`` directly. By PR-merge there are
+zero internal callers of this module, so the lazy ``__getattr__``
+deprecation warning only fires for external consumers — which is
+exactly the audience the warning is for.
+
+This shim mirrors the Step-1 pattern at ``octave_mcp.core.grammar``
+(PR #393): PEP 562 ``__getattr__`` for lazy resolution, single
+``DeprecationWarning`` on attribute access, **identity-preserving**
+re-export so ``ast_nodes.Section is grammar.cst.Section`` holds.
+
+See ``docs/adr/adr-0006-sr1-t1-grammar-core-design.md`` §3 row 4, §2.2.
 """
 
-from dataclasses import dataclass, field
-from typing import Any
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+# Names re-exported from grammar.cst for backward compatibility. Listed
+# here rather than in __all__ so they remain reachable but are not
+# advertised as part of the new front-door surface. Includes the Absent
+# sentinel, all ASTNode subclasses, and the value types — i.e. every
+# public name the legacy module previously exposed.
+_DEPRECATED_AST_EXPORTS: frozenset[str] = frozenset(
+    {
+        "ABSENT",
+        "ASTNode",
+        "Absent",
+        "Assignment",
+        "Block",
+        "Comment",
+        "Document",
+        "HolographicValue",
+        "InlineMap",
+        "ListValue",
+        "LiteralZoneValue",
+        "NodeKind",
+        "Section",
+    }
+)
 
 
-class Absent:
-    """Sentinel type for I2: Deterministic Absence.
+def __getattr__(name: str) -> Any:
+    """PEP 562 lazy resolver for legacy ``octave_mcp.core.ast_nodes`` symbols.
 
-    Represents a field that was not provided, distinct from:
-    - None (Python): explicitly set to null (`KEY::null`)
-    - Default: schema-provided default value
-
-    Per North Star I2: "Absence shall propagate as addressable state,
-    never silently collapse to null or default."
-
-    Usage:
-        # Creating an absent value
-        absent_val = Absent()
-
-        # Checking if a value is absent
-        if isinstance(value, Absent):
-            # Field was not provided
-            pass
-
-        # Absent is falsy but not None
-        assert not absent_val
-        assert absent_val is not None
+    Emits a :class:`DeprecationWarning` on each attribute access for any
+    legacy AST symbol (the caller's :mod:`warnings` filter controls
+    deduplication), then returns the canonical object from
+    :mod:`octave_mcp.core.grammar.cst`. Unknown names raise
+    :class:`AttributeError` per the standard module attribute protocol.
     """
+    if name in _DEPRECATED_AST_EXPORTS:
+        warnings.warn(
+            (
+                f"octave_mcp.core.ast_nodes.{name} is deprecated; import from "
+                "octave_mcp.core.grammar.cst instead. "
+                "Removal tracked under ADR-0006 SR1-T1."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from octave_mcp.core.grammar import cst
 
-    _instance: "Absent | None" = None
-
-    def __new__(cls) -> "Absent":
-        """Create or return singleton instance for efficiency."""
-        if cls._instance is None:
-            cls._instance = super().__new__(cls)
-        return cls._instance
-
-    def __bool__(self) -> bool:
-        """Absent is falsy, like None."""
-        return False
-
-    def __repr__(self) -> str:
-        """Clear representation for debugging."""
-        return "Absent()"
-
-    def __eq__(self, other: object) -> bool:
-        """Absent only equals itself, not None."""
-        return isinstance(other, Absent)
-
-    def __hash__(self) -> int:
-        """Allow Absent to be used in sets/dicts."""
-        return hash("Absent")
+        return getattr(cst, name)
+    raise AttributeError(f"module 'octave_mcp.core.ast_nodes' has no attribute {name!r}")
 
 
-# Module-level singleton for convenience
-ABSENT = Absent()
-
-
-@dataclass
-class ASTNode:
-    """Base class for all AST nodes.
-
-    Issue #182: Comment preservation support.
-    All AST nodes can have attached comments:
-    - leading_comments: Comment lines appearing before this node
-    - trailing_comment: End-of-line comment after this node's value
-    """
-
-    line: int = 0
-    column: int = 0
-    leading_comments: list[str] = field(default_factory=list)
-    trailing_comment: str | None = None
-
-
-@dataclass
-class Assignment(ASTNode):
-    """KEY::value assignment."""
-
-    key: str = ""
-    value: Any = None
-
-
-@dataclass
-class Block(ASTNode):
-    """KEY: with nested children.
-
-    Issue #189: Block inheritance support.
-    Blocks can have a target annotation: BLOCK[->TARGET]:
-    Children inherit this target unless they specify their own.
-
-    Attributes:
-        key: Block key name
-        children: Nested AST nodes
-        target: Optional target for block-level routing inheritance.
-                Syntax: BLOCK[->TARGET]: sets target="TARGET".
-                Children without explicit targets inherit from parent blocks.
-    """
-
-    key: str = ""
-    children: list[ASTNode] = field(default_factory=list)
-    target: str | None = None
-
-
-@dataclass
-class Section(ASTNode):
-    """§NUMBER::NAME section with nested children.
-
-    section_id supports both plain numbers ("1", "2") and suffix forms ("2b", "2c").
-    annotation is the optional bracket tail [content] after section name.
-    """
-
-    section_id: str = "0"
-    key: str = ""
-    annotation: str | None = None
-    children: list[ASTNode] = field(default_factory=list)
-
-
-@dataclass
-class Document(ASTNode):
-    """Top-level OCTAVE document with envelope.
-
-    Attributes:
-        name: Document envelope name (e.g., "MY_DOC" from ===MY_DOC===)
-        meta: Parsed META block as dictionary
-        sections: List of parsed sections (Assignment, Block, Section)
-        has_separator: True if document contains --- separator
-        raw_frontmatter: YAML frontmatter content if present (Issue #91)
-        grammar_version: OCTAVE grammar version from sentinel (Issue #48 Phase 2)
-            Format: OCTAVE::VERSION at document start, e.g., "OCTAVE::5.1.0"
-            When present, enables forward compatibility detection and migration routing.
-        trailing_comments: Comment lines appearing before ===END=== (Issue #182)
-            These are comments that don't have a subsequent section to attach to.
-    """
-
-    name: str = "INFERRED"
-    meta: dict[str, Any] = field(default_factory=dict)
-    sections: list[ASTNode] = field(default_factory=list)
-    has_separator: bool = False
-    raw_frontmatter: str | None = None
-    trailing_comments: list[str] = field(default_factory=list)
-    grammar_version: str | None = None
-
-
-@dataclass
-class Comment(ASTNode):
-    """Comment node."""
-
-    text: str = ""
-
-
-@dataclass
-class ListValue:
-    """List value [a, b, c].
-
-    Attributes:
-        items: Parsed list item values
-        tokens: Optional token slice for token-witnessed reconstruction (ADR-0012).
-                When present, enables correct reconstruction of holographic patterns
-                containing quoted operator symbols (e.g., ["∧"∧REQ→§SELF]).
-                The token list preserves type metadata lost during value extraction.
-    """
-
-    items: list[Any] = field(default_factory=list)
-    tokens: list[Any] | None = None  # Gap_2: Token slice for fidelity reconstruction
-
-
-@dataclass
-class InlineMap:
-    """Inline map [k::v, k2::v2] (data mode only)."""
-
-    pairs: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class HolographicValue:
-    """Holographic pattern value ["example"∧CONSTRAINT→§TARGET].
-
-    Represents a schema field definition in L4 holographic syntax.
-    This AST node is produced when the parser detects holographic operators
-    (∧ constraint chain, →§ target) within a bracketed expression.
-
-    Issue #187: Integrates holographic pattern parsing into parser L4 context.
-
-    Attributes:
-        example: The example value demonstrating expected format.
-        constraints: Parsed ConstraintChain for validation, or None if no constraints.
-        target: Target destination (without § prefix), or None if no target.
-        raw_pattern: Original pattern string for I1 syntactic fidelity.
-        tokens: Optional token slice for token-witnessed reconstruction (ADR-0012).
-    """
-
-    example: Any
-    constraints: Any  # ConstraintChain | None - Any to avoid circular import
-    target: str | None
-    raw_pattern: str = ""
-    tokens: list[Any] | None = None
-
-
-@dataclass
-class LiteralZoneValue:
-    """Literal zone value (fenced code block).
-
-    Issue #235: Represents content between fence markers (``` or longer).
-    Content is preserved exactly as-is -- no NFC normalization, no escape
-    processing, no operator normalization, no variable substitution.
-
-    Follows the HolographicValue/ListValue precedent: value type (not
-    ASTNode subclass). This ensures exhaustive pattern matching catches
-    literal zones and prevents silent normalization through string paths.
-
-    I1: Exempt from normalization (semantic intent is "preserve exactly").
-    I2: Empty content ("") is distinct from absent (no LiteralZoneValue).
-    I3: Nested fences MUST error at parse time, never reach this node.
-
-    Attributes:
-        content: Raw content between fences. Preserved byte-for-byte.
-                 Empty string for empty literal zones (```\\n```).
-        info_tag: Optional language identifier (e.g., "python", "json").
-                  None when no info tag is provided.
-                  Preserved but not validated by OCTAVE parser.
-        fence_marker: The exact fence string used (e.g., "```", "````").
-                      Needed for round-trip emission fidelity.
-    """
-
-    content: str = ""
-    info_tag: str | None = None
-    fence_marker: str = "```"
+if TYPE_CHECKING:
+    # Re-declare the deprecated symbols statically so type-checkers and
+    # static analysers know they are reachable from this namespace.
+    # These bindings are NEVER executed at runtime; PEP 562 __getattr__
+    # is the sole runtime resolution path.
+    from octave_mcp.core.grammar.cst import (  # noqa: F401
+        ABSENT,
+        Absent,
+        Assignment,
+        ASTNode,
+        Block,
+        Comment,
+        Document,
+        HolographicValue,
+        InlineMap,
+        ListValue,
+        LiteralZoneValue,
+        NodeKind,
+        Section,
+    )

--- a/src/octave_mcp/core/constraints.py
+++ b/src/octave_mcp/core/constraints.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
-from octave_mcp.core.ast_nodes import LiteralZoneValue
+from octave_mcp.core.grammar.cst import LiteralZoneValue
 
 
 @dataclass

--- a/src/octave_mcp/core/coverage_mapper.py
+++ b/src/octave_mcp/core/coverage_mapper.py
@@ -16,7 +16,7 @@ Output format per spec:
 
 from dataclasses import dataclass
 
-from octave_mcp.core.ast_nodes import Document, Section
+from octave_mcp.core.grammar.cst import Document, Section
 
 
 @dataclass

--- a/src/octave_mcp/core/emitter.py
+++ b/src/octave_mcp/core/emitter.py
@@ -25,7 +25,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.grammar.cst import (
     Absent,
     Assignment,
     Block,

--- a/src/octave_mcp/core/gbnf_compiler.py
+++ b/src/octave_mcp/core/gbnf_compiler.py
@@ -61,7 +61,7 @@ def _extract_contract_field_specs(contract: object) -> list[str]:
     Returns:
         List of field spec strings like "FIELD[STATUS]::REQ∧ENUM[A,B]"
     """
-    from octave_mcp.core.ast_nodes import ListValue
+    from octave_mcp.core.grammar.cst import ListValue
 
     # Handle plain list of strings
     if isinstance(contract, list):

--- a/src/octave_mcp/core/grammar/__init__.py
+++ b/src/octave_mcp/core/grammar/__init__.py
@@ -29,9 +29,44 @@ from __future__ import annotations
 import warnings
 from typing import TYPE_CHECKING, Any
 
+from octave_mcp.core.grammar.cst import (
+    ABSENT,
+    Absent,
+    Assignment,
+    ASTNode,
+    Block,
+    Comment,
+    Document,
+    HolographicValue,
+    InlineMap,
+    ListValue,
+    LiteralZoneValue,
+    NodeKind,
+    Section,
+)
 from octave_mcp.core.grammar.entry import ParserError, parse, parse_with_warnings
+from octave_mcp.core.grammar.visitor import SymmetricVisitor, Visitor
 
-__all__ = ["ParserError", "parse", "parse_with_warnings"]
+__all__ = [
+    "ABSENT",
+    "ASTNode",
+    "Absent",
+    "Assignment",
+    "Block",
+    "Comment",
+    "Document",
+    "HolographicValue",
+    "InlineMap",
+    "ListValue",
+    "LiteralZoneValue",
+    "NodeKind",
+    "ParserError",
+    "Section",
+    "SymmetricVisitor",
+    "Visitor",
+    "parse",
+    "parse_with_warnings",
+]
 
 # Names re-exported from grammar_compiler.gbnf for backward compatibility.
 # Listed here rather than in __all__ so they remain reachable but are not

--- a/src/octave_mcp/core/grammar/cst.py
+++ b/src/octave_mcp/core/grammar/cst.py
@@ -1,0 +1,356 @@
+"""Concrete Syntax Tree (CST) node definitions (ADR-0006 SR1-T1 Step 4).
+
+This module is the promotion of ``octave_mcp.core.ast_nodes`` to the
+unified grammar package per ADR-0006 §2.2 and §3 row 4. The promotion
+adds three pieces of structural surface without altering the runtime
+semantics of the existing dataclasses:
+
+1. ``NodeKind`` enum — one variant per concrete ``ASTNode`` subclass.
+   Provides a stable discriminator for visitor dispatch and audit-log
+   keying (I4 TRANSFORM_AUDITABILITY). Each node class auto-populates
+   ``self.kind`` from its subclass declaration via a ``__post_init__``
+   hook so callers do not need to pass ``kind`` explicitly — the ~30
+   existing ``Section(...)`` / ``Block(...)`` / ``Assignment(...)`` /
+   ``Document(...)`` call sites continue to work unchanged.
+
+2. Reserved fidelity-preservation fields on the base ``ASTNode``
+   defaulted to ``None`` (per design §4.5 G1+G2):
+
+   * ``leading_trivia: Optional[str]`` — leading whitespace/blank-lines.
+     Populated by Sprint 3+ (SR3-T1 cursor-CST). Enables precise
+     blank-line-stripping audit per design §3a class 2.
+   * ``trailing_trivia: Optional[str]`` — trailing whitespace. Same
+     population timeline as ``leading_trivia``.
+   * ``was_quoted: Optional[bool]`` — did the user write the value with
+     explicit quotes (e.g. ``KEY::"42"``)? Populated by logical-Step 5
+     (next task) via lexer/parser instrumentation. Enables precise
+     identifier-dequoting audit per design §3a class 1 and §4.5 G2.
+
+   These three fields are **reserved, not populated** in this PR — they
+   exist purely to lock the schema shape so that the later population
+   PRs do not need to re-touch every node class and every visitor
+   signature. No code in this PR reads or writes them.
+
+3. PEP 562 deprecation shim at the legacy path
+   ``octave_mcp.core.ast_nodes`` (see that module). Symbol identity is
+   preserved across both paths: ``ast_nodes.Section is grammar.cst.Section``.
+
+The Absent sentinel and value types (ListValue, InlineMap, HolographicValue,
+LiteralZoneValue) are re-exported unchanged — they are not ``ASTNode``
+subclasses so they do not carry a ``kind``.
+
+See ``docs/adr/adr-0006-sr1-t1-grammar-core-design.md`` §2.2, §3 row 4,
+§3a, §4.5 G1+G2.
+
+I2 (Deterministic Absence) Support
+----------------------------------
+
+The ``Absent`` sentinel type distinguishes between:
+
+* ``Absent``: Field not provided (should NOT be emitted)
+* ``None``: Field explicitly set to null (``KEY::null``)
+* Value: Field has an actual value
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class NodeKind(Enum):
+    """Structural discriminator for CST nodes.
+
+    One variant per concrete ``ASTNode`` subclass. Used by visitors to
+    dispatch on node shape without relying on ``isinstance`` chains, and
+    by the future ``tier_normalize`` audit log to key entries by node
+    shape (I4 TRANSFORM_AUDITABILITY).
+
+    NOTE: This is a *structural* marker only. Presentation-aware
+    decisions (e.g. "was this value originally quoted?") live on the
+    node's ``was_quoted`` field, not on ``NodeKind``. See design §4.5 G2.
+    """
+
+    ASSIGNMENT = "ASSIGNMENT"
+    BLOCK = "BLOCK"
+    SECTION = "SECTION"
+    DOCUMENT = "DOCUMENT"
+    COMMENT = "COMMENT"
+
+
+class Absent:
+    """Sentinel type for I2: Deterministic Absence.
+
+    Represents a field that was not provided, distinct from:
+    - None (Python): explicitly set to null (`KEY::null`)
+    - Default: schema-provided default value
+
+    Per North Star I2: "Absence shall propagate as addressable state,
+    never silently collapse to null or default."
+
+    Usage:
+        # Creating an absent value
+        absent_val = Absent()
+
+        # Checking if a value is absent
+        if isinstance(value, Absent):
+            # Field was not provided
+            pass
+
+        # Absent is falsy but not None
+        assert not absent_val
+        assert absent_val is not None
+    """
+
+    _instance: Absent | None = None
+
+    def __new__(cls) -> Absent:
+        """Create or return singleton instance for efficiency."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __bool__(self) -> bool:
+        """Absent is falsy, like None."""
+        return False
+
+    def __repr__(self) -> str:
+        """Clear representation for debugging."""
+        return "Absent()"
+
+    def __eq__(self, other: object) -> bool:
+        """Absent only equals itself, not None."""
+        return isinstance(other, Absent)
+
+    def __hash__(self) -> int:
+        """Allow Absent to be used in sets/dicts."""
+        return hash("Absent")
+
+
+# Module-level singleton for convenience
+ABSENT = Absent()
+
+
+@dataclass
+class ASTNode:
+    """Base class for all AST nodes.
+
+    Issue #182: Comment preservation support.
+    All AST nodes can have attached comments:
+    - leading_comments: Comment lines appearing before this node
+    - trailing_comment: End-of-line comment after this node's value
+
+    ADR-0006 SR1-T1 Step 4 reserved fidelity-preservation fields (NOT
+    populated in this PR — see module docstring):
+    - leading_trivia: Whitespace/blank-line prefix (Sprint 3+).
+    - trailing_trivia: Whitespace suffix (Sprint 3+).
+    - was_quoted: Original quoting state of the value (logical-Step 5).
+
+    ADR-0006 SR1-T1 Step 4 also added ``kind: NodeKind`` as a structural
+    discriminator. Concrete subclasses override the default via their own
+    ``kind`` field declaration with ``init=False``.
+    """
+
+    line: int = 0
+    column: int = 0
+    leading_comments: list[str] = field(default_factory=list)
+    trailing_comment: str | None = None
+    # --- Reserved fidelity fields (ADR-0006 §4.5 G1+G2). Optional[None]; ---
+    # --- DO NOT populate in this PR. Populated by Step 5 / Sprint 3+.   ---
+    leading_trivia: str | None = None
+    trailing_trivia: str | None = None
+    was_quoted: bool | None = None
+    # --- Structural discriminator (ADR-0006 §3 row 4). Subclasses     ---
+    # --- override with their own NodeKind variant via init=False.     ---
+    # The base ASTNode itself is abstract for kind purposes; the default
+    # here is overridden by every concrete subclass. We use a placeholder
+    # that should never be observed in well-formed CSTs.
+    kind: NodeKind = field(default=NodeKind.DOCUMENT, init=False)
+
+
+@dataclass
+class Assignment(ASTNode):
+    """KEY::value assignment."""
+
+    key: str = ""
+    value: Any = None
+    kind: NodeKind = field(default=NodeKind.ASSIGNMENT, init=False)
+
+
+@dataclass
+class Block(ASTNode):
+    """KEY: with nested children.
+
+    Issue #189: Block inheritance support.
+    Blocks can have a target annotation: BLOCK[->TARGET]:
+    Children inherit this target unless they specify their own.
+
+    Attributes:
+        key: Block key name
+        children: Nested AST nodes
+        target: Optional target for block-level routing inheritance.
+                Syntax: BLOCK[->TARGET]: sets target="TARGET".
+                Children without explicit targets inherit from parent blocks.
+    """
+
+    key: str = ""
+    children: list[ASTNode] = field(default_factory=list)
+    target: str | None = None
+    kind: NodeKind = field(default=NodeKind.BLOCK, init=False)
+
+
+@dataclass
+class Section(ASTNode):
+    """§NUMBER::NAME section with nested children.
+
+    section_id supports both plain numbers ("1", "2") and suffix forms ("2b", "2c").
+    annotation is the optional bracket tail [content] after section name.
+    """
+
+    section_id: str = "0"
+    key: str = ""
+    annotation: str | None = None
+    children: list[ASTNode] = field(default_factory=list)
+    kind: NodeKind = field(default=NodeKind.SECTION, init=False)
+
+
+@dataclass
+class Document(ASTNode):
+    """Top-level OCTAVE document with envelope.
+
+    Attributes:
+        name: Document envelope name (e.g., "MY_DOC" from ===MY_DOC===)
+        meta: Parsed META block as dictionary
+        sections: List of parsed sections (Assignment, Block, Section)
+        has_separator: True if document contains --- separator
+        raw_frontmatter: YAML frontmatter content if present (Issue #91)
+        grammar_version: OCTAVE grammar version from sentinel (Issue #48 Phase 2)
+            Format: OCTAVE::VERSION at document start, e.g., "OCTAVE::5.1.0"
+            When present, enables forward compatibility detection and migration routing.
+        trailing_comments: Comment lines appearing before ===END=== (Issue #182)
+            These are comments that don't have a subsequent section to attach to.
+    """
+
+    name: str = "INFERRED"
+    meta: dict[str, Any] = field(default_factory=dict)
+    sections: list[ASTNode] = field(default_factory=list)
+    has_separator: bool = False
+    raw_frontmatter: str | None = None
+    trailing_comments: list[str] = field(default_factory=list)
+    grammar_version: str | None = None
+    kind: NodeKind = field(default=NodeKind.DOCUMENT, init=False)
+
+
+@dataclass
+class Comment(ASTNode):
+    """Comment node."""
+
+    text: str = ""
+    kind: NodeKind = field(default=NodeKind.COMMENT, init=False)
+
+
+@dataclass
+class ListValue:
+    """List value [a, b, c].
+
+    NOT an ASTNode subclass — this is a value type. Does not carry a
+    NodeKind discriminator.
+
+    Attributes:
+        items: Parsed list item values
+        tokens: Optional token slice for token-witnessed reconstruction (ADR-0012).
+                When present, enables correct reconstruction of holographic patterns
+                containing quoted operator symbols (e.g., ["∧"∧REQ→§SELF]).
+                The token list preserves type metadata lost during value extraction.
+    """
+
+    items: list[Any] = field(default_factory=list)
+    tokens: list[Any] | None = None  # Gap_2: Token slice for fidelity reconstruction
+
+
+@dataclass
+class InlineMap:
+    """Inline map [k::v, k2::v2] (data mode only).
+
+    NOT an ASTNode subclass — value type. Does not carry a NodeKind.
+    """
+
+    pairs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class HolographicValue:
+    """Holographic pattern value ["example"∧CONSTRAINT→§TARGET].
+
+    Represents a schema field definition in L4 holographic syntax.
+    This AST node is produced when the parser detects holographic operators
+    (∧ constraint chain, →§ target) within a bracketed expression.
+
+    Issue #187: Integrates holographic pattern parsing into parser L4 context.
+
+    NOT an ASTNode subclass — value type. Does not carry a NodeKind.
+
+    Attributes:
+        example: The example value demonstrating expected format.
+        constraints: Parsed ConstraintChain for validation, or None if no constraints.
+        target: Target destination (without § prefix), or None if no target.
+        raw_pattern: Original pattern string for I1 syntactic fidelity.
+        tokens: Optional token slice for token-witnessed reconstruction (ADR-0012).
+    """
+
+    example: Any
+    constraints: Any  # ConstraintChain | None - Any to avoid circular import
+    target: str | None
+    raw_pattern: str = ""
+    tokens: list[Any] | None = None
+
+
+@dataclass
+class LiteralZoneValue:
+    """Literal zone value (fenced code block).
+
+    Issue #235: Represents content between fence markers (``` or longer).
+    Content is preserved exactly as-is -- no NFC normalization, no escape
+    processing, no operator normalization, no variable substitution.
+
+    Follows the HolographicValue/ListValue precedent: value type (not
+    ASTNode subclass). This ensures exhaustive pattern matching catches
+    literal zones and prevents silent normalization through string paths.
+
+    I1: Exempt from normalization (semantic intent is "preserve exactly").
+    I2: Empty content ("") is distinct from absent (no LiteralZoneValue).
+    I3: Nested fences MUST error at parse time, never reach this node.
+
+    NOT an ASTNode subclass — value type. Does not carry a NodeKind.
+
+    Attributes:
+        content: Raw content between fences. Preserved byte-for-byte.
+                 Empty string for empty literal zones (```\\n```).
+        info_tag: Optional language identifier (e.g., "python", "json").
+                  None when no info tag is provided.
+                  Preserved but not validated by OCTAVE parser.
+        fence_marker: The exact fence string used (e.g., "```", "````").
+                      Needed for round-trip emission fidelity.
+    """
+
+    content: str = ""
+    info_tag: str | None = None
+    fence_marker: str = "```"
+
+
+__all__ = [
+    "ABSENT",
+    "ASTNode",
+    "Absent",
+    "Assignment",
+    "Block",
+    "Comment",
+    "Document",
+    "HolographicValue",
+    "InlineMap",
+    "ListValue",
+    "LiteralZoneValue",
+    "NodeKind",
+    "Section",
+]

--- a/src/octave_mcp/core/grammar/visitor.py
+++ b/src/octave_mcp/core/grammar/visitor.py
@@ -1,0 +1,162 @@
+"""CST visitor protocol (ADR-0006 SR1-T1 Step 4 — scaffold).
+
+This module is the minimum viable visitor surface that logical-Step 5
+(emitter rewrite) consumes. Per design §2.2 the visitor file provides:
+
+* ``Visitor[T]`` — a generic ``typing.Protocol`` declaring the four core
+  visit methods (``visit_section``, ``visit_block``, ``visit_assignment``,
+  ``visit_document``) plus a fallback ``visit`` dispatcher.
+* ``SymmetricVisitor[T]`` — a mixin that asserts emit-after-parse
+  round-trip in debug builds (``__debug__`` gated). The assertion hook
+  is exposed as ``assert_round_trip`` so Step 5's emitter rewrite can
+  wire its parse-after-emit symmetry check without re-touching this
+  file.
+
+Per design §3a the visitor signatures land **once** at Step 4. The
+reserved fidelity fields on ``cst.ASTNode`` mean Step 5 / Sprint 3+ can
+populate ``was_quoted`` / trivia without changing any visit-method
+signature here. See design §4.5.
+
+See ``docs/adr/adr-0006-sr1-t1-grammar-core-design.md`` §2.2, §4.5.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+    Generic,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
+
+if TYPE_CHECKING:
+    from octave_mcp.core.grammar.cst import (
+        Assignment,
+        ASTNode,
+        Block,
+        Document,
+        Section,
+    )
+
+
+T = TypeVar("T")
+T_co = TypeVar("T_co", covariant=True)
+
+
+@runtime_checkable
+class Visitor(Protocol[T_co]):
+    """Generic visitor protocol over CST nodes.
+
+    A ``Visitor[T]`` consumes a CST and produces a value of type ``T``
+    for each node visited. The four ``visit_*`` methods cover the
+    concrete ``ASTNode`` subclasses; the fallback ``visit`` dispatcher
+    is the entry point callers use when they have an unknown-kind node.
+
+    Implementations may dispatch on ``node.kind`` (a ``NodeKind`` enum)
+    to avoid ``isinstance`` chains. Step 5's emitter is the first
+    consumer; the surface is intentionally minimal so it lands once and
+    Step 5 does not have to re-touch this file.
+
+    NOTE: This is a ``runtime_checkable`` Protocol so ``isinstance(obj,
+    Visitor)`` works for structural typing checks in tests. The runtime
+    check verifies method presence only; mypy strict performs the full
+    structural type check at static analysis time.
+    """
+
+    def visit_assignment(self, node: Assignment, /) -> T_co:
+        """Visit an Assignment node."""
+        ...
+
+    def visit_block(self, node: Block, /) -> T_co:
+        """Visit a Block node."""
+        ...
+
+    def visit_section(self, node: Section, /) -> T_co:
+        """Visit a Section node."""
+        ...
+
+    def visit_document(self, node: Document, /) -> T_co:
+        """Visit a Document node."""
+        ...
+
+    def visit(self, node: ASTNode, /) -> T_co:
+        """Fallback dispatcher for unknown-kind nodes.
+
+        Implementations typically dispatch on ``node.kind`` to one of
+        the typed ``visit_*`` methods above.
+        """
+        ...
+
+
+class SymmetricVisitor(Generic[T]):
+    """Mixin that asserts emit-after-parse round-trip in debug builds.
+
+    This is the Step-4 scaffold. Logical-Step 5 (emitter rewrite) is the
+    first real consumer; it will call ``self.assert_round_trip(...)``
+    from inside its emit pipeline whenever it has both the source bytes
+    and the freshly-emitted bytes available.
+
+    The assertion is **debug-gated**: when Python is run with the ``-O``
+    flag (``__debug__ == False``), the check short-circuits to a no-op
+    so production callers pay no overhead. This is consistent with
+    Python's ``assert`` semantics and ensures the symmetry check is a
+    development-time invariant, not a runtime cost.
+
+    The mixin is deliberately minimal. Future steps (notably the
+    Sprint 3+ cursor-CST) will populate ``leading_trivia`` /
+    ``trailing_trivia`` and may extend this hook with byte-precise diff
+    reporting. For now, the contract is: ``source == emitted`` (when
+    both are provided) → no-op; mismatch → ``AssertionError`` in
+    ``__debug__`` mode, no-op otherwise.
+    """
+
+    def assert_round_trip(
+        self,
+        node: ASTNode,
+        /,
+        *,
+        source: str | None = None,
+        emitted: str | None = None,
+    ) -> None:
+        """Assert emit(parse(source)) == source.
+
+        Called from inside the emitter visitor (Step 5) once both the
+        original source bytes and the canonical emitted bytes are
+        available. In ``__debug__`` mode (the default), a mismatch
+        raises ``AssertionError`` with a short diagnostic. In ``-O``
+        mode the call is a no-op — Step 5 may invoke this on every
+        emit without paying overhead in production.
+
+        Args:
+            node: The root CST node that was emitted. Currently unused
+                by the assertion logic; reserved for Step 5 / Sprint 3+
+                to attach precise diff reporting.
+            source: The original source bytes (or ``None`` if not
+                available, e.g. when emitting from a constructed CST
+                that did not originate from parsed bytes).
+            emitted: The freshly-emitted bytes (or ``None`` if not
+                available).
+
+        Note:
+            When either ``source`` or ``emitted`` is ``None``, the
+            assertion is skipped — the check is only meaningful when
+            both halves of the round trip are present.
+        """
+        if not __debug__:
+            return
+        if source is None or emitted is None:
+            return
+        if source != emitted:
+            raise AssertionError(
+                "SymmetricVisitor round-trip mismatch: "
+                f"len(source)={len(source)} len(emitted)={len(emitted)} "
+                f"node.kind={getattr(node, 'kind', None)!r}. "
+                "Emit-after-parse must be byte-identical in debug builds."
+            )
+
+
+__all__ = [
+    "SymmetricVisitor",
+    "Visitor",
+]

--- a/src/octave_mcp/core/hydrator.py
+++ b/src/octave_mcp/core/hydrator.py
@@ -29,7 +29,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal
 
-from octave_mcp.core.ast_nodes import Assignment, ASTNode, Block, Document, ListValue, Section
+from octave_mcp.core.grammar.cst import Assignment, ASTNode, Block, Document, ListValue, Section
 from octave_mcp.core.parser import parse
 
 

--- a/src/octave_mcp/core/literal_zone_audit.py
+++ b/src/octave_mcp/core/literal_zone_audit.py
@@ -11,7 +11,7 @@ import hashlib
 from datetime import UTC, datetime
 from typing import Any
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.grammar.cst import (
     Assignment,
     ASTNode,
     Block,

--- a/src/octave_mcp/core/parser.py
+++ b/src/octave_mcp/core/parser.py
@@ -13,7 +13,7 @@ Parses lexer tokens into AST with:
 
 from typing import Any
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.grammar.cst import (
     Assignment,
     ASTNode,
     Block,

--- a/src/octave_mcp/core/projector.py
+++ b/src/octave_mcp/core/projector.py
@@ -9,8 +9,8 @@ Implements eject() projection modes:
 
 from dataclasses import dataclass, replace
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Assignment, Block, Document
 
 
 @dataclass

--- a/src/octave_mcp/core/repair.py
+++ b/src/octave_mcp/core/repair.py
@@ -15,8 +15,8 @@ from __future__ import annotations
 import math
 from typing import TYPE_CHECKING, Any
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, LiteralZoneValue, Section
 from octave_mcp.core.constraints import EnumConstraint, TypeConstraint
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, LiteralZoneValue, Section
 from octave_mcp.core.repair_log import RepairLog, RepairTier
 from octave_mcp.core.schema_extractor import FieldDefinition, SchemaDefinition
 from octave_mcp.core.validator import ValidationError

--- a/src/octave_mcp/core/schema.py
+++ b/src/octave_mcp/core/schema.py
@@ -3,7 +3,7 @@
 Provides Schema class and validation function that delegates to validator.py.
 """
 
-from octave_mcp.core.ast_nodes import Document
+from octave_mcp.core.grammar.cst import Document
 from octave_mcp.core.validator import ValidationError
 from octave_mcp.core.validator import validate as validate_impl
 

--- a/src/octave_mcp/core/schema_extractor.py
+++ b/src/octave_mcp/core/schema_extractor.py
@@ -18,8 +18,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
-from octave_mcp.core.ast_nodes import Assignment, ASTNode, Block, Document, HolographicValue, Section
 from octave_mcp.core.constraints import RequiredConstraint
+from octave_mcp.core.grammar.cst import Assignment, ASTNode, Block, Document, HolographicValue, Section
 from octave_mcp.core.holographic import (
     HolographicPattern,
     HolographicPatternError,

--- a/src/octave_mcp/core/sealer.py
+++ b/src/octave_mcp/core/sealer.py
@@ -18,8 +18,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-from octave_mcp.core.ast_nodes import Assignment, ASTNode, Document, Section
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Assignment, ASTNode, Document, Section
 
 
 class SealStatus(Enum):

--- a/src/octave_mcp/core/validator.py
+++ b/src/octave_mcp/core/validator.py
@@ -16,7 +16,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.constraints import EnumConstraint, RequiredConstraint
+from octave_mcp.core.grammar.cst import (
     Assignment,
     ASTNode,
     Block,
@@ -26,7 +27,6 @@ from octave_mcp.core.ast_nodes import (
     LiteralZoneValue,
     Section,
 )
-from octave_mcp.core.constraints import EnumConstraint, RequiredConstraint
 from octave_mcp.core.routing import InvalidTargetError, RoutingLog, TargetRegistry, TargetRouter
 from octave_mcp.core.schema_extractor import (
     InheritanceResolver,

--- a/src/octave_mcp/mcp/eject.py
+++ b/src/octave_mcp/mcp/eject.py
@@ -19,9 +19,9 @@ from typing import Any
 
 import yaml
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, InlineMap, ListValue, LiteralZoneValue, Section
 from octave_mcp.core.emitter import emit
 from octave_mcp.core.gbnf_compiler import GBNFCompiler, compile_gbnf_from_meta
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, InlineMap, ListValue, LiteralZoneValue, Section
 from octave_mcp.core.literal_zone_audit import build_literal_zone_repair_log
 from octave_mcp.core.parser import parse
 from octave_mcp.core.projector import project

--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -15,10 +15,10 @@ from difflib import unified_diff
 from pathlib import Path
 from typing import Any
 
-from octave_mcp.core.ast_nodes import Assignment, ASTNode
 from octave_mcp.core.emitter import emit
 from octave_mcp.core.gbnf_compiler import GBNFCompiler
 from octave_mcp.core.grammar import parse_with_warnings
+from octave_mcp.core.grammar.cst import Assignment, ASTNode
 from octave_mcp.core.literal_zone_audit import build_literal_zone_repair_log
 from octave_mcp.core.repair import repair
 from octave_mcp.core.schema_extractor import SchemaDefinition

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -22,7 +22,10 @@ from difflib import unified_diff
 from pathlib import Path
 from typing import Any
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.emitter import emit
+from octave_mcp.core.gbnf_compiler import GBNFCompiler
+from octave_mcp.core.grammar import ParserError, parse, parse_with_warnings
+from octave_mcp.core.grammar.cst import (
     Assignment,
     ASTNode,
     Block,
@@ -33,9 +36,6 @@ from octave_mcp.core.ast_nodes import (
     LiteralZoneValue,
     Section,
 )
-from octave_mcp.core.emitter import emit
-from octave_mcp.core.gbnf_compiler import GBNFCompiler
-from octave_mcp.core.grammar import ParserError, parse, parse_with_warnings
 from octave_mcp.core.hydrator import resolve_hermetic_standard
 from octave_mcp.core.lexer import ENVELOPE_ID_PATTERN, LexerError, tokenize
 from octave_mcp.core.literal_zone_audit import build_literal_zone_repair_log

--- a/tests/integration/test_hydrate_cli.py
+++ b/tests/integration/test_hydrate_cli.py
@@ -334,7 +334,7 @@ class TestHydrateEndToEnd:
         assert doc.meta.get("VERSION") == "1.0.0"
 
         # Check SNAPSHOT section exists
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         snapshot_sections = [s for s in doc.sections if isinstance(s, Section) and "SNAPSHOT" in s.key]
         assert len(snapshot_sections) >= 1

--- a/tests/integration/test_seal_cli.py
+++ b/tests/integration/test_seal_cli.py
@@ -223,7 +223,7 @@ META:
             assert result.exit_code == 0
 
             # Parse output and check SEAL section structure
-            from octave_mcp.core.ast_nodes import Section
+            from octave_mcp.core.grammar.cst import Section
             from octave_mcp.core.parser import parse
 
             doc = parse(result.output)

--- a/tests/properties/test_literal_zones_property.py
+++ b/tests/properties/test_literal_zones_property.py
@@ -11,8 +11,8 @@ then dynamically scales the fence length to wrap them safely.
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
-from octave_mcp.core.ast_nodes import LiteralZoneValue
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import LiteralZoneValue
 from octave_mcp.core.parser import parse
 
 # ---------------------------------------------------------------------------

--- a/tests/repro_issue.py
+++ b/tests/repro_issue.py
@@ -1,7 +1,7 @@
 import unittest
 
-from octave_mcp.core.ast_nodes import Assignment, Document
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Assignment, Document
 from octave_mcp.core.parser import ParserError, parse
 
 

--- a/tests/test_literal_zones_regression.py
+++ b/tests/test_literal_zones_regression.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pytest
 
-from octave_mcp.core.ast_nodes import LiteralZoneValue
+from octave_mcp.core.grammar.cst import LiteralZoneValue
 from octave_mcp.core.lexer import LexerError
 from octave_mcp.core.parser import ParserError, parse
 

--- a/tests/unit/core/grammar/test_cst.py
+++ b/tests/unit/core/grammar/test_cst.py
@@ -1,0 +1,370 @@
+"""Tests for the promoted CST module (ADR-0006 SR1-T1 Step 4).
+
+This module pins the contract for ``octave_mcp.core.grammar.cst`` which
+promotes the legacy ``octave_mcp.core.ast_nodes`` module to the unified
+grammar package. The promotion adds:
+
+* ``NodeKind`` enum (one variant per concrete ASTNode subclass) — provides
+  a stable structural discriminator for visitor dispatch and audit-log
+  keying (I4 TRANSFORM_AUDITABILITY).
+* Reserved fidelity-preservation fields on the base ASTNode, defaulted to
+  ``None``: ``leading_trivia``, ``trailing_trivia``, ``was_quoted``. These
+  are reserved by Step 4 (this PR) and populated by later steps:
+  - ``was_quoted`` → logical-Step 5 (next task) via lexer/parser
+    instrumentation.
+  - ``leading_trivia`` / ``trailing_trivia`` → Sprint 3+ (SR3-T1 cursor-CST)
+    per design doc §3a class-2 dependency table.
+* PEP 562 deprecation shim at the legacy path
+  ``octave_mcp.core.ast_nodes`` preserving symbol identity (``is``) and
+  emitting ``DeprecationWarning`` on attribute access.
+
+See ``docs/adr/adr-0006-sr1-t1-grammar-core-design.md`` §3 row 4, §2.2,
+§4.5 G1+G2.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+# ---------------------------------------------------------------------------
+# NodeKind enum coverage
+# ---------------------------------------------------------------------------
+
+
+def test_node_kind_enum_has_variant_per_node_class() -> None:
+    """NodeKind enum MUST have one variant for each concrete ASTNode subclass."""
+    from octave_mcp.core.grammar.cst import NodeKind
+
+    expected = {"ASSIGNMENT", "BLOCK", "SECTION", "DOCUMENT", "COMMENT"}
+    actual = {member.name for member in NodeKind}
+    assert expected.issubset(
+        actual
+    ), f"NodeKind missing expected variants. Expected superset of {expected}, got {actual}."
+
+
+def test_node_kind_variants_are_unique() -> None:
+    """Each NodeKind variant MUST have a unique value (no aliasing)."""
+    from octave_mcp.core.grammar.cst import NodeKind
+
+    values = [member.value for member in NodeKind]
+    assert len(values) == len(set(values)), f"NodeKind variants must be unique, got duplicates in {values}"
+
+
+# ---------------------------------------------------------------------------
+# Node classes carry their NodeKind discriminator
+# ---------------------------------------------------------------------------
+
+
+def test_assignment_has_assignment_kind() -> None:
+    from octave_mcp.core.grammar.cst import Assignment, NodeKind
+
+    node = Assignment(key="K", value=1)
+    assert node.kind is NodeKind.ASSIGNMENT
+
+
+def test_block_has_block_kind() -> None:
+    from octave_mcp.core.grammar.cst import Block, NodeKind
+
+    node = Block(key="K")
+    assert node.kind is NodeKind.BLOCK
+
+
+def test_section_has_section_kind() -> None:
+    from octave_mcp.core.grammar.cst import NodeKind, Section
+
+    node = Section(section_id="1", key="K")
+    assert node.kind is NodeKind.SECTION
+
+
+def test_document_has_document_kind() -> None:
+    from octave_mcp.core.grammar.cst import Document, NodeKind
+
+    node = Document()
+    assert node.kind is NodeKind.DOCUMENT
+
+
+def test_comment_has_comment_kind() -> None:
+    from octave_mcp.core.grammar.cst import Comment, NodeKind
+
+    node = Comment(text="hi")
+    assert node.kind is NodeKind.COMMENT
+
+
+# ---------------------------------------------------------------------------
+# kind is set automatically — callers do NOT pass it to __init__
+# ---------------------------------------------------------------------------
+
+
+def test_assignment_init_signature_unchanged_no_kind_arg() -> None:
+    """Existing call sites pass key/value; the ``kind`` field MUST NOT be
+    part of the __init__ signature so the ~30 import sites continue to
+    work unchanged."""
+    from octave_mcp.core.grammar.cst import Assignment
+
+    # If kind is init=True we'd need to pass it. The promotion design
+    # requires init=False so this call shape is preserved.
+    node = Assignment(key="X", value=42)
+    assert node.key == "X"
+    assert node.value == 42
+
+
+# ---------------------------------------------------------------------------
+# Reserved fidelity-preservation fields (§4.5 G1+G2)
+# ---------------------------------------------------------------------------
+
+
+def test_assignment_reserves_was_quoted_field_defaulted_none() -> None:
+    """G2 fidelity guardrail: was_quoted reserved Optional[bool] = None."""
+    from octave_mcp.core.grammar.cst import Assignment
+
+    node = Assignment(key="K", value=1)
+    assert node.was_quoted is None, "was_quoted MUST default to None — population is logical-Step 5"
+
+
+def test_assignment_reserves_leading_trivia_field_defaulted_none() -> None:
+    """G1 fidelity guardrail: leading_trivia reserved Optional[str] = None."""
+    from octave_mcp.core.grammar.cst import Assignment
+
+    node = Assignment(key="K", value=1)
+    assert node.leading_trivia is None, "leading_trivia MUST default to None — population is Sprint 3+"
+
+
+def test_assignment_reserves_trailing_trivia_field_defaulted_none() -> None:
+    """G1 fidelity guardrail: trailing_trivia reserved Optional[str] = None."""
+    from octave_mcp.core.grammar.cst import Assignment
+
+    node = Assignment(key="K", value=1)
+    assert node.trailing_trivia is None, "trailing_trivia MUST default to None — population is Sprint 3+"
+
+
+def test_block_reserves_all_three_fidelity_fields() -> None:
+    from octave_mcp.core.grammar.cst import Block
+
+    node = Block(key="K")
+    assert node.was_quoted is None
+    assert node.leading_trivia is None
+    assert node.trailing_trivia is None
+
+
+def test_section_reserves_all_three_fidelity_fields() -> None:
+    from octave_mcp.core.grammar.cst import Section
+
+    node = Section(section_id="1", key="K")
+    assert node.was_quoted is None
+    assert node.leading_trivia is None
+    assert node.trailing_trivia is None
+
+
+def test_document_reserves_all_three_fidelity_fields() -> None:
+    from octave_mcp.core.grammar.cst import Document
+
+    node = Document()
+    assert node.was_quoted is None
+    assert node.leading_trivia is None
+    assert node.trailing_trivia is None
+
+
+def test_comment_reserves_all_three_fidelity_fields() -> None:
+    from octave_mcp.core.grammar.cst import Comment
+
+    node = Comment(text="hi")
+    assert node.was_quoted is None
+    assert node.leading_trivia is None
+    assert node.trailing_trivia is None
+
+
+# ---------------------------------------------------------------------------
+# Backwards-compat: ASTNode base class still exposes original fields
+# ---------------------------------------------------------------------------
+
+
+def test_astnode_base_preserves_existing_fields() -> None:
+    """Promotion MUST NOT alter existing dataclass runtime semantics."""
+    from octave_mcp.core.grammar.cst import ASTNode
+
+    node = ASTNode(line=10, column=5, leading_comments=["# x"], trailing_comment="# y")
+    assert node.line == 10
+    assert node.column == 5
+    assert node.leading_comments == ["# x"]
+    assert node.trailing_comment == "# y"
+
+
+# ---------------------------------------------------------------------------
+# Value types (ListValue, InlineMap, HolographicValue, LiteralZoneValue)
+# are re-exported but are NOT ASTNode subclasses; they do not carry a kind.
+# ---------------------------------------------------------------------------
+
+
+def test_value_types_are_reexported() -> None:
+    """Value types must still be importable from the new path."""
+    from octave_mcp.core.grammar.cst import (
+        Absent,
+        HolographicValue,
+        InlineMap,
+        ListValue,
+        LiteralZoneValue,
+    )
+
+    assert ListValue is not None
+    assert InlineMap is not None
+    assert HolographicValue is not None
+    assert LiteralZoneValue is not None
+    assert Absent is not None
+
+
+def test_absent_singleton_preserved() -> None:
+    """Absent sentinel remains a singleton per I2 (Deterministic Absence)."""
+    from octave_mcp.core.grammar.cst import ABSENT, Absent
+
+    assert Absent() is Absent(), "Absent must remain a singleton"
+    assert ABSENT is Absent(), "ABSENT module-level constant must be the singleton"
+
+
+# ---------------------------------------------------------------------------
+# Symbol identity across the deprecation shim
+# ---------------------------------------------------------------------------
+
+
+def test_section_identity_preserved_across_shim() -> None:
+    """``ast_nodes.Section`` MUST be the same object as ``grammar.cst.Section``."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.Section is new_path.Section
+
+
+def test_block_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.Block is new_path.Block
+
+
+def test_assignment_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.Assignment is new_path.Assignment
+
+
+def test_document_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.Document is new_path.Document
+
+
+def test_astnode_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.ASTNode is new_path.ASTNode
+
+
+def test_comment_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.Comment is new_path.Comment
+
+
+def test_absent_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.Absent is new_path.Absent
+        assert legacy.ABSENT is new_path.ABSENT
+
+
+def test_value_type_identity_preserved_across_shim() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        from octave_mcp.core import ast_nodes as legacy
+        from octave_mcp.core.grammar import cst as new_path
+
+        assert legacy.ListValue is new_path.ListValue
+        assert legacy.InlineMap is new_path.InlineMap
+        assert legacy.HolographicValue is new_path.HolographicValue
+        assert legacy.LiteralZoneValue is new_path.LiteralZoneValue
+
+
+# ---------------------------------------------------------------------------
+# Deprecation contract — mirrors tests/unit/test_grammar_deprecation_shim.py
+# ---------------------------------------------------------------------------
+
+
+def test_accessing_legacy_ast_nodes_symbol_emits_deprecation_warning() -> None:
+    """Lazy attribute access on the legacy path MUST emit DeprecationWarning."""
+    import octave_mcp.core.ast_nodes as legacy
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _ = legacy.Section  # triggers PEP 562 __getattr__
+
+    deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecation, (
+        "Accessing octave_mcp.core.ast_nodes.Section must emit a DeprecationWarning, "
+        f"got: {[str(w.message) for w in caught]}"
+    )
+    message = str(deprecation[0].message)
+    assert "octave_mcp.core.grammar.cst" in message, (
+        "Deprecation message must reference the new grammar.cst location, " f"got: {message}"
+    )
+
+
+def test_from_import_of_legacy_ast_nodes_symbol_emits_warning() -> None:
+    """``from octave_mcp.core.ast_nodes import Section`` MUST emit
+    DeprecationWarning (TMG-coverage pattern from PR #394).
+
+    NOTE: This test asserts the legacy import path's deprecation contract,
+    so it must keep the literal legacy path even after the project-wide
+    import-site rewrite landed in this PR.
+    """
+    import importlib
+    import sys
+
+    sys.modules.pop("octave_mcp.core.ast_nodes", None)
+    importlib.import_module("octave_mcp.core.ast_nodes")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # Deliberately import from the LEGACY path to assert the
+        # deprecation contract. The import-site sweep MUST NOT touch this
+        # line; if a future codemod re-runs, preserve the legacy path
+        # here.
+        legacy_mod = importlib.import_module("octave_mcp.core.ast_nodes")
+        _ = legacy_mod.Section  # triggers PEP 562 __getattr__
+
+    deprecation = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecation, (
+        "Importing Section via the legacy octave_mcp.core.ast_nodes path must emit a "
+        f"DeprecationWarning, got: {[str(w.message) for w in caught]}"
+    )
+
+
+def test_unknown_attribute_on_legacy_shim_raises_attribute_error() -> None:
+    """PEP 562 __getattr__ must still raise AttributeError for unknown names."""
+    import octave_mcp.core.ast_nodes as legacy
+
+    try:
+        _ = legacy.this_symbol_does_not_exist  # type: ignore[attr-defined]
+    except AttributeError:
+        return
+    raise AssertionError(
+        "Accessing an unknown attribute on octave_mcp.core.ast_nodes must raise "
+        "AttributeError, not silently succeed."
+    )

--- a/tests/unit/core/grammar/test_visitor.py
+++ b/tests/unit/core/grammar/test_visitor.py
@@ -1,0 +1,218 @@
+"""Tests for the CST visitor protocol (ADR-0006 SR1-T1 Step 4).
+
+This module pins the Step-4 scaffold for ``octave_mcp.core.grammar.visitor``.
+The full visitor consumer arrives at logical-Step 5 (emitter rewrite); this
+step delivers just enough surface for Step 5 to consume without re-touching
+the visitor file.
+
+The scaffold provides:
+
+* ``Visitor[T]`` — a generic ``typing.Protocol`` with ``visit_section``,
+  ``visit_block``, ``visit_assignment``, ``visit_document`` methods and a
+  fallback ``visit`` dispatcher.
+* ``SymmetricVisitor[T]`` — a mixin that asserts emit-after-parse round-trip
+  in debug builds only (``__debug__`` gated). Step 5 wires the assertion to
+  the rewritten emitter.
+
+See ``docs/adr/adr-0006-sr1-t1-grammar-core-design.md`` §2.2 ("visitor.py
+— Visitor[T] protocol; SymmetricVisitor mixin").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Visitor protocol surface exists and is importable
+# ---------------------------------------------------------------------------
+
+
+def test_visitor_protocol_is_importable() -> None:
+    from octave_mcp.core.grammar.visitor import Visitor  # noqa: F401
+
+
+def test_symmetric_visitor_mixin_is_importable() -> None:
+    from octave_mcp.core.grammar.visitor import SymmetricVisitor  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Visitor[T] is a Protocol with the expected method names
+# ---------------------------------------------------------------------------
+
+
+def test_visitor_protocol_declares_visit_section() -> None:
+    from octave_mcp.core.grammar.visitor import Visitor
+
+    assert hasattr(Visitor, "visit_section"), "Visitor protocol must declare visit_section"
+
+
+def test_visitor_protocol_declares_visit_block() -> None:
+    from octave_mcp.core.grammar.visitor import Visitor
+
+    assert hasattr(Visitor, "visit_block"), "Visitor protocol must declare visit_block"
+
+
+def test_visitor_protocol_declares_visit_assignment() -> None:
+    from octave_mcp.core.grammar.visitor import Visitor
+
+    assert hasattr(Visitor, "visit_assignment"), "Visitor protocol must declare visit_assignment"
+
+
+def test_visitor_protocol_declares_visit_document() -> None:
+    from octave_mcp.core.grammar.visitor import Visitor
+
+    assert hasattr(Visitor, "visit_document"), "Visitor protocol must declare visit_document"
+
+
+def test_visitor_protocol_declares_fallback_visit_dispatcher() -> None:
+    from octave_mcp.core.grammar.visitor import Visitor
+
+    assert hasattr(Visitor, "visit"), "Visitor protocol must declare a fallback visit() dispatcher"
+
+
+# ---------------------------------------------------------------------------
+# A concrete identity visitor traverses a small Document and returns it
+# unchanged (proves the protocol is consumable, not dead code).
+# ---------------------------------------------------------------------------
+
+
+def test_identity_visitor_traverses_document_unchanged() -> None:
+    from octave_mcp.core.grammar.cst import (
+        Assignment,
+        ASTNode,
+        Block,
+        Document,
+        NodeKind,
+        Section,
+    )
+    from octave_mcp.core.grammar.visitor import Visitor
+
+    class IdentityVisitor:
+        """Concrete visitor that returns each node unchanged.
+
+        This proves the Visitor[ASTNode] protocol is structurally usable
+        without forcing a particular dispatch implementation.
+        """
+
+        def visit_assignment(self, node: Assignment) -> ASTNode:
+            return node
+
+        def visit_block(self, node: Block) -> ASTNode:
+            return node
+
+        def visit_section(self, node: Section) -> ASTNode:
+            return node
+
+        def visit_document(self, node: Document) -> ASTNode:
+            return node
+
+        def visit(self, node: ASTNode) -> ASTNode:
+            kind = node.kind
+            if kind is NodeKind.ASSIGNMENT:
+                return self.visit_assignment(node)  # type: ignore[arg-type]
+            if kind is NodeKind.BLOCK:
+                return self.visit_block(node)  # type: ignore[arg-type]
+            if kind is NodeKind.SECTION:
+                return self.visit_section(node)  # type: ignore[arg-type]
+            if kind is NodeKind.DOCUMENT:
+                return self.visit_document(node)  # type: ignore[arg-type]
+            return node
+
+    visitor: Visitor[ASTNode] = IdentityVisitor()
+
+    doc = Document(
+        name="DOC",
+        sections=[
+            Assignment(key="K", value=1),
+            Block(key="B", children=[Assignment(key="K2", value=2)]),
+            Section(section_id="1", key="S"),
+        ],
+    )
+
+    result = visitor.visit(doc)
+    assert result is doc, "Identity visitor must return the same object"
+    # Confirm each child can be dispatched
+    for child in doc.sections:
+        out = visitor.visit(child)
+        assert out is child
+
+
+# ---------------------------------------------------------------------------
+# SymmetricVisitor mixin — minimal scaffold consumable by Step 5
+# ---------------------------------------------------------------------------
+
+
+def test_symmetric_visitor_can_be_subclassed() -> None:
+    """SymmetricVisitor is a mixin; subclassing must succeed without args."""
+    from octave_mcp.core.grammar.visitor import SymmetricVisitor
+
+    class MyEmitter(SymmetricVisitor[str]):
+        def visit_assignment(self, node: Any) -> str:
+            return ""
+
+        def visit_block(self, node: Any) -> str:
+            return ""
+
+        def visit_section(self, node: Any) -> str:
+            return ""
+
+        def visit_document(self, node: Any) -> str:
+            return ""
+
+        def visit(self, node: Any) -> str:
+            return ""
+
+    emitter = MyEmitter()
+    assert emitter is not None
+
+
+def test_symmetric_visitor_exposes_assert_round_trip_hook() -> None:
+    """Step 5's emitter rewrite will call into a round-trip assertion hook.
+
+    The scaffold must expose a callable surface that Step 5 can override or
+    consume. The exact assertion mechanism is Step-5 work; here we only pin
+    that the surface exists so Step 5 does not re-touch this file.
+    """
+    from octave_mcp.core.grammar.visitor import SymmetricVisitor
+
+    assert hasattr(SymmetricVisitor, "assert_round_trip"), (
+        "SymmetricVisitor must expose assert_round_trip() so Step 5's emitter "
+        "rewrite can hook the parse↔emit symmetry check without re-touching visitor.py"
+    )
+
+
+def test_symmetric_visitor_assert_round_trip_is_debug_gated() -> None:
+    """The assertion is debug-only — in __debug__=False (python -O) it MUST
+    short-circuit to a no-op so production callers pay no overhead.
+
+    We can't easily flip __debug__ at runtime, but we CAN call the method
+    with mismatched inputs in a __debug__=True context and verify the
+    contract: either it asserts in debug mode, or no-ops in non-debug mode.
+    Either path is acceptable; what's NOT acceptable is raising in a
+    non-debug build. Since the test runner runs with __debug__=True, we
+    pin only that the method exists and is callable.
+    """
+    from octave_mcp.core.grammar.cst import Document
+    from octave_mcp.core.grammar.visitor import SymmetricVisitor
+
+    class _ConcreteSV(SymmetricVisitor[str]):
+        def visit_assignment(self, node: Any) -> str:
+            return ""
+
+        def visit_block(self, node: Any) -> str:
+            return ""
+
+        def visit_section(self, node: Any) -> str:
+            return ""
+
+        def visit_document(self, node: Any) -> str:
+            return ""
+
+        def visit(self, node: Any) -> str:
+            return ""
+
+    sv = _ConcreteSV()
+    # Calling assert_round_trip on matching baseline=canonical inputs MUST
+    # always succeed (it's a no-op when they agree, regardless of debug flag).
+    doc = Document()
+    sv.assert_round_trip(doc, source="x", emitted="x")  # must not raise

--- a/tests/unit/test_at_operator.py
+++ b/tests/unit/test_at_operator.py
@@ -105,7 +105,7 @@ class TestAtOperatorParser:
         assignment = doc.sections[0]
         assert assignment.key == "REFS"
         # List should contain @ expressions
-        from octave_mcp.core.ast_nodes import ListValue
+        from octave_mcp.core.grammar.cst import ListValue
 
         assert isinstance(assignment.value, ListValue)
         assert len(assignment.value.items) == 2

--- a/tests/unit/test_block_inheritance.py
+++ b/tests/unit/test_block_inheritance.py
@@ -23,7 +23,7 @@ class TestBlockTargetParsing:
         Input: RISKS[->RISK_LOG]:
         Expected: Block node with key="RISKS" and target="RISK_LOG"
         """
-        from octave_mcp.core.ast_nodes import Block
+        from octave_mcp.core.grammar.cst import Block
 
         doc = parse("""
 ===TEST===
@@ -51,7 +51,7 @@ RISKS[->RISK_LOG]:
         Input: DATA[->INDEXER]:  (section marker implicit in -> syntax)
         Expected: Block.target == "INDEXER"
         """
-        from octave_mcp.core.ast_nodes import Block
+        from octave_mcp.core.grammar.cst import Block
 
         doc = parse("""
 ===TEST===
@@ -77,7 +77,7 @@ DATA[->INDEXER]:
         Input: SIMPLE:
         Expected: Block.target is None
         """
-        from octave_mcp.core.ast_nodes import Block
+        from octave_mcp.core.grammar.cst import Block
 
         doc = parse("""
 ===TEST===
@@ -109,7 +109,7 @@ SIMPLE:
           - OUTER.target == "OUTER_TARGET"
           - INNER.target == "INNER_TARGET"
         """
-        from octave_mcp.core.ast_nodes import Block
+        from octave_mcp.core.grammar.cst import Block
 
         doc = parse("""
 ===TEST===
@@ -241,7 +241,7 @@ class TestBlockInheritanceIntegration:
 
         Expected: CRITICAL field routes to RISK_LOG
         """
-        from octave_mcp.core.ast_nodes import Assignment, Block
+        from octave_mcp.core.grammar.cst import Assignment, Block
         from octave_mcp.core.schema_extractor import (
             InheritanceResolver,
         )

--- a/tests/unit/test_block_inheritance_validation.py
+++ b/tests/unit/test_block_inheritance_validation.py
@@ -9,7 +9,7 @@ are used during validation to route fields without explicit targets.
 TDD RED phase: Tests should FAIL until fixes are implemented.
 """
 
-from octave_mcp.core.ast_nodes import Block
+from octave_mcp.core.grammar.cst import Block
 from octave_mcp.core.holographic import parse_holographic_pattern
 from octave_mcp.core.parser import parse
 from octave_mcp.core.schema_extractor import (

--- a/tests/unit/test_eject_conversion.py
+++ b/tests/unit/test_eject_conversion.py
@@ -5,7 +5,7 @@ _ast_to_markdown, and _block_to_markdown functions.
 Targets coverage of eject.py lines 40-41, 58, 72-80, 111-114, 127-133.
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, InlineMap, ListValue
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, InlineMap, ListValue
 from octave_mcp.mcp.eject import (
     _ast_to_dict,
     _ast_to_markdown,

--- a/tests/unit/test_eject_sections.py
+++ b/tests/unit/test_eject_sections.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, ListValue, Section
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, ListValue, Section
 from octave_mcp.mcp.eject import EjectTool, _ast_to_dict, _convert_section
 
 # --- Unit tests for _convert_section ---

--- a/tests/unit/test_emitter.py
+++ b/tests/unit/test_emitter.py
@@ -11,8 +11,8 @@ Tests AST → canonical OCTAVE string emission with:
 
 import pytest
 
-from octave_mcp.core.ast_nodes import Absent, Assignment, Block, Document, InlineMap, ListValue
 from octave_mcp.core.emitter import FormatOptions, emit, emit_meta, emit_value, needs_quotes
+from octave_mcp.core.grammar.cst import Absent, Assignment, Block, Document, InlineMap, ListValue
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_format_options.py
+++ b/tests/unit/test_format_options.py
@@ -9,8 +9,8 @@ Tests cover:
 4. key_sorting - Optionally sort keys alphabetically within blocks
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, Section
 from octave_mcp.core.emitter import FormatOptions, emit
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, Section
 
 
 class TestFormatOptionsDataclass:

--- a/tests/unit/test_format_style.py
+++ b/tests/unit/test_format_style.py
@@ -23,7 +23,8 @@ import tempfile
 
 import pytest
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import (
     Assignment,
     Block,
     Comment,
@@ -32,7 +33,6 @@ from octave_mcp.core.ast_nodes import (
     ListValue,
     Section,
 )
-from octave_mcp.core.emitter import emit
 from octave_mcp.core.parser import parse
 from octave_mcp.mcp.write import (
     E_AST_CYCLE,

--- a/tests/unit/test_gh246_numbered_key_in_list.py
+++ b/tests/unit/test_gh246_numbered_key_in_list.py
@@ -8,8 +8,8 @@ This is a violation of I1 (Syntactic Fidelity) and I3 (Mirror Constraint) when
 the canonicaliser splits numbered-key items into separate tokens.
 """
 
-from octave_mcp.core.ast_nodes import InlineMap, ListValue
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import InlineMap, ListValue
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_gh261_bracket_annotation_after_flow.py
+++ b/tests/unit/test_gh261_bracket_annotation_after_flow.py
@@ -9,7 +9,7 @@ ROOT CAUSE:
 TDD: RED phase — tests define expected behavior before the fix is applied.
 """
 
-from octave_mcp.core.ast_nodes import Assignment, ListValue
+from octave_mcp.core.grammar.cst import Assignment, ListValue
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_gh269_annotated_identifier_coalescing.py
+++ b/tests/unit/test_gh269_annotated_identifier_coalescing.py
@@ -7,7 +7,7 @@ It should produce two separate values (ListValue), NOT one coalesced string.
 This preserves I1::SYNTACTIC_FIDELITY — normalization must not alter semantics.
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, ListValue
+from octave_mcp.core.grammar.cst import Assignment, Block, ListValue
 from octave_mcp.core.parser import parse, parse_with_warnings
 
 

--- a/tests/unit/test_gh310_pattern_regex_quotes.py
+++ b/tests/unit/test_gh310_pattern_regex_quotes.py
@@ -10,8 +10,8 @@ I4 (TRANSFORM_AUDITABILITY): Auto-quoting bare values must be logged.
 TDD: RED phase - these tests define the expected behavior before implementation.
 """
 
-from octave_mcp.core.ast_nodes import Assignment
 from octave_mcp.core.emitter import emit, emit_assignment
+from octave_mcp.core.grammar.cst import Assignment
 from octave_mcp.core.parser import parse, parse_with_warnings
 
 

--- a/tests/unit/test_gh357_deep_section_indentation.py
+++ b/tests/unit/test_gh357_deep_section_indentation.py
@@ -13,8 +13,8 @@ coverage gap: prior to GH#357, zero tests covered Section nodes with deeply
 nested blocks, leaving the codebase vulnerable to silent regressions.
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, Section
 from octave_mcp.core.emitter import emit, emit_section
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, Section
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_grammar_sentinel.py
+++ b/tests/unit/test_grammar_sentinel.py
@@ -11,8 +11,8 @@ This enables:
 - Schema version binding
 """
 
-from octave_mcp.core.ast_nodes import Document
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Document
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_holographic_pattern.py
+++ b/tests/unit/test_holographic_pattern.py
@@ -474,7 +474,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_returns_holographic_value_for_simple_pattern(self):
         """Parser should return HolographicValue for ["example"∧REQ→§SELF]."""
-        from octave_mcp.core.ast_nodes import Assignment, HolographicValue
+        from octave_mcp.core.grammar.cst import Assignment, HolographicValue
         from octave_mcp.core.parser import parse
 
         doc = parse('===TEST===\nID::["abc123"∧REQ→§INDEXER]\n===END===')
@@ -486,7 +486,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_returns_holographic_value_with_constraint_chain(self):
         """Parser should return HolographicValue with constraint chain."""
-        from octave_mcp.core.ast_nodes import Assignment, HolographicValue
+        from octave_mcp.core.grammar.cst import Assignment, HolographicValue
         from octave_mcp.core.parser import parse
 
         doc = parse('===TEST===\nSTATUS::["ACTIVE"∧REQ∧ENUM[ACTIVE,DRAFT]→§INDEXER]\n===END===')
@@ -501,7 +501,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_returns_holographic_value_without_target(self):
         """Parser should return HolographicValue without target (target optional)."""
-        from octave_mcp.core.ast_nodes import Assignment, HolographicValue
+        from octave_mcp.core.grammar.cst import Assignment, HolographicValue
         from octave_mcp.core.parser import parse
 
         doc = parse('===TEST===\nVALUE::["test"∧REQ]\n===END===')
@@ -514,7 +514,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_returns_list_value_for_non_holographic(self):
         """Parser should return ListValue for regular lists without holographic operators."""
-        from octave_mcp.core.ast_nodes import Assignment, ListValue
+        from octave_mcp.core.grammar.cst import Assignment, ListValue
         from octave_mcp.core.parser import parse
 
         doc = parse("===TEST===\nITEMS::[a, b, c]\n===END===")
@@ -526,7 +526,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_holographic_with_numeric_example(self):
         """Parser should handle holographic pattern with numeric example."""
-        from octave_mcp.core.ast_nodes import HolographicValue
+        from octave_mcp.core.grammar.cst import HolographicValue
         from octave_mcp.core.parser import parse
 
         doc = parse("===TEST===\nCOUNT::[42∧REQ∧RANGE[0,100]→§SELF]\n===END===")
@@ -540,7 +540,7 @@ class TestParserHolographicIntegration:
         Note: TYPE(X) constraints use parentheses which the lexer doesn't support.
         Using simpler constraints that the lexer understands.
         """
-        from octave_mcp.core.ast_nodes import HolographicValue
+        from octave_mcp.core.grammar.cst import HolographicValue
         from octave_mcp.core.parser import parse
 
         # Simplified pattern without TYPE(LIST) since lexer doesn't support parentheses
@@ -551,7 +551,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_holographic_preserves_raw_pattern(self):
         """Parser should preserve raw pattern string for I1 fidelity."""
-        from octave_mcp.core.ast_nodes import HolographicValue
+        from octave_mcp.core.grammar.cst import HolographicValue
         from octave_mcp.core.parser import parse
 
         doc = parse('===TEST===\nID::["abc123"∧REQ→§INDEXER]\n===END===')
@@ -563,7 +563,7 @@ class TestParserHolographicIntegration:
 
     def test_parser_holographic_in_block_context(self):
         """Parser should recognize holographic patterns inside blocks."""
-        from octave_mcp.core.ast_nodes import Assignment, Block, HolographicValue
+        from octave_mcp.core.grammar.cst import Assignment, Block, HolographicValue
         from octave_mcp.core.parser import parse
 
         content = """===TEST===
@@ -589,7 +589,7 @@ FIELDS:
 
     def test_parser_holographic_with_ascii_arrow(self):
         """Parser should handle ASCII arrow variant (->§) in holographic patterns."""
-        from octave_mcp.core.ast_nodes import HolographicValue
+        from octave_mcp.core.grammar.cst import HolographicValue
         from octave_mcp.core.parser import parse
 
         doc = parse('===TEST===\nID::["abc123"∧REQ->§INDEXER]\n===END===')
@@ -599,7 +599,7 @@ FIELDS:
 
     def test_parser_distinguishes_holographic_from_inline_map(self):
         """Parser should distinguish holographic from inline map [k::v]."""
-        from octave_mcp.core.ast_nodes import InlineMap, ListValue
+        from octave_mcp.core.grammar.cst import InlineMap, ListValue
         from octave_mcp.core.parser import parse
 
         # Inline map pattern: [k::v]

--- a/tests/unit/test_hydrator.py
+++ b/tests/unit/test_hydrator.py
@@ -381,7 +381,7 @@ META:
         reparsed = parse(output)
 
         # Find SNAPSHOT in reparsed doc
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         reparsed_snapshot = None
         for section in reparsed.sections:
@@ -552,7 +552,7 @@ class TestPrunedGeneration:
         terms = _get_field_value(pruned, "TERMS")
         # Should be empty list when all terms are used
         if terms is not None:
-            from octave_mcp.core.ast_nodes import ListValue
+            from octave_mcp.core.grammar.cst import ListValue
 
             if isinstance(terms, ListValue):
                 assert len(terms.items) == 0
@@ -574,7 +574,7 @@ class TestHydrationOutput:
         result = hydrate(source_path, registry, policy)
 
         # §1::CONTENT should still exist
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         content_section = None
         for section in result.sections:
@@ -1980,7 +1980,7 @@ def _create_test_registry():
 
 def _find_snapshot_section(doc):
     """Find §CONTEXT::SNAPSHOT section in document."""
-    from octave_mcp.core.ast_nodes import Section
+    from octave_mcp.core.grammar.cst import Section
 
     for section in doc.sections:
         if isinstance(section, Section):
@@ -1991,7 +1991,7 @@ def _find_snapshot_section(doc):
 
 def _find_manifest_section(doc):
     """Find §SNAPSHOT::MANIFEST section in document."""
-    from octave_mcp.core.ast_nodes import Section
+    from octave_mcp.core.grammar.cst import Section
 
     for section in doc.sections:
         if isinstance(section, Section):
@@ -2002,7 +2002,7 @@ def _find_manifest_section(doc):
 
 def _find_pruned_section(doc):
     """Find §SNAPSHOT::PRUNED section in document."""
-    from octave_mcp.core.ast_nodes import Section
+    from octave_mcp.core.grammar.cst import Section
 
     for section in doc.sections:
         if isinstance(section, Section):
@@ -2013,7 +2013,7 @@ def _find_pruned_section(doc):
 
 def _find_child_block(section, name: str):
     """Find a child block within a section."""
-    from octave_mcp.core.ast_nodes import Block
+    from octave_mcp.core.grammar.cst import Block
 
     for child in section.children:
         if isinstance(child, Block) and child.key == name:
@@ -2023,7 +2023,7 @@ def _find_child_block(section, name: str):
 
 def _get_snapshot_terms(snapshot_section) -> dict:
     """Get terms from a SNAPSHOT section."""
-    from octave_mcp.core.ast_nodes import Assignment
+    from octave_mcp.core.grammar.cst import Assignment
 
     terms = {}
     for child in snapshot_section.children:
@@ -2040,7 +2040,7 @@ def _get_term_definition(snapshot_section, term_name: str):
 
 def _get_field_value(section_or_block, field_name: str):
     """Get a field value from section or block."""
-    from octave_mcp.core.ast_nodes import Assignment
+    from octave_mcp.core.grammar.cst import Assignment
 
     for child in section_or_block.children:
         if isinstance(child, Assignment) and child.key == field_name:

--- a/tests/unit/test_i2_deterministic_absence.py
+++ b/tests/unit/test_i2_deterministic_absence.py
@@ -14,8 +14,8 @@ This test module verifies the tri-state distinction:
 TDD Phase: RED - These tests should fail until I2 is implemented.
 """
 
-from octave_mcp.core.ast_nodes import Absent, Assignment, Document, ListValue
 from octave_mcp.core.emitter import emit, emit_value
+from octave_mcp.core.grammar.cst import Absent, Assignment, Document, ListValue
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_literal_zones_ast.py
+++ b/tests/unit/test_literal_zones_ast.py
@@ -7,7 +7,7 @@ T01: Verifies dataclass construction, field access, equality, and the D1
 constraint that LiteralZoneValue is NOT an ASTNode subclass.
 """
 
-from octave_mcp.core.ast_nodes import ASTNode, LiteralZoneValue
+from octave_mcp.core.grammar.cst import ASTNode, LiteralZoneValue
 
 
 class TestLiteralZoneValueConstruction:

--- a/tests/unit/test_literal_zones_constraints.py
+++ b/tests/unit/test_literal_zones_constraints.py
@@ -12,13 +12,13 @@ Tests cover:
 - Existing constraint parsing regressions still pass
 """
 
-from octave_mcp.core.ast_nodes import LiteralZoneValue
 from octave_mcp.core.constraints import (
     ConstraintChain,
     LangConstraint,
     LiteralConstraint,
     RequiredConstraint,
 )
+from octave_mcp.core.grammar.cst import LiteralZoneValue
 
 # ---------------------------------------------------------------------------
 # LiteralConstraint tests

--- a/tests/unit/test_literal_zones_emitter.py
+++ b/tests/unit/test_literal_zones_emitter.py
@@ -6,8 +6,8 @@ including round-trip fidelity with the parser.
 GH#346: Tests for literal zone fence indentation in emit_meta().
 """
 
-from octave_mcp.core.ast_nodes import Assignment, LiteralZoneValue
 from octave_mcp.core.emitter import emit, emit_assignment, emit_meta, emit_value
+from octave_mcp.core.grammar.cst import Assignment, LiteralZoneValue
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_literal_zones_parser.py
+++ b/tests/unit/test_literal_zones_parser.py
@@ -7,7 +7,7 @@ import unicodedata
 
 import pytest
 
-from octave_mcp.core.ast_nodes import Assignment, LiteralZoneValue
+from octave_mcp.core.grammar.cst import Assignment, LiteralZoneValue
 from octave_mcp.core.parser import parse
 
 

--- a/tests/unit/test_literal_zones_passthrough.py
+++ b/tests/unit/test_literal_zones_passthrough.py
@@ -7,12 +7,12 @@ unchanged) in all value-type dispatch paths:
 - repair.py: _repair_ast_node() logs literal zone in audit but never modifies
 """
 
-from octave_mcp.core.ast_nodes import (
+from octave_mcp.core.constraints import ConstraintChain, EnumConstraint
+from octave_mcp.core.grammar.cst import (
     Assignment,
     Document,
     LiteralZoneValue,
 )
-from octave_mcp.core.constraints import ConstraintChain, EnumConstraint
 from octave_mcp.core.holographic import HolographicPattern
 from octave_mcp.core.projector import project
 from octave_mcp.core.repair import _repair_ast_node, repair, repair_value

--- a/tests/unit/test_literal_zones_roundtrip.py
+++ b/tests/unit/test_literal_zones_roundtrip.py
@@ -9,8 +9,8 @@ from B0-S1 (A8 assumption validation).
 
 import pytest
 
-from octave_mcp.core.ast_nodes import LiteralZoneValue
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import LiteralZoneValue
 from octave_mcp.core.lexer import LexerError
 from octave_mcp.core.parser import parse
 

--- a/tests/unit/test_literal_zones_validator.py
+++ b/tests/unit/test_literal_zones_validator.py
@@ -11,7 +11,7 @@ Tests cover:
 - I5 compliance: literal_zones_validated is always False in validator output
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document, InlineMap, ListValue, LiteralZoneValue
+from octave_mcp.core.grammar.cst import Assignment, Block, Document, InlineMap, ListValue, LiteralZoneValue
 from octave_mcp.core.validator import Validator, _count_literal_zones
 
 # ---------------------------------------------------------------------------
@@ -111,7 +111,7 @@ class TestToPythonValueLiteralZone:
 
     def test_to_python_value_existing_list_value_still_works(self):
         """_to_python_value still converts ListValue to list (regression)."""
-        from octave_mcp.core.ast_nodes import ListValue
+        from octave_mcp.core.grammar.cst import ListValue
 
         validator = Validator()
         lv = ListValue(items=["a", "b"])

--- a/tests/unit/test_literal_zones_write.py
+++ b/tests/unit/test_literal_zones_write.py
@@ -16,8 +16,8 @@ import tempfile
 
 import pytest
 
-from octave_mcp.core.ast_nodes import LiteralZoneValue
 from octave_mcp.core.emitter import is_absent, needs_quotes
+from octave_mcp.core.grammar.cst import LiteralZoneValue
 from octave_mcp.core.parser import parse
 from octave_mcp.core.validator import _count_literal_zones
 from octave_mcp.mcp.write import WriteTool, _normalize_value_for_ast
@@ -392,12 +392,12 @@ def _find_literal_zone_content(doc_text: str, key: str = "CODE") -> str:
     assert matching, f"No literal zone with key={key!r} found in parsed document"
     # Re-extract the LiteralZoneValue from the parsed document directly.
     # Walk the AST to find the assignment with the given key.
-    from octave_mcp.core.ast_nodes import Assignment, Block
+    from octave_mcp.core.grammar.cst import Assignment, Block
 
     def _find(nodes: list) -> str | None:
         for node in nodes:
             if isinstance(node, Assignment) and node.key == key:
-                from octave_mcp.core.ast_nodes import LiteralZoneValue as LZV
+                from octave_mcp.core.grammar.cst import LiteralZoneValue as LZV
 
                 if isinstance(node.value, LZV):
                     return node.value.content
@@ -574,7 +574,7 @@ class TestIssue259LiteralZoneInBlockValue:
         Issue #259 RED: TEMPLATE: followed by a fence currently produces an
         empty Block node (children=[]) — the LiteralZoneValue is never parsed.
         """
-        from octave_mcp.core.ast_nodes import Assignment, Block, Section
+        from octave_mcp.core.grammar.cst import Assignment, Block, Section
         from octave_mcp.core.parser import parse as octave_parse
 
         doc = octave_parse(_DOC_BLOCK_WITH_LITERAL_ZONE)

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -6,7 +6,7 @@ and nested block structure.
 
 import pytest
 
-from octave_mcp.core.ast_nodes import Assignment, Block, ListValue
+from octave_mcp.core.grammar.cst import Assignment, Block, ListValue
 from octave_mcp.core.lexer import LexerError
 from octave_mcp.core.parser import ParserError, parse, parse_with_warnings
 

--- a/tests/unit/test_parser_bare_lines.py
+++ b/tests/unit/test_parser_bare_lines.py
@@ -10,7 +10,7 @@ Test Strategy:
 3. Create foundation for multi-word value tests (issues #63, #66)
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block
+from octave_mcp.core.grammar.cst import Assignment, Block
 from octave_mcp.core.parser import parse, parse_with_warnings
 
 

--- a/tests/unit/test_parser_duplicate_keys.py
+++ b/tests/unit/test_parser_duplicate_keys.py
@@ -161,7 +161,7 @@ PATTERNS::[PATTERN::"first", PATTERN::"second"]
         assert len(items) == 2, f"Both items must be preserved, got {len(items)}"
 
         # Verify each item has the correct value
-        from octave_mcp.core.ast_nodes import InlineMap
+        from octave_mcp.core.grammar.cst import InlineMap
 
         assert isinstance(items[0], InlineMap)
         assert isinstance(items[1], InlineMap)

--- a/tests/unit/test_parser_siblings.py
+++ b/tests/unit/test_parser_siblings.py
@@ -11,8 +11,8 @@ the innermost block.
 TDD: RED phase - these tests must FAIL before implementation.
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Assignment, Block
 from octave_mcp.core.parser import parse
 
 
@@ -248,7 +248,7 @@ SIBLING_BLOCK:
         )
 
         # First should be Section marker
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         assert isinstance(doc.sections[0], Section), f"Expected Section, got {type(doc.sections[0])}"
         assert doc.sections[0].key == "info" or doc.sections[0].section_id == "CONTEXT"
@@ -272,7 +272,7 @@ SIBLING_ASSIGNMENT::at_root
         ), f"Expected 2 sections, got {len(doc.sections)}: {[getattr(s, 'key', str(s)) for s in doc.sections]}"
 
         # First is Section marker
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         assert isinstance(doc.sections[0], Section)
         assert doc.sections[0].section_id == "1"
@@ -295,7 +295,7 @@ SIBLING_BLOCK:
         # Should have 2 top-level sections
         assert len(doc.sections) == 2, f"Expected 2 sections, got {len(doc.sections)}"
 
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         assert isinstance(doc.sections[0], Section)
         assert isinstance(doc.sections[1], Block)
@@ -316,7 +316,7 @@ SIBLING_BLOCK:
         # Should have 3 top-level section markers
         assert len(doc.sections) == 3, f"Expected 3 sections, got {len(doc.sections)}"
 
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         for i, section in enumerate(doc.sections, start=1):
             assert isinstance(section, Section), f"Section {i} should be Section, got {type(section)}"

--- a/tests/unit/test_policy_enforcement.py
+++ b/tests/unit/test_policy_enforcement.py
@@ -14,7 +14,7 @@ REQUIRED_IN_SCHEMA::[
 ]
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document
+from octave_mcp.core.grammar.cst import Assignment, Block, Document
 from octave_mcp.core.holographic import parse_holographic_pattern
 from octave_mcp.core.parser import parse
 from octave_mcp.core.schema_extractor import (

--- a/tests/unit/test_pr361_review_fixes.py
+++ b/tests/unit/test_pr361_review_fixes.py
@@ -14,7 +14,7 @@ import os
 
 import pytest
 
-from octave_mcp.core.ast_nodes import Comment
+from octave_mcp.core.grammar.cst import Comment
 from octave_mcp.core.parser import parse_with_warnings
 from octave_mcp.mcp.write import WriteTool, _all_section_marks_quoted, _auto_quote_section_refs_in_values
 

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -14,7 +14,7 @@ Design decisions from debate-hall synthesis:
 import hashlib
 from datetime import datetime
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document
+from octave_mcp.core.grammar.cst import Assignment, Block, Document
 from octave_mcp.core.holographic import parse_holographic_pattern
 from octave_mcp.core.routing import RoutingEntry, RoutingLog
 from octave_mcp.core.schema_extractor import FieldDefinition, SchemaDefinition

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -90,7 +90,7 @@ META:
         In Python, isinstance(True, (int, float)) returns True because bool inherits from int.
         This test ensures the validator explicitly rejects booleans for NUMBER type.
         """
-        from octave_mcp.core.ast_nodes import Document
+        from octave_mcp.core.grammar.cst import Document
 
         schema = {"META": {"fields": {"COUNT": {"type": "NUMBER"}}}}
 

--- a/tests/unit/test_schema_extractor.py
+++ b/tests/unit/test_schema_extractor.py
@@ -579,7 +579,7 @@ FIELDS:
         2. SchemaDefinition.default_target set
         3. Validator uses default_target for fields without explicit target
         """
-        from octave_mcp.core.ast_nodes import Assignment, Block, Document
+        from octave_mcp.core.grammar.cst import Assignment, Block, Document
         from octave_mcp.core.schema_extractor import extract_schema_from_document
         from octave_mcp.core.validator import Validator
 

--- a/tests/unit/test_sealer.py
+++ b/tests/unit/test_sealer.py
@@ -114,7 +114,7 @@ META:
 
     def test_seal_document_seal_has_required_fields(self):
         """SEAL section should have SCOPE, ALGORITHM, HASH."""
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
         from octave_mcp.core.parser import parse
         from octave_mcp.core.sealer import seal_document
 
@@ -142,7 +142,7 @@ META:
 
     def test_seal_document_preserves_grammar_version(self):
         """Sealed document should include GRAMMAR if source has grammar_version."""
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
         from octave_mcp.core.parser import parse
         from octave_mcp.core.sealer import seal_document
 
@@ -211,7 +211,7 @@ META:
 
     def test_verify_seal_returns_invalid_for_tampered(self):
         """verify_seal should return INVALID for tampered document."""
-        from octave_mcp.core.ast_nodes import Assignment
+        from octave_mcp.core.grammar.cst import Assignment
         from octave_mcp.core.parser import parse
         from octave_mcp.core.sealer import SealStatus, seal_document, verify_seal
 

--- a/tests/unit/test_section_parsing.py
+++ b/tests/unit/test_section_parsing.py
@@ -4,8 +4,8 @@ Tests that § section markers are preserved during parsing and emission,
 maintaining document hierarchy structure.
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Assignment, Block
 from octave_mcp.core.parser import parse
 
 
@@ -262,7 +262,7 @@ SIBLING::value
 
         # Second child: nested §1.1 section
         child_section = parent.children[1]
-        from octave_mcp.core.ast_nodes import Section
+        from octave_mcp.core.grammar.cst import Section
 
         assert isinstance(child_section, Section)
         assert child_section.section_id == "1.1"

--- a/tests/unit/test_validator_section.py
+++ b/tests/unit/test_validator_section.py
@@ -15,7 +15,7 @@ PHASE 2 (Bug fix): Wire section_schemas through Validator.validate()
 - Pass to _validate_section
 """
 
-from octave_mcp.core.ast_nodes import Assignment, Block, Document
+from octave_mcp.core.grammar.cst import Assignment, Block, Document
 from octave_mcp.core.holographic import parse_holographic_pattern
 from octave_mcp.core.schema_extractor import FieldDefinition, SchemaDefinition
 from octave_mcp.core.validator import Validator

--- a/tests/unit/test_variable_syntax.py
+++ b/tests/unit/test_variable_syntax.py
@@ -13,8 +13,8 @@ TDD: These tests are written FIRST (RED phase) before implementation.
 
 import pytest
 
-from octave_mcp.core.ast_nodes import Assignment, ListValue
 from octave_mcp.core.emitter import emit
+from octave_mcp.core.grammar.cst import Assignment, ListValue
 from octave_mcp.core.lexer import LexerError, TokenType, tokenize
 from octave_mcp.core.parser import parse, parse_with_warnings
 

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -2088,7 +2088,7 @@ KEY::value
         This directly tests the normalization function to verify it converts
         dicts to proper AST structures.
         """
-        from octave_mcp.core.ast_nodes import Block, InlineMap
+        from octave_mcp.core.grammar.cst import Block, InlineMap
         from octave_mcp.mcp.write import _normalize_value_for_ast
 
         # Test simple nested dict
@@ -5241,7 +5241,7 @@ class TestGH369NestedBlockChangePathResolution:
         same level. This is the safety net against any future writer regression
         and supports I5 (Schema Sovereignty: validation status visible).
         """
-        from octave_mcp.core.ast_nodes import Assignment, Block, Document, ListValue
+        from octave_mcp.core.grammar.cst import Assignment, Block, Document, ListValue
         from octave_mcp.core.validator import Validator
 
         # Construct an AST representing the corruption pattern directly so the


### PR DESCRIPTION
## Summary

Promotes `core/ast_nodes.py` to `core/grammar/cst.py` per ADR-0006 SR1-T1 Step 4 (3rd execution per §3a re-sequencing). Adds `NodeKind` enum, visitor protocol scaffold, and reserved fidelity-preservation fields — without altering the runtime semantics of any existing dataclass.

**Key constraint — reserved, not populated:** The three fidelity-preservation fields (`leading_trivia`, `trailing_trivia`, `was_quoted`) are defaulted to `None` and **NOT populated in this PR**. Population is:
- `was_quoted` → logical-Step 5 (next task) via lexer/parser instrumentation
- `leading_trivia` / `trailing_trivia` → Sprint 3+ (SR3-T1 cursor-CST) per design §3a class-2

No code in this PR reads or writes these fields. They exist purely to lock the schema shape so the later population PRs do not need to re-touch every node and every visitor signature.

## What landed

- **`src/octave_mcp/core/grammar/cst.py`** (new) — promoted dataclasses + `NodeKind` enum (ASSIGNMENT/BLOCK/SECTION/DOCUMENT/COMMENT, one per concrete `ASTNode` subclass) + reserved fidelity fields on the base node. Each subclass sets `kind` via `field(default=..., init=False)` so the ~62 existing call sites pass unchanged.
- **`src/octave_mcp/core/grammar/visitor.py`** (new) — `Visitor[T]` (runtime-checkable Protocol) + `SymmetricVisitor[T]` (debug-gated round-trip assertion mixin with `assert_round_trip` hook for Step 5).
- **`src/octave_mcp/core/ast_nodes.py`** (rewritten) — PEP 562 deprecation shim mirroring PR #393's Step-1 pattern; lazy `__getattr__` emits `DeprecationWarning` on attribute access; symbol identity (`is`) preserved across both paths.
- **`src/octave_mcp/core/grammar/__init__.py`** — re-exports cst + visitor symbols alongside Step 2's `parse` seam.
- **62 internal import sites** rewritten (`from octave_mcp.core.ast_nodes import` → `from octave_mcp.core.grammar.cst import`) across 18 `src/` files and 44 `tests/` files.
- **`tests/unit/core/grammar/test_cst.py`** + **`tests/unit/core/grammar/test_visitor.py`** (new) — 40 tests covering NodeKind coverage, reserved-field defaults, symbol identity across the shim, deprecation warning contract, and visitor protocol surface.

## Quality gates (all green at HEAD)

- **pytest**: 2949 passed, 11 skipped, 10 xfailed (10 strict-xfails preserved unchanged; they flip later at logical-Step 3 per §3a)
- **mypy --strict**: 53 source files, no issues
- **ruff check**: all checks passed
- **black --check**: 182 files unchanged

## Design doc references

- §3 row 4 — the Step 4 migration row.
- §2.2 — `core/grammar/` package layout (cst.py, visitor.py).
- §3a — 2026-05-11 re-sequencing rationale (execution order 1→2→**4**→5→3→6).
- §4.5 G1+G2 — fidelity guardrails for reserved trivia / `was_quoted` fields.

## Scope-fence honoured

- No population of `was_quoted`, `leading_trivia`, or `trailing_trivia`.
- No semantic changes to any existing dataclass.
- No lexer / parser / emitter touch.
- No `core/grammar/entry.py` semantics change.
- No `tests/unit/test_writer_reader_symmetry.py` xfail-set change.
- No CHANGELOG entry (logical-Step 3 PR will own the user-facing v1.12.0 entry).
- No `--no-verify` on commits; conventional commit messages used.

## Test plan

- [x] `uv run pytest` — 2949 passed, 11 skipped, 10 xfailed
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run black --check src/ tests/` — clean
- [x] Symbol identity verified: `ast_nodes.Section is grammar.cst.Section` (and same for every promoted symbol)
- [x] Deprecation warning verified: legacy-path attribute access emits `DeprecationWarning` referencing the new `grammar.cst` location
- [x] 10 strict-xfails behaviourally unchanged
- [ ] T3 review chain (TMG ⊕ CRS ⊕ CE ⊕ CIV) + cubic AI sign-off

## Logical-Step 5 readiness

The visitor scaffold leaves Step 5 the following surfaces to consume without re-touching `visitor.py`:
- `Visitor[T]` Protocol — Step 5's emitter implements `visit_assignment` / `visit_block` / `visit_section` / `visit_document` / `visit`.
- `SymmetricVisitor[T]` mixin — Step 5's rewritten emitter subclasses it and calls `self.assert_round_trip(node, source=..., emitted=...)` inside the emit pipeline. Debug-gated → zero overhead in `-O` builds.
- `NodeKind` discriminator on every concrete node — Step 5's emitter dispatches on `node.kind` instead of `isinstance` chains, replacing `IDENTIFIER_PATTERN` / `ANNOTATION_PATTERN` / `EXPRESSION_PATTERN` regex re-derivations.
- Reserved `was_quoted` on ASTNode base — Step 5's lexer/parser instrumentation populates it; the emitter visitor consults it for the I1 type-fidelity guard (§4.5 G2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promoted AST nodes to `octave_mcp.core.grammar.cst` and added a `NodeKind` discriminator plus a minimal visitor scaffold, without changing runtime behavior. Reserved trivia/quoting fields for future fidelity work and shipped a deprecation shim for the old `octave_mcp.core.ast_nodes` path.

- New Features
  - Promoted node dataclasses to `core/grammar/cst.py`; each concrete node sets `kind: NodeKind`.
  - Reserved `ASTNode` fields: `leading_trivia`, `trailing_trivia`, `was_quoted` (all default `None`, not populated yet).
  - Added `core/grammar/visitor.py` with `Visitor[T]` protocol and `SymmetricVisitor[T]` mixin.
  - Added PEP 562 deprecation shim at `core/ast_nodes.py` (identity-preserving; warns on access).
  - Re-exported symbols via `octave_mcp.core.grammar` for a single import front door.

- Migration
  - Import nodes from `octave_mcp.core.grammar.cst`; the legacy `octave_mcp.core.ast_nodes` still works but emits DeprecationWarning.
  - No behavior changes; reserved fields require no action until they are populated in a later step.

<sup>Written for commit 8d944220c7b9dc1b606a42cf046620cd081992f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

