### PR TITLE
feat(repair_log): tag W002 emit discriminant by warning code (GH-386)

### DIFF
--- a/src/octave_mcp/core/lexer.py
+++ b/src/octave_mcp/core/lexer.py
@@ -1192,6 +1192,8 @@ def tokenize(content: str, lenient: bool = False) -> tuple[list[Token], list[Any
                 # normalisations via the shared discriminant in core.repair_log.
                 # See is_destructive_normalization_repair docstring for the I1/I3
                 # rationale.
+                # GH-386: pass the warning code explicitly so a future W003+
+                # normalisation is not silently suppressed by the W002 guard.
                 if normalized_from:
                     candidate = {
                         "type": "normalization",
@@ -1200,7 +1202,7 @@ def tokenize(content: str, lenient: bool = False) -> tuple[list[Token], list[Any
                         "line": line,
                         "column": column,
                     }
-                    if not is_destructive_normalization_repair(candidate):
+                    if not is_destructive_normalization_repair(candidate, warning_code="W002"):
                         repairs.append(candidate)
 
                 # Update position - count embedded newlines in matched text

--- a/src/octave_mcp/core/repair_log.py
+++ b/src/octave_mcp/core/repair_log.py
@@ -4,10 +4,27 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+# GH-386 (ADR-0006 SR1, CE follow-up to PR #383): the destructive-empty-
+# normalization guard now keys on warning code AND shape, not on shape
+# alone. Suppression is restricted to this closed set so a future W003+
+# normalization warning that legitimately reuses the (original, normalized)
+# shape with an empty `normalized` value cannot be silently suppressed by
+# the W002 guard.
+#
+# To opt a new code into suppression, add it here AND add a discriminator
+# test in tests/unit/test_w002_discriminant_tagging.py asserting the
+# desired empty-handling semantics. The set is frozen so it cannot be
+# mutated by side effect at import time.
+SUPPRESSIBLE_NORMALIZATION_CODES: frozenset[str] = frozenset({"W002"})
 
-def is_destructive_normalization_repair(repair: dict[str, Any]) -> bool:
-    """Return True iff `repair` is a normalization-shaped record whose
-    post-normalization output is missing or empty.
+
+def is_destructive_normalization_repair(
+    repair: dict[str, Any],
+    *,
+    warning_code: str = "W002",
+) -> bool:
+    """Return True iff `repair` is a destructive normalization record for
+    the given warning code.
 
     ADR-0006 SR0-T2 (GH#381): a normalization repair with an empty
     `normalized` value would render downstream as a W002 correction with
@@ -16,6 +33,19 @@ def is_destructive_normalization_repair(repair: dict[str, Any]) -> bool:
     I1 (SYNTACTIC_FIDELITY) and I3 (MIRROR_CONSTRAINT), and breaks the
     HARD_SYMMETRY invariant by emitting a correction the rendered diff
     cannot reflect.
+
+    GH-386 (SR1 CE follow-up): the helper now requires the caller to
+    declare which warning code it is guarding. Suppression returns True
+    only when ALL of:
+      1. ``warning_code`` is in ``SUPPRESSIBLE_NORMALIZATION_CODES``
+         (today: ``{"W002"}``), AND
+      2. the record is *normalization-shaped*, AND
+      3. the ``normalized`` value is missing or empty.
+
+    A future W003+ normalization warning that wants different empty-
+    handling MUST NOT be silently suppressed by this guard; the helper
+    returns False for any non-enumerated code, leaving the policy to the
+    call site.
 
     A record is "normalization-shaped" if either:
       * ``type == "normalization"`` (lexer/parser warning shape), or
@@ -28,16 +58,23 @@ def is_destructive_normalization_repair(repair: dict[str, Any]) -> bool:
 
     Scope is intentionally narrow: it does NOT classify other warning
     codes (e.g. W_UNQUOTED_SECTION_IN_VALUE uses original/repaired and
-    is out of scope; broader audit-cardinality discriminants are tracked
-    at #386 for SR1).
+    is out of scope).
 
     Args:
         repair: A repair / warning candidate dict.
+        warning_code: The warning code the caller is guarding. Defaults
+            to ``"W002"`` for backwards-compatibility with existing call
+            sites. Pass an explicit code at every call site for clarity
+            and to make future-code policy decisions self-documenting.
 
     Returns:
         True iff the record is a destructive (empty-normalised)
-        normalization repair that callers must suppress.
+        normalization repair under the given warning code that callers
+        must suppress; False otherwise (including for any warning code
+        outside ``SUPPRESSIBLE_NORMALIZATION_CODES``).
     """
+    if warning_code not in SUPPRESSIBLE_NORMALIZATION_CODES:
+        return False
     is_normalization_shaped = repair.get("type") == "normalization" or "normalized" in repair
     if not is_normalization_shaped:
         return False

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -96,8 +96,8 @@ E_AMBIGUOUS_PATH = "E_AMBIGUOUS_PATH"
 #
 # When format_style is omitted (None), today's behaviour is preserved exactly:
 # emit(doc) with no pre-pass and no short-circuit (the "current" sentinel
-# documented in the PR description). This guarantees the 2788 baseline tests
-# remain byte-identical.
+# documented in the PR description). This guarantees the historical baseline
+# test suite remains byte-identical (no behavioural drift on the default path).
 FORMAT_STYLE_VALUES: tuple[str, str, str] = ("preserve", "expanded", "compact")
 E_INVALID_FORMAT_STYLE = "E_INVALID_FORMAT_STYLE"
 W_COMPACT_REFUSED = "W_COMPACT_REFUSED"
@@ -1545,8 +1545,13 @@ class WriteTool(BaseTool):
                 # alone but lacking the `normalized` key would slip past the
                 # helper. Belt-and-braces: also gate on a non-empty
                 # normalized_value so neither defect class can land.
+                #
+                # GH-386: the helper now keys on warning code AND shape. Pass
+                # the W002 discriminant explicitly so a future W003+
+                # normalization warning routed through this branch is not
+                # silently suppressed by the W002 guard.
                 normalized_value = w.get("normalized", "")
-                if is_destructive_normalization_repair(w) or not normalized_value:
+                if is_destructive_normalization_repair(w, warning_code="W002") or not normalized_value:
                     continue
                 corrections.append(
                     {
@@ -2001,9 +2006,14 @@ class WriteTool(BaseTool):
         # shaped) and emit W002 with empty `after`. Belt-and-braces: also
         # gate on a non-empty normalized_value so the malformed case is
         # suppressed too. The helper's narrow semantics are preserved.
+        #
+        # GH-386: the helper now keys on warning code AND shape. Pass the
+        # W002 discriminant explicitly so a future W003+ normalization
+        # warning routed through this mapping is not silently suppressed
+        # by the W002 guard.
         for token_repair in tokenize_repairs:
             normalized_value = token_repair.get("normalized", "")
-            if is_destructive_normalization_repair(token_repair) or not normalized_value:
+            if is_destructive_normalization_repair(token_repair, warning_code="W002") or not normalized_value:
                 continue
             corrections.append(
                 {

--- a/tests/unit/test_w002_discriminant_tagging.py
+++ b/tests/unit/test_w002_discriminant_tagging.py
@@ -1,0 +1,116 @@
+"""GH-386: Warning-code discriminant on the destructive-normalization guard.
+
+Context
+-------
+PR #383 centralised the destructive-empty-`after` suppression into
+``is_destructive_normalization_repair`` in ``octave_mcp.core.repair_log``.
+The helper keyed purely on *shape* (``type == "normalization"`` OR a
+``normalized`` field present), which is safe for today's W002 ASCII-alias
+set but brittle: a future W003+ that reuses the same record shape but
+legitimately wants different empty-handling would be silently suppressed.
+
+GH-386 (CE follow-up from PR #383) refactors the helper to additionally
+accept a warning code (or category) and only suppress when BOTH:
+  * the warning code is W002 (or an explicitly enumerated successor), AND
+  * the ``normalized`` value is empty.
+
+A future W003+ normalization warning must pass through the helper (return
+False) so its caller can apply its own empty-handling policy.
+
+These tests pin the new contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from octave_mcp.core.repair_log import (
+    SUPPRESSIBLE_NORMALIZATION_CODES,
+    is_destructive_normalization_repair,
+)
+
+# ---------------------------------------------------------------------------
+# Suppression-eligible code set
+# ---------------------------------------------------------------------------
+
+
+def test_suppressible_codes_contains_w002() -> None:
+    """W002 is the canonical destructive-normalization code today."""
+    assert "W002" in SUPPRESSIBLE_NORMALIZATION_CODES
+
+
+def test_suppressible_codes_is_a_frozen_set() -> None:
+    """The enumeration is intentionally a closed set; mutation is forbidden
+    so a future warning code cannot opt itself into suppression by side
+    effect at import time.
+    """
+    assert isinstance(SUPPRESSIBLE_NORMALIZATION_CODES, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Helper signature: accepts warning_code
+# ---------------------------------------------------------------------------
+
+
+def test_helper_accepts_explicit_w002_code_and_suppresses_empty() -> None:
+    """Explicit W002 + normalization-shaped + empty `normalized` -> True."""
+    record = {"type": "normalization", "original": '"""', "normalized": ""}
+    assert is_destructive_normalization_repair(record, warning_code="W002") is True
+
+
+def test_helper_default_warning_code_is_w002_for_backwards_compat() -> None:
+    """Existing call sites that pass no code MUST get the legacy
+    W002-suppression behaviour (preserves PR #383's centralisation
+    contract).
+    """
+    record = {"type": "normalization", "original": '"""', "normalized": ""}
+    assert is_destructive_normalization_repair(record) is True
+
+
+# ---------------------------------------------------------------------------
+# Non-W002 normalization warning passes through
+# ---------------------------------------------------------------------------
+
+
+def test_helper_does_not_suppress_non_w002_normalization_with_empty_value() -> None:
+    """A future W003+ normalization warning with the same record shape and
+    an empty ``normalized`` value MUST NOT be silently suppressed by the
+    W002 guard. The helper returns False so the caller can apply its own
+    policy.
+
+    This is the GH-386 acceptance criterion.
+    """
+    record = {"type": "normalization", "original": "x", "normalized": ""}
+    assert is_destructive_normalization_repair(record, warning_code="W003") is False
+
+
+def test_helper_does_not_suppress_unknown_code_with_normalized_shape() -> None:
+    """Any warning code outside the suppression-eligible set passes
+    through, regardless of shape."""
+    record = {"original": "x", "normalized": "", "line": 1, "column": 1}
+    assert is_destructive_normalization_repair(record, warning_code="W_FUTURE") is False
+
+
+def test_helper_passes_non_w002_through_even_for_non_empty_record() -> None:
+    """Sanity: non-W002 + well-formed record -> False (no suppression)."""
+    record = {"type": "normalization", "original": "x", "normalized": "y"}
+    assert is_destructive_normalization_repair(record, warning_code="W003") is False
+
+
+# ---------------------------------------------------------------------------
+# Existing W002 behaviour is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_w002_still_suppresses_empty_normalized_key_only_shape() -> None:
+    """A record carrying ``normalized`` (no ``type``) is normalization-
+    shaped via the second discriminant; the W002 guard still applies."""
+    record: dict[str, Any] = {"original": "->", "normalized": "", "line": 1, "column": 1}
+    assert is_destructive_normalization_repair(record, warning_code="W002") is True
+
+
+def test_w002_does_not_suppress_well_formed_record() -> None:
+    """Well-formed records with non-empty ``normalized`` are not
+    destructive even under W002."""
+    record = {"original": "->", "normalized": "→", "line": 1, "column": 1}
+    assert is_destructive_normalization_repair(record, warning_code="W002") is False

--- a/tests/unit/test_w002_malformed_repair_guard.py
+++ b/tests/unit/test_w002_malformed_repair_guard.py
@@ -40,14 +40,14 @@ def test_helper_returns_false_for_record_lacking_both_discriminants() -> None:
     malformed emit.
     """
     malformed: dict[str, Any] = {"original": "->", "line": 1, "column": 1}
-    assert is_destructive_normalization_repair(malformed) is False
+    assert is_destructive_normalization_repair(malformed, warning_code="W002") is False
 
 
 def test_helper_returns_true_for_normalization_typed_with_empty_normalized() -> None:
     """type=="normalization" is normalization-shaped; empty `normalized`
     is destructive."""
     record = {"type": "normalization", "original": '"""', "normalized": ""}
-    assert is_destructive_normalization_repair(record) is True
+    assert is_destructive_normalization_repair(record, warning_code="W002") is True
 
 
 def test_helper_returns_true_for_repair_with_empty_normalized_field() -> None:
@@ -55,14 +55,14 @@ def test_helper_returns_true_for_repair_with_empty_normalized_field() -> None:
     normalization-shaped via the second discriminant; empty value is
     destructive."""
     record = {"original": "->", "normalized": "", "line": 1, "column": 1}
-    assert is_destructive_normalization_repair(record) is True
+    assert is_destructive_normalization_repair(record, warning_code="W002") is True
 
 
 def test_helper_returns_false_for_well_formed_repair() -> None:
     """Well-formed records with non-empty `normalized` are not
     destructive."""
     record = {"original": "->", "normalized": "→", "line": 1, "column": 1}
-    assert is_destructive_normalization_repair(record) is False
+    assert is_destructive_normalization_repair(record, warning_code="W002") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the CE follow-up brittleness concern from PR #383 review (GH-386, ADR-0006 SR1 parallel track).

- `is_destructive_normalization_repair` now keys on warning code AND record shape, not shape alone. Suppression restricted to a closed `SUPPRESSIBLE_NORMALIZATION_CODES = frozenset({"W002"})` set so a future W003+ normalization warning that legitimately reuses the (original, normalized) shape with empty `normalized` cannot be silently suppressed by the W002 guard.
- Helper accepts keyword-only `warning_code` (default `"W002"` for backwards-compatibility with PR #383's centralisation contract). All three call sites — `core/lexer.py`, `mcp/write.py:_map_parse_warnings_to_corrections`, `mcp/write.py:_track_corrections` — pass the W002 discriminant explicitly so policy decisions surface at the call site.
- 9 new helper-level tests in `tests/unit/test_w002_discriminant_tagging.py` pin the new contract, including the GH-386 acceptance criterion that a non-W002 normalization warning passes through with non-empty diff.
- Folded change per HO direction: refresh stale "2788 baseline tests" comment at `src/octave_mcp/mcp/write.py:99` to version-agnostic phrasing.

## Acceptance criteria (GH-386)

- [x] Helper signature includes warning code / category.
- [x] Test added that demonstrates a non-W002 normalization warning passes through with non-empty diff (when introduced).
- [x] HARD_SYMMETRY suite remains green.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `black --check src/ tests/` — clean
- [x] `mypy src` (CI invocation) — clean (53 source files)
- [x] `pytest -q` — 3012 passed / 11 skipped (up from 3003 baseline at main HEAD c7660ac post-PR #401)
- [x] Existing `test_w002_malformed_repair_guard.py` (cubic P2 coverage from PR #383) continues to pass via backwards-compatible default `warning_code="W002"`.

## Constraints honoured

- T2 implementation tier; no public API surface change (helper gains a keyword-only optional parameter with default preserving today's semantics).
- No release-prep files touched (CHANGELOG / README / pyproject.toml / PROJECT-CONTEXT.oct.md). Parallel to PR #402 v1.12.0 release prep lane.
- Single PR; folded comment fix included in the same commit per HO direction.

Refs: #386, #383, ADR-0006 SR1-T1 grammar core design v1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make destructive-normalization suppression explicit by warning code so only W002 is suppressed. Future normalization warnings (e.g., W003+) are not silently dropped; all call sites now pass `warning_code="W002"`.

- **Bug Fixes**
  - Added keyword-only `warning_code` to `is_destructive_normalization_repair` (default `"W002"`); introduced `SUPPRESSIBLE_NORMALIZATION_CODES = frozenset({"W002"})`.
  - Updated `core/lexer.py` and both `mcp/write.py` mapping paths to pass `warning_code="W002"`; refreshed a version-agnostic baseline comment in `mcp/write.py`.
  - Added `tests/unit/test_w002_discriminant_tagging.py` to pin non-W002 pass-through; updated `tests/unit/test_w002_malformed_repair_guard.py` to pass the code explicitly.

<sup>Written for commit 289ce744a644a892a6c9d94560489274b2823ee2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

