### PR TITLE
fix(ci): supply release notes via body input (append_body is a boolean flag)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -177,7 +177,16 @@ jobs:
       - name: Update release notes
         uses: softprops/action-gh-release@v2
         with:
-          append_body: |
+          # softprops/action-gh-release@v2 input contract:
+          # - `body` (String): the release notes text
+          # - `append_body` (Boolean): flag enabling append-to-existing-body
+          # Earlier revisions of this workflow placed the footer text inside
+          # `append_body:`, which the action coerced to a truthy boolean and
+          # then silently dropped the content (no `body`/`body_path` supplied).
+          # That is why v1.10/v1.11/v1.12 GH Releases shipped without the
+          # Installation footer despite this job reporting success.
+          append_body: true
+          body: |
 
             ## Installation
 


### PR DESCRIPTION
## Summary

The `create-github-release-notes` job in `.github/workflows/publish.yml` has been a silent no-op since the workflow was written. GH Releases for v1.10, v1.11, and v1.12 shipped without the `## Installation` / `## Documentation` / `## PyPI` footer despite the job reporting success across all three releases. This PR corrects the structural misuse.

## Root cause (verified, not assumed)

Verified against the [softprops/action-gh-release@v2 README inputs table](https://github.com/softprops/action-gh-release#inputs):

| Input         | Type    | Purpose                                       |
| ------------- | ------- | --------------------------------------------- |
| `body`        | String  | Text communicating notable changes            |
| `body_path`   | String  | Path to load text from                        |
| `append_body` | Boolean | Append to existing body (flag, not text)      |

The previous configuration placed the footer text inside `append_body:`. That input is a **Boolean flag** (enables append-vs-overwrite mode), not the body content. The action coerced the multi-line YAML scalar to a truthy boolean (so the input layer validated and the job exited green) and then dropped the content because no `body`/`body_path` was supplied.

## Why this is NOT a v2 regression

The misuse predates the `@v2` pinning — the workflow has been structurally wrong since it was written. The earlier hypothesis that v2 had regressed `tag_name` auto-detection was incorrect: per the action docs, `tag_name` defaults to `github.ref_name`, which resolves correctly under a `release: published` event. The action was already targeting the right release; the body was being dropped because of the input-shape error above.

## Fix

Single workflow-file edit: move the footer text into `body:` and set `append_body: true` as the (correctly typed) flag. A clarifying comment captures the input-contract for future maintainers.

```diff
       - name: Update release notes
         uses: softprops/action-gh-release@v2
         with:
-          append_body: |
+          append_body: true
+          body: |

             ## Installation
             ...
```

## Constraints preserved

- Workflow file only — no other files touched.
- `id-token: write` and `contents: write` permissions unchanged.
- Action version `@v2` pinning unchanged.
- Branch off main, conventional commits.

## Test plan

- [x] YAML syntax validated locally (`python -c "import yaml; yaml.safe_load(open(...))"`)
- [x] GitHub's workflow parser will validate on push (CI green = only pre-release validation available)
- [ ] Validates on next release (v1.13.0); no test path available pre-release.

Refs: silent no-op observed on v1.10, v1.11, v1.12 GH Releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GitHub Releases notes step so the footer is published. The footer is now passed via the `body` input with `append_body: true` to append.

- **Bug Fixes**
  - Footer text was incorrectly placed in `append_body` (a boolean), so content was dropped despite green runs.
  - Move footer to `body: |` and set `append_body: true`.
  - Add comments clarifying `softprops/action-gh-release@v2` inputs. No other workflow or permission changes.

<sup>Written for commit d4bf869f4af0c820f4c0c75cebfbd68a74d9a1b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

