### PR TITLE
chore(release): prepare v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,45 +5,53 @@ All notable changes to OCTAVE-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.12.0] - 2026-05-11 - "Validator Collapse & Audit-Completeness Closure" Release (ADR-0006 SR1-T1)
 
-### Added — ADR-0006 SR1-T1 Step 6 (validator surface collapse; closes R2)
+This release completes the full ADR-0006 SR1-T1 writer/reader symmetry programme (six steps merged across PRs #393, #394, #395, #396, #397, #398, #399, #400, #401). It single-sources the validator surface (closing North Star Risk **R2**) and enforces I4 (TRANSFORM_AUDITABILITY) at boundary cases by routing every canonical re-emit transformation through a `TIER_NORMALIZATION` receipt.
+
+### ⚠️ Breaking Changes — direct importers of internal API
+
+The MCP tool surface (`octave_validate`, `octave_write`, `octave_eject`, `octave_compile_grammar`) and the CLI are **unchanged**. The break is for Python code that imported internal validator symbols directly.
+
+| Old (≤ 1.11.0) | New (1.12.0+) |
+|---|---|
+| `from octave_mcp.core.schema import validate` | **deleted** — use `Validator(schema).validate(doc)` |
+| `from octave_mcp.core.schema import Schema` | `from octave_mcp.schemas.repository import Schema` |
+| `from octave_mcp.core.validator import validate` *(module-level)* | `Validator(schema).validate(doc, strict=...)` |
+| `from octave_mcp.core.validator import validate_frontmatter` | `from octave_mcp.core.grammar.entry import validate_frontmatter` *(also re-exported from `octave_mcp.core.grammar`)* |
+| `from octave_mcp.core.grammar import compile_grammar` *(legacy module)* | unchanged shim retained — grammar compiler now lives at `octave_mcp.core.grammar_compiler.gbnf`; the old import path emits a DeprecationWarning |
+| `from octave_mcp.core.ast_nodes import …` *(internal node types)* | `from octave_mcp.core.grammar.cst import …` — new `NodeKind`, `Visitor[T]`, and reserved fields (`was_quoted`, `leading_trivia`, `trailing_trivia`) |
+
+Code example:
+
+```python
+# Before (≤ 1.11.0)
+from octave_mcp.core.validator import validate
+errors = validate(doc, schema, strict=True)
+
+# After (1.12.0+)
+from octave_mcp.core.validator import Validator
+errors = Validator(schema).validate(doc, strict=True)
+```
+
+### ⚠️ Breaking Behaviour — RepairLog volume shift (I4 enforcement)
+
+`RepairLog` now records all TIER_NORMALIZATION events. Documents containing trivia normalisation (blank-line stripping, triple-quote collapse, identifier dequoting) that previously produced an empty repair log now produce one or more entries. **This reflects correct behaviour per I4 — pre-1.12.0 silent canonical mutation was an under-reporting bug.**
+
+If your tests or downstream consumers assert `len(repair_log.entries) == 0` (or `len(corrections) == 0`) on such documents, they will now fail. Migration:
+
+- To detect **content normalisation**, filter `corrections` by `tier == "NORMALIZATION"`.
+- To detect **schema repairs**, filter by `tier == "REPAIR"`.
+
+See `docs/adr/adr-0006-sr1-t1-grammar-core-design.md` §3 row 6 + §2.2 (module boundaries) + §3a (Reconciler bridge pattern) + §4.4 (drift-elimination evidence).
+
+### Added — ADR-0006 SR1-T1 Step 6 (validator surface collapse; closes R2) — #401
 - **`core/grammar/entry.py`** now hosts `validate_frontmatter()` as a parse-stage hook. The legacy location `octave_mcp.core.validator.validate_frontmatter` is intentionally absent — no shim retained (design §3 row 6, §2.2).
 - **`octave_mcp.core.grammar` package** re-exports `validate_frontmatter` for convenience (`from octave_mcp.core.grammar import validate_frontmatter`).
 - **`class Validator`** is now a structural `visitor.Visitor[None]` — it exposes `visit_document`, `visit_section`, `visit_block`, `visit_assignment`, and the `visit` dispatcher. The orchestrating `Validator.validate(doc, ...)` method remains the canonical entry point; the visit methods are the protocol surface that future visitors compose against.
 - **`tests/unit/test_validator_surface_collapse.py`** — R2 closure witness asserting schema.py is unimportable, module-level `validate()` is gone, `validate_frontmatter` lives at the new location, and `Validator` satisfies `Visitor[None]` structurally.
 
-### Removed — ADR-0006 SR1-T1 Step 6 (BREAKING for direct importers of internal API)
-- **`octave_mcp.core.schema`** — module deleted. Its `validate()` function was a thin delegator to `octave_mcp.core.validator.validate()` (which is also removed; see below). Its `Schema` container class has been relocated to `octave_mcp.schemas.repository` (co-located with its sole consumer, `SchemaRepository`).
-- **`octave_mcp.core.validator.validate`** — module-level function removed. The canonical surface is the class-based API:
-
-  ```python
-  # Before (pre-1.12.0)
-  from octave_mcp.core.validator import validate
-  errors = validate(doc, schema, strict=True)
-
-  # After (1.12.0+)
-  from octave_mcp.core.validator import Validator
-  errors = Validator(schema).validate(doc, strict=True)
-  ```
-
-- **`octave_mcp.core.validator.validate_frontmatter`** — relocated to `octave_mcp.core.grammar.entry.validate_frontmatter`. Importers must update.
-
-### Changed
-- **`mcp/validate.py`, `mcp/write.py`, `cli/main.py`** — no public API change. These call sites already used the class-based `Validator(schema).validate(doc, ...)` surface; Step 6 only deletes the legacy shims they did not use.
-- **Test files** that imported the module-level `validate()` have been updated to the class-based API (`tests/unit/test_schema.py`, `tests/integration/test_e2e.py`, `tests/vectors/test_vectors.py`, `tests/unit/test_unknown_fields.py`, `tests/unit/test_repair.py`, `tests/unit/test_crs_review_schema.py`, `tests/unit/test_forbidden_repairs.py`, `tests/unit/test_gh344_meta_field_false_positive.py`, `tests/unit/test_gh358_meta_id_field.py`). Tests using `validate_frontmatter` (`tests/unit/test_frontmatter_validation.py`) and tests using the `Schema` container (`tests/unit/test_schema_repository.py`) have been updated to the new import paths. No test assertions were weakened.
-
-### Migration note
-Public consumers of `octave_mcp.core.validator.validate()` or `octave_mcp.core.schema.*` must migrate to the class-based API: `Validator(schema).validate(document)`. The MCP tool surface (`octave_validate`, `octave_write`) is unchanged. See `docs/adr/adr-0006-sr1-t1-grammar-core-design.md` §3 row 6 + §2.2 (module boundaries) + §4.4 (drift-elimination evidence).
-
-### Risk closure
-This release retires **R2 — `validator_drift_multiple_validators`** from the OCTAVE-MCP North Star Risks. Validator surface is now single-sourced on `class Validator`; there is no second validation path. **SR1-T1 is complete** — all six steps (1 → 2 → 4 → 5 → 3 → 6 per design v1.3 §3a execution order) are now merged.
-
-## [1.12.0] - "Audit-Completeness Closure" Release (ADR-0006 SR1-T1 Step 3)
-
-This release completes I4 (TRANSFORM_AUDITABILITY) enforcement per ADR-0006 SR1-T1 Step 3. Every canonical re-emit transformation now produces a `TIER_NORMALIZATION` receipt in the `RepairLog` and surfaces through `octave_write`'s `corrections` list. The third HARD_SYMMETRY conjunct (`corrections non-empty IFF diff_unified non-empty`) now holds at boundary cases that previously generated silent canonical mutations.
-
-### Added
+### Added — ADR-0006 SR1-T1 Step 3 (audit-completeness closure) — #399, #400
 - **`core/grammar/tier_normalize.py`** — Centralised TIER_NORMALIZATION audit channel. Public surface:
   - `log_repair(log, rule_id, before, after, *, safe=True, semantics_changed=False)` — single precise entry point for normalisation receipts.
   - `active(log)` context manager — ContextVar-scoped sink so pipeline-internal sites (notably emitter identifier-dequoting) can record receipts without RepairLog threading through `emit()`'s public signature.
@@ -51,6 +59,13 @@ This release completes I4 (TRANSFORM_AUDITABILITY) enforcement per ADR-0006 SR1-
   - Stable rule IDs: `TN_IDENTIFIER_DEQUOTE` (precise was_quoted-driven), `TN_RECONCILE_CANONICAL` (reconciler bridge).
 - **Precise instrumentation in `core/emitter.py`** — `emit_assignment` now logs `TN_IDENTIFIER_DEQUOTE` via `tier_normalize.log_repair_if_active` whenever `assignment.was_quoted is True` AND the emitter chose to emit bare. The hook is no-op outside the active context (preserves today's behaviour for callers that do not opt in).
 - **Additive consumer wiring in `mcp/write.py`** — Each `_emit_with_style` invocation is now wrapped with `tier_normalize.active(tier_normalize_log)`. After final emit, `reconcile_canonical_emission` runs and the log drains into `result["corrections"]` mirroring the existing schema-repair loop. The edit is purely additive (~30 lines including comments; no envelope / public API change).
+
+### Added — ADR-0006 SR1-T1 Steps 1, 2, 4, 5 (grammar core seams) — #393, #394, #396, #397, #398
+- **Step 1 (#393)** — `core/grammar.py` renamed to `core/grammar_compiler/gbnf.py`; a deprecation shim retained at `core/grammar.py` re-exports the public surface and emits a DeprecationWarning. Internal call sites switched to the new path.
+- **Step 2 (#394)** — `core/grammar/` package installed as the parse-stage seam. `core/grammar/entry.py::parse()` is currently an identity wrapper around `core/parser.py::parse`, ready to host CST construction in Sprint 2.
+- **Step 4 (#397)** — `core/ast_nodes` promoted to `core/grammar/cst.py`. Introduces `NodeKind` discriminator, `Visitor[T]` protocol, and reserved fields (`was_quoted`, `leading_trivia`, `trailing_trivia`) on CST nodes. Internal import sites switched (#396).
+- **Step 5 (#398)** — `core/emitter.py` rewritten as a CST visitor. `was_quoted` is populated on `Assignment` nodes during parsing and consumed at emit time. META-dict values are not yet covered by `was_quoted` propagation — deferred to Sprint 3+ work (see Implementation note below).
+- **Test corpus expansion (#395)** — HARD_SYMMETRY corpus extended with corner-case fixtures (deeply nested keys, trailing whitespace, multi-byte identifiers).
 
 ### Changed
 - **`tests/unit/test_writer_reader_symmetry.py`** — `_AUDIT_CARDINALITY_XFAILS` and `_GH385_DEEP_NESTING_XFAILS` are now empty frozensets. The 10 previously strict-xfailed fixtures flip to expected pass:
@@ -66,8 +81,11 @@ This release completes I4 (TRANSFORM_AUDITABILITY) enforcement per ADR-0006 SR1-
   - `tests/fixtures/symmetry/deeply_nested_keys.oct.md` (GH#385 corpus expansion)
 - **`octave-literacy` and `octave-mastery` skills** — New §7 sections document the `tier_normalize` audit channel, RepairLog completeness semantics, and reconciler-bridge self-deprecation pattern.
 
-### Consumer note (BREAKING for tests that asserted empty RepairLog)
-- `RepairLog` now records all TIER_NORMALIZATION events. Tests asserting `len(repair_log.entries) == 0` (or `len(corrections) == 0`) on documents containing trivia normalisation (blank-line stripping, triple-quote collapse) will see entries. **This reflects correct behaviour per I4 — pre-1.12.0 silent canonical mutation was an under-reporting bug.** To detect content normalisation, filter `corrections` by `tier == "NORMALIZATION"`; to detect schema repairs filter by `tier == "REPAIR"`.
+### Changed — internal API migration map (test files updated)
+- Test files that imported the module-level `validate()` were migrated to the class-based API (`tests/unit/test_schema.py`, `tests/integration/test_e2e.py`, `tests/vectors/test_vectors.py`, `tests/unit/test_unknown_fields.py`, `tests/unit/test_repair.py`, `tests/unit/test_crs_review_schema.py`, `tests/unit/test_forbidden_repairs.py`, `tests/unit/test_gh344_meta_field_false_positive.py`, `tests/unit/test_gh358_meta_id_field.py`). Tests using `validate_frontmatter` (`tests/unit/test_frontmatter_validation.py`) and the `Schema` container (`tests/unit/test_schema_repository.py`) were updated to the new import paths. No test assertions were weakened. The MCP and CLI call sites (`mcp/validate.py`, `mcp/write.py`, `cli/main.py`) already used the class-based `Validator(schema).validate(doc, ...)` surface and required no change.
+
+### Risk closure
+This release retires **R2 — `validator_drift_multiple_validators`** from the OCTAVE-MCP North Star Risks. Validator surface is now single-sourced on `class Validator`; there is no second validation path. **SR1-T1 is complete** — all six steps (1 → 2 → 4 → 5 → 3 → 6 per design v1.3 §3a execution order) are now merged.
 
 ### Implementation note (reconciler self-deprecation, design §3a)
 - The reconciler bridge is a **temporary, self-deprecating mechanism**. The 8 hydration / `deeply_nested_keys` fixtures and the 2 (`spec_full`, `empty_triple_quoted`) fixtures are currently all covered by the bridge because META-side dequoting is not threaded through `was_quoted` (META values live in `Document.meta: dict[str, Any]`, not Assignment nodes). When Sprint 3+ populates `leading_trivia` / `trailing_trivia` (per design §4.5 G1) and the new triple-quote-collapse lexer W-code lands, precise upstream loggers will cover their respective diffs, the de-duplication precondition will fail, and the reconciler will no-op — **no code change required**. See `docs/adr/adr-0006-sr1-t1-grammar-core-design.md` §3a ("Reconciler bridge pattern") for the full rationale.
@@ -75,15 +93,16 @@ This release completes I4 (TRANSFORM_AUDITABILITY) enforcement per ADR-0006 SR1-
 ### Deviation from HO 8/2 split directive
 - The HO directive anticipated 8 fixtures flipping via precise `was_quoted` instrumentation and 2 via the reconciler bridge. Empirically, all 10 flip via the reconciler bridge because META-key dequoting (where `TYPE::"SPEC"` → `TYPE::SPEC` happens) operates on `Document.meta: dict[str, Any]` values, not on `Assignment` nodes — the parser does not currently carry `was_quoted` for META values. The precise `TN_IDENTIFIER_DEQUOTE` hook is wired and active for Assignment-shaped values (`§N::CONTENT` body assignments); it simply does not fire on these specific fixtures because their dequoting targets are in META. The reconciler bridge correctly absorbs the gap and self-deprecates the same way once META-side `was_quoted` (or trivia population) lands.
 
-### Quality Gates
-- pytest: 2991 passing (+20 from 2971: 10 xfails flipped to expected pass + 10 new tier_normalize unit tests), 11 skipped, 0 xfailed, 0 failures.
+### Quality Gates (at v1.12.0 release HEAD)
+- pytest: **3003 passing, 11 skipped, 0 xfailed, 0 failures** (Python 3.11/3.12/3.13 matrix; CI run 25699798578 on c7660ac).
+- Property-based tests: 14 passing.
 - mypy --strict: clean.
 - ruff check / black --check: clean.
 - Smoke parity: `canonical_hash` unchanged for both ground-truth fixtures (`3f680a6b…` for `hydration/source.oct.md`; `fc758a43…` for `symmetry/empty_triple_quoted.oct.md`).
 - Constitutional compliance: I1, I2, I3, I4 (now fully enforced at boundary cases), I5.
 
-### Added (carried over from Unreleased)
-- **`format_style` parameter on `octave_write`** (#376, PR-A) — New optional parameter on the MCP tool (`format_style`) and CLI command (`--format-style`) accepting `"preserve"`, `"expanded"`, or `"compact"`. The three modes are AST-level pre-passes that funnel into the single canonical `emit()` (I1 Single-Canon Discipline), not parallel emitters:
+### Added — `format_style` parameter on `octave_write` — #376 PR-A
+- **`format_style` parameter on `octave_write`** — New optional parameter on the MCP tool (`format_style`) and CLI command (`--format-style`) accepting `"preserve"`, `"expanded"`, or `"compact"`. The three modes are AST-level pre-passes that funnel into the single canonical `emit()` (I1 Single-Canon Discipline), not parallel emitters:
   - `"preserve"` — Strategy C narrow short-circuit: when `parse(new_content) == parse(baseline_content)`, write baseline bytes verbatim and skip canonical re-emission.
   - `"expanded"` — Lift `InlineMap` (and `ListValue` items that are `InlineMap`) into `Block` form before `emit()`.
   - `"compact"` — Collapse atom-only Blocks (no comments anywhere in subtree, arity ≤ 8) into `inline-list-of-InlineMap` form. Comment-bearing subtrees are vetoed and a new `W_COMPACT_REFUSED` correction is appended to the repair log (I3 Mirror Constraint + I4 Auditability). The CLI surfaces these records on stderr.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This release completes the ADR-0006 writer/reader symmetry programme: the SR0 co
 - **W002 destructive empty-`after` corrections eliminated** — pre-1.12.0 the W002 normalization repair could emit `after=""` corrections that silently destroyed source content. The discriminant is now centralised and the destructive variant is rejected at write + lexer. (#383)
 - **Ambiguous `Block.child` paths surface as `W_AMBIGUOUS_PATH` warning** — `octave_write` now drains an `E_AMBIGUOUS_PATH`-scaffolded warning into emit error envelopes when a `changes` path is structurally ambiguous (e.g. duplicate child key target). Warning-only in v1.12.0 — does **not** yet hard-fail. (#391, #392)
 - **HARD_SYMMETRY roundtrip suite enforced in CI** — corner-case fixtures (deeply nested keys, trailing whitespace, multi-byte identifiers, blank-line stripping, triple-quote collapse, identifier dequoting) all enforce writer/reader symmetry; 10 previously strict-xfailed fixtures flipped to expected pass via the reconciler bridge. (#385, #395, #399)
+- **SR1-T4 — Explicit `octave_write` no-op invariant assertion**: when supplied content already matches target bytes, the write tool is a true no-op (no normalisation, no corrections emitted). Closes the symmetry programme's writer contract. (#407)
+- **GH-386 / W002 discriminant** — W002 destructive-normalization guard now uses a discriminant against a closed `SUPPRESSIBLE_NORMALIZATION_CODES` set; future W003+ codes require explicit admission policy. Prevents accidental warning suppression as new normalisation codes are added. (#408)
 
 ### NOT YET in this release (coming in v1.13.0)
 > These are intentional deferrals with named dependencies. They will land **after** ADR-0006 Sprint 2 exit criteria are written.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This release completes the ADR-0006 writer/reader symmetry programme: the SR0 co
 - **`octave_validate` and `octave_write` share a unified grammar core** — validator surface single-sourced on `class Validator` (now a `Visitor[None]`); `core/schema.py` deleted; `core/grammar/entry.py` is the parse-stage seam. Closes **R2 — `validator_drift_multiple_validators`**. (#393, #394, #396, #397, #398, #399, #400, #401)
 - **W002 destructive empty-`after` corrections eliminated** — pre-1.12.0 the W002 normalization repair could emit `after=""` corrections that silently destroyed source content. The discriminant is now centralised and the destructive variant is rejected at write + lexer. (#383)
 - **Ambiguous `Block.child` paths surface as `W_AMBIGUOUS_PATH` warning** — `octave_write` now drains an `E_AMBIGUOUS_PATH`-scaffolded warning into emit error envelopes when a `changes` path is structurally ambiguous (e.g. duplicate child key target). Warning-only in v1.12.0 — does **not** yet hard-fail. (#391, #392)
-- **HARD_SYMMETRY roundtrip suite enforced in CI** — corner-case fixtures (deeply nested keys, trailing whitespace, multi-byte identifiers, blank-line stripping, triple-quote collapse, identifier dequoting) all enforce writer/reader symmetry; 10 previously strict-xfailed fixtures flipped to expected pass via the reconciler bridge. (#385, #395, #399)
+- **HARD_SYMMETRY roundtrip suite enforced in CI** — corner-case fixtures (deeply nested keys, trailing whitespace, multi-byte identifiers, blank-line stripping, triple-quote collapse, identifier dequoting) all enforce writer/reader symmetry; 10 corner-case fixtures (deeply nested keys, blank-line stripping, triple-quote collapse, etc.) now enforced as expected-pass rather than skipped, via the reconciler bridge. (#385, #395, #399)
 - **SR1-T4 — Explicit `octave_write` no-op invariant assertion**: when supplied content already matches target bytes, the write tool is a true no-op (no normalisation, no corrections emitted). Closes the symmetry programme's writer contract. (#407)
 - **GH-386 / W002 discriminant** — W002 destructive-normalization guard now uses a discriminant against a closed `SUPPRESSIBLE_NORMALIZATION_CODES` set; future W003+ codes require explicit admission policy. Prevents accidental warning suppression as new normalisation codes are added. (#408)
 
@@ -22,6 +22,50 @@ This release completes the ADR-0006 writer/reader symmetry programme: the SR0 co
 - **`format_style="preserve"` as default** — currently opt-in only. Default flip is pending Strategy A (per-key dirty tracking) per **#376** + **#377**. Triggering the default on today's Strategy C narrow short-circuit would cause unsafe writes on byte-identical-but-AST-different inputs.
 - **Single-region diffs on edits** — currently `octave_write` produces full-document canonical re-emits even for one-line edits. Cursor-backed CST + per-key dirty tracking is pending **#377**.
 - **Full hard-fail on ambiguous paths** — currently warning-only via `W_AMBIGUOUS_PATH` (see Shipped). Hard-fail with `E_AMBIGUOUS_PATH` is pending **#369** (Block.child path corruption hard-fail) and downstream consumer migration.
+
+### ⚠️ Known Issues (filed for v1.13.0)
+
+These pre-existing defects in `octave_write` changes-mode primitives are
+not fixed in v1.12.0. They are confirmed in #411 and will be addressed
+alongside Strategy A in v1.13.0.
+
+- **#411 defect 1 — `$op:APPEND` emits Python dict syntax inside OCTAVE
+  arrays.** Calling `octave_write` with `{"$op":"APPEND","value":{"K":"V"}}`
+  on a list-valued target produces `{'K': 'V'}` (Python repr) in the
+  output. The tool returns `validation_status: VALIDATED` because the
+  lexer accepts the form, but the output is semantically invalid OCTAVE.
+  **Workaround:** pass APPEND values as a list of K::V strings, not a
+  dict; or use content-mode rewrite.
+
+- **#411 defect 2 — `format_style:"expanded"` over-eagerly lifts inner
+  list-of-atoms.** The lifter cannot distinguish a structured record
+  (`KEY::[TOKEN::X, STATUS::Y]`) from a list of K::V data points
+  (`FACTS::[a::1, b::2]`). Both lift to Block form. The lift is
+  semantically wrong on the second case and drops the outer `]` causing
+  document boundary loss. **Workaround:** do not run `expanded` on
+  documents containing inner list-of-atoms; pre-canonicalise block-form
+  entries only.
+
+- **#411 defect 3 — `$op:MERGE` rejects inline-array top-level targets.**
+  Feature gap, not corruption. MERGE only supports Block/Section/META
+  targets. **Workaround:** content-mode rewrite for inline-array
+  records.
+
+- **#411 defect 4 — Validator false-green on writer output.** All three
+  defects above produce output that `octave_validate` accepts. This
+  violates HARD_SYMMETRY in the *output* direction (the validator
+  cannot be used to verify that `octave_write` output is semantically
+  correct). Tracked separately as a lexer-level investigation.
+
+Until v1.13.0 ships, callers should spot-check `octave_write` diffs
+visually rather than relying on `validation_status: VALIDATED` alone
+for changes-mode operations on inline-array top-level entries.
+
+### Related work tracked separately
+
+- **#403 — annotation-content discipline epic** — broader programme on
+  annotation hygiene across the writer/reader surface. Not a v1.12.0
+  blocker; tracked for visibility and future sprint planning.
 
 ### ⚠️ Breaking Changes — direct importers of internal API
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,21 @@ All notable changes to OCTAVE-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.12.0] - 2026-05-11 - "Validator Collapse & Audit-Completeness Closure" Release (ADR-0006 SR1-T1)
+## [1.12.0] - 2026-05-11 - "Writer/Reader Symmetry" Release (ADR-0006 SR0 + SR1-T1)
 
-This release completes the full ADR-0006 SR1-T1 writer/reader symmetry programme (six steps merged across PRs #393, #394, #395, #396, #397, #398, #399, #400, #401). It single-sources the validator surface (closing North Star Risk **R2**) and enforces I4 (TRANSFORM_AUDITABILITY) at boundary cases by routing every canonical re-emit transformation through a `TIER_NORMALIZATION` receipt.
+This release completes the ADR-0006 writer/reader symmetry programme: the SR0 corpus + W002 destructive-correction work (#383) and all six SR1-T1 steps (#393, #394, #395, #396, #397, #398, #399, #400, #401). It single-sources the validator surface (closing North Star Risk **R2**) and enforces I4 (TRANSFORM_AUDITABILITY) at boundary cases by routing every canonical re-emit transformation through a `TIER_NORMALIZATION` receipt.
+
+### Shipped in v1.12.0
+- **`octave_validate` and `octave_write` share a unified grammar core** — validator surface single-sourced on `class Validator` (now a `Visitor[None]`); `core/schema.py` deleted; `core/grammar/entry.py` is the parse-stage seam. Closes **R2 — `validator_drift_multiple_validators`**. (#393, #394, #396, #397, #398, #399, #400, #401)
+- **W002 destructive empty-`after` corrections eliminated** — pre-1.12.0 the W002 normalization repair could emit `after=""` corrections that silently destroyed source content. The discriminant is now centralised and the destructive variant is rejected at write + lexer. (#383)
+- **Ambiguous `Block.child` paths surface as `W_AMBIGUOUS_PATH` warning** — `octave_write` now drains an `E_AMBIGUOUS_PATH`-scaffolded warning into emit error envelopes when a `changes` path is structurally ambiguous (e.g. duplicate child key target). Warning-only in v1.12.0 — does **not** yet hard-fail. (#391, #392)
+- **HARD_SYMMETRY roundtrip suite enforced in CI** — corner-case fixtures (deeply nested keys, trailing whitespace, multi-byte identifiers, blank-line stripping, triple-quote collapse, identifier dequoting) all enforce writer/reader symmetry; 10 previously strict-xfailed fixtures flipped to expected pass via the reconciler bridge. (#385, #395, #399)
+
+### NOT YET in this release (coming in v1.13.0)
+> These are intentional deferrals with named dependencies. They will land **after** ADR-0006 Sprint 2 exit criteria are written.
+- **`format_style="preserve"` as default** — currently opt-in only. Default flip is pending Strategy A (per-key dirty tracking) per **#376** + **#377**. Triggering the default on today's Strategy C narrow short-circuit would cause unsafe writes on byte-identical-but-AST-different inputs.
+- **Single-region diffs on edits** — currently `octave_write` produces full-document canonical re-emits even for one-line edits. Cursor-backed CST + per-key dirty tracking is pending **#377**.
+- **Full hard-fail on ambiguous paths** — currently warning-only via `W_AMBIGUOUS_PATH` (see Shipped). Hard-fail with `E_AMBIGUOUS_PATH` is pending **#369** (Block.child path corruption hard-fail) and downstream consumer migration.
 
 ### ⚠️ Breaking Changes — direct importers of internal API
 
@@ -59,6 +71,13 @@ See `docs/adr/adr-0006-sr1-t1-grammar-core-design.md` §3 row 6 + §2.2 (module 
   - Stable rule IDs: `TN_IDENTIFIER_DEQUOTE` (precise was_quoted-driven), `TN_RECONCILE_CANONICAL` (reconciler bridge).
 - **Precise instrumentation in `core/emitter.py`** — `emit_assignment` now logs `TN_IDENTIFIER_DEQUOTE` via `tier_normalize.log_repair_if_active` whenever `assignment.was_quoted is True` AND the emitter chose to emit bare. The hook is no-op outside the active context (preserves today's behaviour for callers that do not opt in).
 - **Additive consumer wiring in `mcp/write.py`** — Each `_emit_with_style` invocation is now wrapped with `tier_normalize.active(tier_normalize_log)`. After final emit, `reconcile_canonical_emission` runs and the log drains into `result["corrections"]` mirroring the existing schema-repair loop. The edit is purely additive (~30 lines including comments; no envelope / public API change).
+
+### Added — ADR-0006 SR0 (writer/reader symmetry foundation) — #383
+- **SR0-T1 HARD_SYMMETRY roundtrip suite** — `tests/unit/test_writer_reader_symmetry.py` establishes the writer/reader symmetry contract as enforced CI baseline. The suite asserts the three HARD_SYMMETRY conjuncts (parse-equivalence, byte-equivalence under canonical, repair-cardinality correctness).
+- **SR0-T2 W002 destructive-correction elimination** — the W002 normalization repair previously could emit `after=""` corrections that destroyed source content during canonical re-emit. The discriminant for destructive variants is now centralised in the lexer + write path, and destructive variants are rejected before they reach the RepairLog. Follow-up hardening landed via `e16a728` (CE: discriminant centralisation) and `5a9d9af` (cubic P2: defensive guard for malformed normalization repairs).
+
+### Added — ADR-0006 SR1-T3a (ambiguous path warning surface) — #391, #392
+- **`W_AMBIGUOUS_PATH` deprecation warning + `E_AMBIGUOUS_PATH` scaffolding** — `octave_write` now detects structurally ambiguous `changes` paths (e.g. duplicate child-key targets in a Block) and surfaces a `W_AMBIGUOUS_PATH` warning into the emit error envelope. The `E_AMBIGUOUS_PATH` error symbol is scaffolded but not yet emitted — the hard-fail transition is gated behind #369 and downstream consumer migration in v1.13.0+. Follow-up hardening landed via `e360827` (CRS+CE: verify $op behaviour on ambiguous paths + remove singleton race in warning buffer) and `70d5016` (CE: drain `W_AMBIGUOUS_PATH` into emit error envelopes).
 
 ### Added — ADR-0006 SR1-T1 Steps 1, 2, 4, 5 (grammar core seams) — #393, #394, #396, #397, #398
 - **Step 1 (#393)** — `core/grammar.py` renamed to `core/grammar_compiler/gbnf.py`; a deprecation shim retained at `core/grammar.py` re-exports the public surface and emits a DeprecationWarning. Internal call sites switched to the new path.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
-[![Tests](https://img.shields.io/badge/tests-2258%20passing-brightgreen.svg)]()
+[![Tests](https://img.shields.io/badge/tests-3003%20passing-brightgreen.svg)]()
 [![PyPI](https://img.shields.io/pypi/v/octave-mcp.svg)](https://pypi.org/project/octave-mcp/)
 
 **Deterministic document infrastructure for LLM pipelines.** Canonicalization, schema validation, grammar compilation, and MCP tools for durable AI artifacts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "1.11.0"
+version = "1.12.0"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release preparation for **OCTAVE-MCP v1.12.0** — the ADR-0006 SR1-T1 writer/reader symmetry programme is complete, R2 (validator_drift_multiple_validators) is retired, and I4 (TRANSFORM_AUDITABILITY) is now fully enforced at boundary cases.

This branch has been **rebased onto current `main`** to pick up #407 (SR1-T4 octave_write no-op invariant) and #408 (GH-386 W002 discriminant) which merged after the original PR was opened. The CHANGELOG and `uv.lock` are now in sync with merged-main reality, and a **Known Issues** block documents four pre-existing `octave_write` changes-mode defects (#411) that will be fixed alongside Strategy A in v1.13.0.

- Bumps `pyproject.toml` to `1.12.0`.
- Regenerates `uv.lock` so the `octave-mcp` editable entry visibly reflects `1.12.0` (was pinned at `1.11.0`).
- Refreshes the CHANGELOG `v1.12.0` `Shipped` section to include #407 and #408.
- Adds a CHANGELOG **Known Issues (filed for v1.13.0)** section documenting #411 defects 1–4 with workarounds.
- Adds a CHANGELOG **Related work tracked separately** pointer to #403 (annotation-content discipline epic).
- Replaces internal "strict-xfail" jargon with consumer-friendly wording.
- Refreshes the README test-count badge to the current CI baseline.

PyPI publish is **not** triggered by this PR. The existing release workflow gates publish behind human merge approval.

## Newly included after rebase

- **SR1-T4 — explicit `octave_write` no-op invariant assertion (#407)** — when supplied content already matches target bytes, the write tool is a true no-op (no normalisation, no corrections emitted). Closes the symmetry programme's writer contract.
- **GH-386 / W002 discriminant (#408)** — the W002 destructive-normalization guard now uses a discriminant against a closed `SUPPRESSIBLE_NORMALIZATION_CODES` set; future W003+ codes require explicit admission policy. Prevents accidental warning suppression as new normalisation codes are added.

## Known Issues (filed for v1.13.0)

Four pre-existing defects in `octave_write` changes-mode primitives are **not fixed in v1.12.0**. They are confirmed in #411 and will be addressed alongside Strategy A in v1.13.0:

1. **`$op:APPEND` emits Python dict syntax inside OCTAVE arrays** — dict values become `{'K': 'V'}` (Python repr) in output. Workaround: pass APPEND values as a list of K::V strings, or use content-mode rewrite.
2. **`format_style:"expanded"` over-eagerly lifts inner list-of-atoms** — cannot distinguish structured records from K::V data lists; drops outer `]` causing document boundary loss. Workaround: do not run `expanded` on documents containing inner list-of-atoms.
3. **`$op:MERGE` rejects inline-array top-level targets** — feature gap, not corruption. Workaround: content-mode rewrite for inline-array records.
4. **Validator false-green on writer output** — `octave_validate` accepts all three of the above. Output-direction HARD_SYMMETRY break, tracked separately as a lexer-level investigation.

Until v1.13.0 ships, callers should spot-check `octave_write` diffs visually rather than relying on `validation_status: VALIDATED` alone for changes-mode operations on inline-array top-level entries.

## Release notes draft (publish-ready)

> The body below is the GitHub Release notes for `v1.12.0`. The format is **end-user-facing**, distinct from the CHANGELOG entry (which is keep-a-changelog style and version-history-facing).

---

### OCTAVE-MCP v1.12.0 — "Writer/Reader Symmetry"

This release completes the ADR-0006 SR0 + SR1-T1 writer/reader symmetry programme. The validator surface is single-sourced on `class Validator`, every canonical re-emit transformation produces a `TIER_NORMALIZATION` receipt in the RepairLog, and the `octave_write` no-op invariant is explicitly asserted. It is the largest internal-API restructuring since v1.0.

**MCP tool surface (`octave_validate`, `octave_write`, `octave_eject`, `octave_compile_grammar`) and the CLI are unchanged.** The breakage is restricted to Python code that imported internal validator symbols directly.

#### Breaking changes — import map

| Old (≤ 1.11.0) | New (1.12.0+) |
|---|---|
| `from octave_mcp.core.schema import validate` | **deleted** — use `Validator(schema).validate(doc)` |
| `from octave_mcp.core.schema import Schema` | `from octave_mcp.schemas.repository import Schema` |
| `from octave_mcp.core.validator import validate` *(module-level)* | `Validator(schema).validate(doc, strict=...)` |
| `from octave_mcp.core.validator import validate_frontmatter` | `from octave_mcp.core.grammar.entry import validate_frontmatter` |
| `from octave_mcp.core.grammar import compile_grammar` *(legacy module)* | deprecation shim retained — emits `DeprecationWarning`. New canonical path: `octave_mcp.core.grammar_compiler.gbnf`. |
| `from octave_mcp.core.ast_nodes import …` | `from octave_mcp.core.grammar.cst import …` — new `NodeKind`, `Visitor[T]`, reserved fields `was_quoted` / `leading_trivia` / `trailing_trivia`. |

```python
# Before (≤ 1.11.0)
from octave_mcp.core.validator import validate
errors = validate(doc, schema, strict=True)

# After (1.12.0+)
from octave_mcp.core.validator import Validator
errors = Validator(schema).validate(doc, strict=True)
```

#### Behavioural change — RepairLog volume shift (I4 enforcement)

`RepairLog` now records all TIER_NORMALIZATION events. Documents containing trivia normalisation — blank-line stripping, triple-quote collapse, identifier dequoting — that previously produced an empty repair log will now produce one or more entries. **This reflects correct behaviour per I4 (TRANSFORM_AUDITABILITY) — pre-1.12.0 silent canonical mutation was an under-reporting bug, not a feature.**

If your tests or downstream consumers assert `len(repair_log.entries) == 0` or `len(corrections) == 0` on such documents, they will now fail. Migration:

- To detect **content normalisation**, filter `corrections` by `tier == "NORMALIZATION"`.
- To detect **schema repairs**, filter by `tier == "REPAIR"`.

#### What else is in the release

- **`octave_validate` and `octave_write` share a unified grammar core** — validator surface single-sourced on `class Validator` (now a `Visitor[None]`); `core/schema.py` deleted. Closes **R2 — `validator_drift_multiple_validators`**. (#393, #394, #396, #397, #398, #399, #400, #401)
- **W002 destructive empty-`after` corrections eliminated** — the W002 discriminant is centralised and the destructive variant is rejected at write + lexer. (#383)
- **SR1-T4 octave_write no-op invariant** — when supplied content already matches target bytes, `octave_write` is a true no-op. (#407)
- **GH-386 W002 discriminant against closed set** — `SUPPRESSIBLE_NORMALIZATION_CODES` is closed; W003+ codes require explicit admission policy. (#408)
- **Ambiguous `Block.child` paths surface as `W_AMBIGUOUS_PATH`** — warning-only in v1.12.0; hard-fail deferred to v1.13.0+. (#391, #392)
- **HARD_SYMMETRY roundtrip suite enforced in CI** — 10 corner-case fixtures (deeply nested keys, blank-line stripping, triple-quote collapse, etc.) now enforced as expected-pass rather than skipped, via the reconciler bridge. (#385, #395, #399)
- **Grammar core refactor** — `core/grammar.py` → `core/grammar_compiler/gbnf.py` (with deprecation shim); new `core/grammar/` package; `core/grammar/entry.py::parse()` is the parse-stage seam ready to host CST construction in Sprint 2. (#393, #394)
- **CST promotion** — `ast_nodes` → `core/grammar/cst.py` with `NodeKind`, `Visitor[T]`, and reserved trivia fields. (#396, #397)
- **Emitter as CST visitor** — `core/emitter.py` rewritten; `was_quoted` populated on Assignment nodes. (#398)
- **TIER_NORMALIZATION audit channel** — `core/grammar/tier_normalize.py` centralises normalisation receipts. (#399, #400)

#### NOT yet in this release (coming in v1.13.0)

- **`format_style="preserve"` as default** — currently opt-in only. Pending Strategy A (per-key dirty tracking) per #376 + #377.
- **Single-region diffs on edits** — currently full-document canonical re-emits. Pending #377.
- **Full hard-fail on ambiguous paths** — currently warning-only. Pending #369 and downstream consumer migration.
- **#411 changes-mode primitives fixes** — `$op:APPEND` Python-dict bug, `format_style:"expanded"` lifter, `$op:MERGE` inline-array gap, and validator false-green on writer output. Fixed alongside Strategy A.

#### Quality baseline

- pytest: **3108 passed, 11 skipped, 1 xfailed** (run on rebased branch HEAD, Python 3.14).
- mypy --strict, ruff, black: all clean.
- Constitutional compliance: I1, I2, I3, I4 (now fully enforced at boundary cases), I5.

Install: `pip install octave-mcp==1.12.0`

See [CHANGELOG.md](https://github.com/elevanaltd/octave-mcp/blob/main/CHANGELOG.md) and [ADR-0006](https://github.com/elevanaltd/octave-mcp/blob/main/docs/adr/adr-0006-sr1-t1-grammar-core-design.md) for full detail.

---

## Related work tracked separately

- **#403 — annotation-content discipline epic** — broader programme on annotation hygiene across the writer/reader surface. Not a v1.12.0 blocker; tracked for visibility and future sprint planning.

## Cross-repo heads-up — draft notification bodies (post after release)

> Drafts only. Do not post yet. To be filed as issues/discussions on `HestAI-MCP` and `debate-hall` after this PR merges and v1.12.0 is published.

### Heads-up for `elevanaltd/HestAI-MCP`

> Title suggestion: **OCTAVE-MCP v1.12.0 — internal-API import map + RepairLog volume shift**

OCTAVE-MCP v1.12.0 is out and includes two changes worth surfacing if HestAI-MCP touches the OCTAVE Python internals directly. **The MCP tool surface (`octave_validate`, `octave_write`, etc.) is unchanged; this only affects Python imports.** First, the validator surface has been single-sourced: `octave_mcp.core.schema` is deleted, `octave_mcp.core.validator.validate` (module-level) is gone, and `validate_frontmatter` has moved to `octave_mcp.core.grammar.entry`. The class-based API is now canonical: `Validator(schema).validate(doc, ...)`. Second, `RepairLog` now logs all TIER_NORMALIZATION events per I4 — if any HestAI-MCP test or consumer asserts an empty repair log on documents with trivia normalisation (blank-line stripping, triple-quote collapse, identifier dequoting), those assertions will now see entries. To filter, use `tier == "NORMALIZATION"` for content normalisation and `tier == "REPAIR"` for schema repairs. Full migration map in the [v1.12.0 release notes](https://github.com/elevanaltd/octave-mcp/releases/tag/v1.12.0).

### Heads-up for `elevanaltd/debate-hall`

> Title suggestion: **OCTAVE-MCP v1.12.0 — RepairLog volume shift may surface in debate transcript validation**

OCTAVE-MCP v1.12.0 enforces I4 (TRANSFORM_AUDITABILITY) at boundary cases — every canonical re-emit transformation now produces a TIER_NORMALIZATION receipt. If debate-hall validates or writes `.oct.md` transcripts that contain blank-line normalisation, triple-quote collapse, or identifier dequoting, the `corrections` list returned by `octave_write` will now include entries that were silently dropped pre-1.12.0. This is correct behaviour: pre-1.12.0 silent canonical mutation was an under-reporting bug, not a feature. The debate-hall MCP tool surface that consumes OCTAVE-MCP is unaffected (no public-API break), but any internal assertions of `corrections == []` on normalised transcripts will need to filter by `tier == "REPAIR"` (schema repairs) versus `tier == "NORMALIZATION"` (canonical normalisation). There is also an internal-API import map for Python code that touches `octave_mcp.core.validator` or `octave_mcp.core.schema` directly — see the [v1.12.0 release notes](https://github.com/elevanaltd/octave-mcp/releases/tag/v1.12.0).

---

## Test plan

- [ ] CI green on `chore/release-v1.12.0-prep` (pytest matrix, mypy, ruff, black, doc-numbering validator).
- [ ] Review Gate workflow green at new HEAD.
- [ ] Visual diff review of CHANGELOG to confirm v1.12.0 entry is internally coherent and includes #407 + #408 in Shipped, #411 defects 1–4 in Known Issues, and #403 in Related work.
- [ ] Confirm `pyproject.toml` `version = "1.12.0"` and `uv.lock` octave-mcp entry `version = "1.12.0"` agree.
- [ ] After merge, human triggers PyPI publish via existing release workflow.
- [ ] After publish, post the two cross-repo heads-up drafts (above) to HestAI-MCP and debate-hall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
