### PR TITLE
feat: Shape B format_style deprecation rollout (PR-4 T10+T11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to OCTAVE-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v1.13.0 — "Strategy A Span-Aware Preserve" (ADR-0006 SR2)
+
+This release lands the Strategy A span-aware preserve-mode engine (#418), the META audit-marker admission policy (#419, GH#384), and the Shape B `format_style` deprecation rollout (PR-4 / addendum §5). The default `format_style` does **not** flip in this release — see "Deprecated" below for the v1.14.0 plan.
+
+### Added
+- **Strategy A span-aware preserve mode engine (#418).** When `format_style="preserve"` is passed, `octave_write` returns single-region slice-and-replace output: clean nodes are sliced verbatim from the post-NFC baseline bytes, only mutated subtrees are re-emitted canonically. Diff footprint ≤0.5% of file size on representative documents (≈162KB governance fixture). Subsumes **GH#248** mixed `[X]`/`<X>` annotation form drift — annotations in unchanged regions are byte-identical to baseline. Implemented across the lexer (post-NFC `normalize_content()` public utility), emitter (`FormatOptions.baseline_bytes` + `enable_preserve` span-aware dispatch in the single `emit()` codepath, no parallel emitters), and write pipeline (NFC threading at all three `_emit_with_style` call sites, `spans_valid_for_baseline` discriminator for content-mode vs. changes-mode docs).
+- **Paired-write discipline across four mutation surfaces.** The Strategy A slice path requires that every AST mutation be paired with the appropriate `dirty` / `body_dirty` / `meta_dirty` flag, or the emitter would splice stale baseline bytes. PR-3 of #418 installed this contract on `mcp/write.py` (PR-2 carryover), `cli/main.py` (CE BLOCKER cycle 4), `core/repair.py` (CE BLOCKER cycle 3), and `core/parser.py` (CE BLOCKER cycle 5). A structural lint gate (`tests/unit/test_dirty_paired_write_lint.py`) enforces both proximity-based pairing (write/repair/cli) and AST-scoped function-body checks (repair propagation, parser post-pass invocation) so the bug class cannot recur.
+- **META audit-marker admission via Option C (#419, GH#384).** Closed-set `META_AUDIT_ADMIT_PATTERNS` matches audit markers (e.g. `AUDIT_*::`, `EVIDENCE::`) in META blocks and emits informational `W_META_AUDIT` warnings rather than rejecting them; non-matching patterns still fall through to the regular admission rules.
+- **`octave_mcp.core.lexer.normalize_content(content: str) -> str`** — public utility exposing the fence-aware NFC normalisation that `tokenize()` applies internally. Callers feeding `baseline_bytes` to `_emit_with_style` must use this (or `mcp.write._to_baseline_bytes`) so byte spans index the same bytes the parser saw. See `docs/api.md` for the NFC contract.
+
+### Deprecated
+- **Passing `format_style=None` *explicitly* now emits a `DeprecationWarning`** at both the MCP `octave_write` tool surface and the CLI `octave write` command (via the new `--format-style none` literal choice). In **v1.14.0** the default will change from full canonical re-emit to span-aware `"preserve"` mode. To keep the current canonical re-emit behaviour across the flip, pass `format_style="expanded"` explicitly. To opt in to preserve mode now, pass `format_style="preserve"`. **OMITTING the parameter does NOT emit a warning** — that is the supported way to accept the future default silently. See ADR-0006 Sprint 2 addendum §5 Shape B for the rationale.
+- **Notice.** v1.14.0 will flip the `format_style` default. Callers asserting byte-shape of `octave_write` outputs SHOULD review their integration and pin a `format_style` value explicitly before the v1.14.0 upgrade.
+
+### Migration
+- No code changes required to upgrade from v1.12.0 to v1.13.0. Behaviour on the default path (`format_style` omitted) is byte-identical to v1.12.0.
+- To silence the new `DeprecationWarning` while intentionally keeping v1.12.0 behaviour, replace any `format_style=None` explicit pass with `format_style="expanded"`.
+- See `docs/usage.md` for the v1.12.0 → v1.13.0 → v1.14.0 behaviour matrix per `format_style` value.
+
+### Status of v1.12.0 known issues (#411)
+PR #418 (Strategy A engine) explicitly does NOT subsume #411 defects 1 and 2 (`$op:APPEND` Python-dict emission; `format_style:"expanded"` lifter dropping outer `]`); those remain open for a follow-up sprint. PR #418 partially subsumes #411 defects 3 and 4 — preserve mode now surfaces nested-merge errors structurally (no longer silently invalid output) although MERGE on inline-array top-level targets is still rejected and the validator's false-green on inline-array writer output remains tracked separately. See ADR-0006 Sprint 2 addendum EC-4 / EC-4b for the subsumption retriage record.
+
+### Related PRs
+- **#418** — Strategy A span-aware preserve mode engine (PR-3 / T8 + T9 + reviewer rework cycles 1–5).
+- **#419** — META audit-marker admission (GH#384 / SR2-T3).
+- **#421** — Sprint 2 EC coordination (EC-1 + EC-2 SATISFIED).
+- **PR-4 (this release)** — Shape B `format_style` deprecation warning + v1.13.0 documentation (T10 + T11).
+
 ## [1.12.0] - 2026-05-11 - "Writer/Reader Symmetry" Release (ADR-0006 SR0 + SR1-T1)
 
 This release completes the ADR-0006 writer/reader symmetry programme: the SR0 corpus + W002 destructive-correction work (#383) and all six SR1-T1 steps (#393, #394, #395, #396, #397, #398, #399, #400, #401). It single-sources the validator surface (closing North Star Risk **R2**) and enforces I4 (TRANSFORM_AUDITABILITY) at boundary cases by routing every canonical re-emit transformation through a `TIER_NORMALIZATION` receipt.

--- a/docs/api.md
+++ b/docs/api.md
@@ -237,9 +237,10 @@ values are **AST-level pre-passes that all funnel into the single canonical
 
 | Mode | Semantics | When to use |
 |---|---|---|
-| _(unset / `null`)_ | Today's canonical behaviour byte-for-byte. No pre-pass, no short-circuit. | Default — preserves existing call-site behaviour. All baseline tests pass unchanged. |
-| `"preserve"` | **Strategy C narrow short-circuit.** If `parse(new_content) == parse(baseline_content)` (AST-equality, ignoring whitespace), write the baseline file's bytes verbatim and skip canonical re-emission entirely. Otherwise fall through to canonical `emit()`. | Governance / context files where whitespace-only or no-op edits should produce a zero-byte diff. **Note:** richer per-key dirty tracking (Strategy A) is intentionally deferred to [GH#377](https://github.com/elevanaltd/octave-mcp/issues/377). |
-| `"expanded"` | AST normalisation pre-pass that lifts `InlineMap` (and `ListValue` items that are `InlineMap`) into `Block` form before `emit()`. Materially changes on-disk shape vs default. | Canonicalisation pipelines where compact inline shapes must be normalised to multi-line Blocks for diff stability or downstream tooling. |
+| _(unset / omitted)_ | Today's canonical behaviour byte-for-byte. No pre-pass, no short-circuit. | Default — preserves existing call-site behaviour. **Note:** in **v1.14.0** this default will flip to `"preserve"`; pin a value explicitly if byte-shape stability across versions matters. |
+| _(explicit `null` / `None`)_ | **Deprecated in v1.13.0.** Same byte-for-byte behaviour as omission today, but emits a `DeprecationWarning` to announce the v1.14.0 default flip. | Avoid — either omit the parameter (accept the future default) or pin an explicit string value. |
+| `"preserve"` | **Strategy A span-aware preserve mode (#418).** Single-region slice-and-replace: clean nodes are sliced verbatim from the post-NFC baseline bytes; only mutated subtrees (`dirty`, `body_dirty`, `repaired`, `meta_dirty[k]=True`) are re-emitted canonically. Diff footprint ≤0.5% of file size on representative documents. Subsumes GH#248 mixed annotation form drift. Falls through to canonical `emit()` when the doc was parsed from user-supplied new content (content mode — spans index the new content, not the baseline file). | The recommended mode for changes-mode edits where unchanged regions should produce zero-byte diff. |
+| `"expanded"` | AST normalisation pre-pass that lifts `InlineMap` (and `ListValue` items that are `InlineMap`) into `Block` form before `emit()`. Materially changes on-disk shape vs default. | Canonicalisation pipelines where compact inline shapes must be normalised to multi-line Blocks for diff stability or downstream tooling. ALSO the recommended pin if you want to keep v1.12.0 canonical re-emit behaviour past the v1.14.0 default flip. |
 | `"compact"` | AST pre-pass that collapses atom-only Blocks (no `Comment` anywhere in subtree, arity ≤ 8) into `Assignment(value=ListValue([InlineMap{...}, ...]))` form. Subtrees containing **any** `Comment` are vetoed and a `W_COMPACT_REFUSED` correction is appended to the repair log. | Token-minimised outputs for LLM consumption — but mind the comment veto. |
 
 ##### `W_COMPACT_REFUSED` repair record
@@ -271,13 +272,53 @@ form would silently drop them. The veto + audit-log pattern preserves both
 the source content and a transparent record of where compact-mode could not
 be applied.
 
-##### Forward reference
+##### Strategy A NFC contract for `baseline_bytes` (#377, #418)
 
-Strategy A (per-key dirty tracking, deep changes-mode paths, source-span
-infrastructure, and the `_normalize_value_for_ast` Block-shape preservation
-fix) is tracked in [GH#377](https://github.com/elevanaltd/octave-mcp/issues/377).
-The default value of `format_style` may flip from unset to `"preserve"` at
-that point; today's PR-A ships the toggle as purely additive.
+When `format_style="preserve"` is engaged, the span-aware emitter slices
+unchanged regions verbatim from a `baseline_bytes: bytes` value supplied
+via `FormatOptions`. The slice path is only correct if `baseline_bytes`
+satisfies the **post-NFC byte equality contract**:
+
+> `baseline_bytes == octave_mcp.core.lexer.normalize_content(raw).encode("utf-8")`
+
+where `raw` is the original file content. The reason is structural —
+`tokenize()` applies fence-aware NFC normalisation via the internal
+`_normalize_with_fence_detection` pass, and every `Token.start_byte` /
+`Token.end_byte` (and the AST node spans derived from them) indexes the
+NFC-normalised byte stream, **not** the raw on-disk bytes. A plain
+`unicodedata.normalize("NFC", raw)` is **not equivalent** because the
+fence-aware pass deliberately exempts literal-zone (fenced) content from
+NFC. Passing un-normalised `baseline_bytes` would corrupt the slice
+output for any document containing pre-NFC Unicode outside literal
+zones.
+
+The MCP `WriteTool` and CLI `write` command thread this contract
+automatically via the internal `mcp.write._to_baseline_bytes()` helper.
+**Python callers using `mcp.write._emit_with_style` directly** must
+either:
+
+* prefer `_to_baseline_bytes(raw_str)` (recommended — single source of
+  truth, returns `None` on malformed baselines so the slice path
+  degrades safely), OR
+* call `from octave_mcp.core.lexer import normalize_content; baseline_bytes = normalize_content(raw).encode("utf-8")`.
+
+The CE-identified hard constraints behind this contract are documented
+in PR #418's commit history as **HC-1** (don't pass pre-NFC `str` to the
+slice path), **HC-2** (`baseline_bytes` type is `bytes | None`, not
+`str | None`), and **HC-3** (expose `normalize_content()` as a public
+utility for write-pipeline callers).
+
+##### `spans_valid_for_baseline` discriminator
+
+`_emit_with_style(spans_valid_for_baseline=...)` is a structural
+discriminator that must be `True` only when the parsed `Document` was
+built from the same content that `baseline_bytes` represents — i.e.
+changes-mode or normalize-mode where `doc = parse(baseline_content)`.
+It must be `False` in content-mode where the caller supplied entirely
+new content, because the doc's `start_byte`/`end_byte` values index the
+NEW content's bytes, not the old baseline. Slicing the old baseline
+with new-content spans would produce garbage; the discriminator forces
+fall-through to canonical `emit()` in that case.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -576,5 +576,70 @@ octave-mcp-server 2>&1 | tee server-log.txt
 
 ---
 
+## Migration: `format_style` across versions (v1.12 → v1.13 → v1.14)
+
+`octave_write`'s `format_style` parameter is being rolled out in three stages
+across v1.12.0, v1.13.0, and v1.14.0. This section documents the behaviour
+matrix and the recommended upgrade path for callers.
+
+### Behaviour matrix
+
+| `format_style` value | v1.12.0 behaviour | v1.13.0 behaviour | v1.14.0 behaviour (planned) |
+|---|---|---|---|
+| _(parameter omitted)_ | Full canonical re-emit. Today's default. | **Unchanged** — full canonical re-emit. No warning. | **Flips to `"preserve"`** — span-aware preserve mode. No warning. |
+| `None` *(explicit)* | Full canonical re-emit (same as omitted). | **Deprecated** — same full canonical re-emit behaviour, but emits a `DeprecationWarning` announcing the v1.14.0 flip. | Behaviour TBD; treat as removed. Pin an explicit string value. |
+| `"preserve"` | Strategy C narrow short-circuit (`parse∘emit` identity). | **Strategy A span-aware preserve mode (#418).** Single-region slice-and-replace; clean nodes byte-identical to baseline. | Same as v1.13.0 (the new default). |
+| `"expanded"` | AST lift `InlineMap` → `Block` form. | Unchanged. | Unchanged. |
+| `"compact"` | AST collapse atom-only Blocks → inline-list; veto + `W_COMPACT_REFUSED` on comment-bearing subtrees. | Unchanged. | Unchanged. |
+| unknown string | `E_INVALID_FORMAT_STYLE` | `E_INVALID_FORMAT_STYLE` | `E_INVALID_FORMAT_STYLE` |
+
+### Recommended upgrade path
+
+| If you are on v1.12.0 and you… | …recommended action for v1.13.0 |
+|---|---|
+| omit `format_style` and DO NOT care about the v1.14.0 default flip | No change required. Keep omitting. You will silently accept Strategy A preserve mode in v1.14.0. |
+| omit `format_style` and DO care about byte-shape stability across the v1.14.0 flip | Pin an explicit value now. Pass `format_style="expanded"` if you want to keep v1.12.0 canonical re-emit behaviour, or `format_style="preserve"` if you want the future default. |
+| pass `format_style=None` explicitly (e.g. from a wrapper that always sets it) | Replace with `format_style="expanded"` (keep current behaviour) **or** drop the explicit None (accept the future default silently). The explicit-None path will emit a `DeprecationWarning` in v1.13.0. |
+| pass `format_style="preserve"` explicitly | No change. You will now benefit from Strategy A's single-region diffs (≤0.5% diff footprint) instead of Strategy C's narrow short-circuit. |
+| pass `format_style="expanded"` or `format_style="compact"` explicitly | No change. Behaviour is preserved across the flip. |
+
+### Silencing the `DeprecationWarning`
+
+The v1.13.0 `DeprecationWarning` fires only when `format_style=None` is
+passed *explicitly*. The cleanest way to silence it is to replace the
+explicit `None` with the value that captures your intent:
+
+```python
+# Before — emits DeprecationWarning in v1.13.0:
+result = await write_tool.execute(target_path=path, changes=changes, format_style=None)
+
+# After — explicit pin, no warning, byte-shape stable across v1.14.0:
+result = await write_tool.execute(target_path=path, changes=changes, format_style="expanded")
+```
+
+If you need to suppress the warning at the consumer level instead (e.g. a
+library that wraps `octave_write` and cannot change its caller's code),
+use the standard `warnings` filter:
+
+```python
+import warnings
+
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="octave_mcp")
+    result = await write_tool.execute(target_path=path, changes=changes, format_style=None)
+```
+
+This is **not recommended** as a long-term strategy — the underlying
+behavioural flip still lands in v1.14.0. Use the explicit-pin upgrade
+above as a permanent fix.
+
+### CLI equivalent
+
+The CLI surface mirrors the same contract. `octave write --format-style none`
+is the explicit-None analogue and emits the deprecation warning; omitting
+`--format-style` is silent. The behaviour matrix above applies identically.
+
+---
+
 For MCP configuration details, see [MCP Configuration Guide](mcp-configuration.md).
 For API reference, see [API Reference](api.md).

--- a/src/octave_mcp/cli/main.py
+++ b/src/octave_mcp/cli/main.py
@@ -399,16 +399,20 @@ def validate(file: str | None, use_stdin: bool, schema: str | None, fix: bool, v
 @click.option(
     "--format-style",
     "format_style",
-    type=click.Choice(["preserve", "expanded", "compact"]),
+    type=click.Choice(["preserve", "expanded", "compact", "none"]),
     default=None,
     help=(
         "Output formatting style (GH#376 PR-A). "
-        "'preserve' = Strategy C no-op shortcut (write baseline bytes verbatim "
-        "when new content is AST-equal to existing file). "
+        "'preserve' = Strategy A span-aware preserve mode (write baseline bytes "
+        "verbatim for unchanged regions, re-emit only mutated subtrees). "
         "'expanded' = lift inline-map shapes into Block form. "
         "'compact' = collapse atom-only Blocks to inline-list form (vetoed on "
         "comment-bearing subtrees, W_COMPACT_REFUSED logged). "
-        "Default: today's canonical behaviour."
+        "'none' = explicitly request today's canonical behaviour (emits a "
+        "DeprecationWarning — in v1.14.0 the default will flip to 'preserve'). "
+        "Omitting the flag accepts the current default silently and will "
+        "accept the v1.14.0 default flip silently — pass an explicit value "
+        "if you want byte-shape stability across versions."
     ),
 )
 def write(
@@ -432,6 +436,7 @@ def write(
     """
     import json as json_module
     import sys
+    import warnings as _warnings
 
     from octave_mcp.core.emitter import emit  # noqa: F401 -- kept for backwards-compatible imports
     from octave_mcp.core.file_ops import atomic_write_octave, validate_octave_path
@@ -445,6 +450,27 @@ def write(
         _to_baseline_bytes,
     )
     from octave_mcp.schemas.loader import get_builtin_schema
+
+    # ADR-0006 Sprint 2 addendum §5 Shape B (PR-4 T10): the CLI mirrors
+    # the MCP tool's explicit-None deprecation contract. Click cannot
+    # distinguish "omitted" from "explicitly passed None" — omitting
+    # ``--format-style`` always sets the parameter to None. To honour
+    # the "warn ONLY on explicit None" rule, we expose ``--format-style
+    # none`` as a literal choice that maps to None AND triggers the
+    # warning; bare omission stays silent.
+    if format_style == "none":
+        _warnings.warn(
+            "Passing --format-style=none explicitly is deprecated. "
+            "In v1.14.0 the default will change from full canonical "
+            "re-emit to span-aware preserve mode. To keep the current "
+            "canonical re-emit behaviour, pass --format-style=expanded "
+            "explicitly. To opt in to preserve mode now, pass "
+            "--format-style=preserve. To accept the future default "
+            "silently, omit the flag entirely.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        format_style = None
 
     # CRS-FIX #3: XOR enforcement - exactly ONE input source
     # Count how many input sources are provided

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -2047,25 +2047,61 @@ class WriteTool(BaseTool):
 
         # GH#376 PR-A: format_style toggle. Three modes are AST projections
         # of one canonical emit() (I1 Single-Canon Discipline).
+        #
+        # CE + CRS CONDITIONAL on PR #422: the schema description and
+        # null-handling must reflect Strategy A (GH#377, shipped via PR #418)
+        # AND the Shape B deprecation contract — otherwise JSON-RPC clients
+        # see stale Strategy-C metadata, and explicit `null` from a client
+        # gets rejected at the schema boundary before reaching the Python
+        # DeprecationWarning code path.
         schema.add_parameter(
             "format_style",
             "string",
             required=False,
             description=(
                 "Output formatting style for canonical emission. "
-                "'preserve' (Strategy C): if new content is AST-equal to the existing file, "
-                "write the baseline bytes verbatim — zero diff for whitespace-only edits. "
-                "'expanded': lift inline-map shapes (KEY::[K::V,...]) into Block form before emit. "
-                "'compact': collapse atom-only Blocks (no comments, arity-bounded) into "
-                "inline-list-of-InlineMap form. Comment-bearing subtrees are vetoed and a "
-                f"{W_COMPACT_REFUSED} record surfaces in corrections (I3 Mirror Constraint, "
-                "I4 Auditability). When omitted, today's canonical behaviour is preserved exactly. "
-                "(GH#376 PR-A — full preserve-mode strategy A is tracked separately as #377.)"
+                "'preserve' (Strategy A, GH#377): span-aware preserve mode — "
+                "clean nodes slice from baseline_bytes, dirty/repaired nodes "
+                "re-emit canonically. Diff footprint ≤0.5% of file size on "
+                "single-key edits against representative documents. Subsumes "
+                "GH#248 mixed annotation form drift. "
+                "'expanded': lift inline-map shapes (KEY::[K::V,...]) into "
+                "Block form before emit. "
+                "'compact': collapse atom-only Blocks (no comments, "
+                f"arity-bounded) into inline-list-of-InlineMap form. "
+                f"Comment-bearing subtrees vetoed with {W_COMPACT_REFUSED} "
+                "(I3 Mirror Constraint, I4 Auditability). "
+                "DEPRECATED v1.13.0: Passing format_style=null explicitly "
+                "emits a DeprecationWarning; the default will change from "
+                "full canonical re-emit to 'preserve' in v1.14.0. To keep "
+                "canonical re-emit past the flip, pass 'expanded' "
+                "explicitly. To opt in to the new default early, pass "
+                "'preserve'. Omitting the parameter accepts the future "
+                "default silently."
             ),
             enum=list(FORMAT_STYLE_VALUES),
         )
 
-        return schema.build()
+        built = schema.build()
+
+        # CE + CRS CONDITIONAL on PR #422: widen format_style to allow
+        # explicit null so JSON-RPC clients reach the Python-side
+        # DeprecationWarning instead of being rejected at the schema
+        # boundary. SchemaBuilder.add_parameter accepts only a scalar
+        # type string and a string-only enum list, so we post-process
+        # the built schema rather than widening the builder API (which
+        # has 29 other callsites). The contract on Python callers is
+        # unchanged — explicit None still triggers the deprecation
+        # warning at WriteTool.execute (the warning's source-of-truth
+        # check is "format_style" in kwargs and kwargs["format_style"]
+        # is None, not the schema enum).
+        _fs_schema = built["properties"]["format_style"]
+        _fs_schema["type"] = ["string", "null"]
+        # Append None to the enum so the canonical JSON Schema validator
+        # accepts a literal `null` from JSON-RPC clients.
+        _fs_schema["enum"] = [*FORMAT_STYLE_VALUES, None]
+
+        return built
 
     def _validate_path(self, target_path: str) -> tuple[bool, str | None]:
         """Validate target path for security.

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -3308,6 +3308,19 @@ class WriteTool(BaseTool):
             base_hash: Optional CAS consistency check hash
             schema: Optional schema name for validation
             debug_grammar: Whether to include compiled grammar in output (default: False)
+            format_style: Output formatting mode. One of ``"preserve"`` /
+                ``"expanded"`` / ``"compact"`` or omitted.
+
+                .. deprecated:: 1.13.0
+                    Passing ``format_style=None`` EXPLICITLY is deprecated.
+                    In v1.14.0 the default will change from full canonical
+                    re-emit to span-aware ``"preserve"`` mode. To keep the
+                    current canonical re-emit behaviour beyond v1.14.0,
+                    pass ``format_style="expanded"`` explicitly. To opt in
+                    to preserve mode now, pass ``format_style="preserve"``.
+                    OMITTING the parameter does NOT emit a warning — that
+                    is the supported way to accept the future default
+                    silently. See ADR-0006 Sprint 2 addendum §5 Shape B.
 
         Returns:
             Dictionary with:
@@ -3346,6 +3359,29 @@ class WriteTool(BaseTool):
         corrections_only = params.get("corrections_only", False) or params.get("dry_run", False)
         parse_error_policy = params.get("parse_error_policy", "error")
         # GH#376 PR-A: format_style is optional; None preserves today's behaviour.
+        #
+        # ADR-0006 Sprint 2 addendum §5 Shape B (PR-4 T10): in v1.13.0,
+        # passing format_style=None EXPLICITLY emits a DeprecationWarning
+        # so callers know the v1.14.0 default flip is coming. Omitting
+        # the parameter does NOT warn — that would spam every caller of
+        # the default path. The distinction is made by checking
+        # ``"format_style" in kwargs`` (explicit) versus absent (omitted).
+        # In v1.14.0 the default will flip from full canonical re-emit
+        # to span-aware "preserve" mode.
+        if "format_style" in kwargs and kwargs["format_style"] is None:
+            import warnings as _warnings
+
+            _warnings.warn(
+                "Passing format_style=None explicitly is deprecated. "
+                "In v1.14.0 the default will change from full canonical "
+                "re-emit to span-aware preserve mode. To keep the current "
+                "canonical re-emit behaviour, pass format_style='expanded' "
+                "explicitly. To opt in to preserve mode now, pass "
+                "format_style='preserve'. To accept the future default "
+                "silently, omit the parameter entirely.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         format_style = params.get("format_style")
 
         if parse_error_policy not in ("error", "salvage"):

--- a/tests/unit/test_format_style.py
+++ b/tests/unit/test_format_style.py
@@ -174,9 +174,15 @@ class TestFormatStyleSchema:
         schema = tool.get_input_schema()
         assert "format_style" in schema["properties"]
         prop = schema["properties"]["format_style"]
-        assert prop["type"] == "string"
-        # Enum lists exactly the three documented values
-        assert set(prop["enum"]) == {"preserve", "expanded", "compact"}
+        # CE + CRS CONDITIONAL on PR #422: the type is widened to admit
+        # explicit `null` so JSON-RPC clients reach the Python-side
+        # DeprecationWarning instead of being rejected at the schema
+        # boundary. The three documented string values are still admitted.
+        assert prop["type"] == ["string", "null"]
+        # Enum admits the three documented string values AND None for
+        # the Shape B explicit-null deprecation path.
+        assert {v for v in prop["enum"] if v is not None} == {"preserve", "expanded", "compact"}
+        assert None in prop["enum"]
         # Optional (not required)
         assert "format_style" not in schema.get("required", [])
 

--- a/tests/unit/test_format_style_deprecation.py
+++ b/tests/unit/test_format_style_deprecation.py
@@ -1,0 +1,253 @@
+"""DeprecationWarning coverage for the v1.13.0 ``format_style`` Shape B rollout.
+
+ADR-0006 Sprint 2 addendum §5 (PR-4 T10): in v1.13.0 the MCP ``octave_write``
+tool and the CLI ``write`` command both keep today's full canonical re-emit
+behaviour when ``format_style`` is omitted, BUT emit a ``DeprecationWarning``
+when the caller passes ``format_style=None`` *explicitly*. The warning
+announces the upcoming v1.14.0 default flip (from canonical re-emit to
+span-aware ``"preserve"`` mode).
+
+This test suite enforces the Shape B contract:
+
+  1. ``format_style=None`` passed explicitly → ``DeprecationWarning`` fires.
+  2. ``format_style`` omitted entirely      → no warning.
+  3. ``format_style`` passed with any valid string ("preserve", "expanded",
+     "compact") → no warning.
+  4. Byte-shape of output under "explicit None" is identical to byte-shape
+     of output when omitted — the v1.13.0 contract is "warn but keep
+     today's behaviour exactly". This guards against a careless future
+     refactor that warns AND flips the default in the same release.
+
+Hard constraints (from the PR-4 task spec):
+  * No default flip in v1.13.0.
+  * Warning fires ONLY on explicit None, NOT on omission.
+  * All public entrypoints get the warning (MCP tool + CLI).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import warnings
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from octave_mcp.cli.main import cli
+from octave_mcp.mcp.write import WriteTool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run_mcp_execute(**kwargs) -> dict:
+    """Invoke ``WriteTool().execute(**kwargs)`` synchronously and return the result."""
+    tool = WriteTool()
+    return asyncio.run(tool.execute(**kwargs))
+
+
+def _make_tmp_file(initial: str) -> str:
+    """Create a temp .oct.md file with ``initial`` content; return its path."""
+    fd, path = tempfile.mkstemp(suffix=".oct.md")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(initial)
+    except Exception:
+        os.unlink(path)
+        raise
+    return path
+
+
+# ---------------------------------------------------------------------------
+# MCP surface coverage
+# ---------------------------------------------------------------------------
+
+
+class TestMCPDeprecationWarning:
+    """Shape B coverage for the MCP ``WriteTool.execute`` entrypoint."""
+
+    def test_deprecation_warning_fires_on_explicit_none(self) -> None:
+        """Passing ``format_style=None`` explicitly MUST emit a DeprecationWarning."""
+        path = _make_tmp_file('===TEST===\nKEY::"v1"\n===END===\n')
+        try:
+            with pytest.warns(DeprecationWarning, match="format_style=None"):
+                _run_mcp_execute(
+                    target_path=path,
+                    changes={"KEY": "v2"},
+                    format_style=None,
+                )
+        finally:
+            os.unlink(path)
+
+    def test_no_warning_when_omitted(self) -> None:
+        """Omitting ``format_style`` MUST NOT emit any DeprecationWarning.
+
+        This is the dominant call path. If a warning fired on omission, every
+        existing caller would be spammed — defeating the point of Shape B.
+        """
+        path = _make_tmp_file('===TEST===\nKEY::"v1"\n===END===\n')
+        try:
+            with warnings.catch_warnings():
+                # Promote any DeprecationWarning to an error so a stray warning
+                # would fail this test instead of being silently swallowed.
+                warnings.simplefilter("error", DeprecationWarning)
+                _run_mcp_execute(
+                    target_path=path,
+                    changes={"KEY": "v2"},
+                    # format_style omitted intentionally
+                )
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.parametrize("style", ["preserve", "expanded", "compact"])
+    def test_no_warning_on_explicit_valid_style(self, style: str) -> None:
+        """Any explicit valid ``format_style`` value MUST be silent."""
+        path = _make_tmp_file('===TEST===\nKEY::"v1"\n===END===\n')
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                _run_mcp_execute(
+                    target_path=path,
+                    changes={"KEY": "v2"},
+                    format_style=style,
+                )
+        finally:
+            os.unlink(path)
+
+    def test_behavior_unchanged_under_explicit_none_vs_omitted(self) -> None:
+        """v1.13.0 contract: byte-shape of output under explicit-None MUST
+        match byte-shape under omission. The warning fires but the behaviour
+        does NOT flip until v1.14.0. This guards against a careless future
+        refactor that warns AND changes the default in the same release.
+        """
+        initial = '===TEST===\nKEY::"v1"\nOTHER::"stable"\n===END===\n'
+
+        # Run with omitted format_style.
+        path_omitted = _make_tmp_file(initial)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                _run_mcp_execute(target_path=path_omitted, changes={"KEY": "v2"})
+            output_omitted = Path(path_omitted).read_bytes()
+        finally:
+            os.unlink(path_omitted)
+
+        # Run with explicit None (suppressing the expected warning so the test
+        # is asserting BEHAVIOUR not the warning here).
+        path_explicit = _make_tmp_file(initial)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                _run_mcp_execute(target_path=path_explicit, changes={"KEY": "v2"}, format_style=None)
+            output_explicit = Path(path_explicit).read_bytes()
+        finally:
+            os.unlink(path_explicit)
+
+        assert output_omitted == output_explicit, (
+            "v1.13.0 contract violated: explicit-None and omitted "
+            "format_style produced different output bytes. The default flip "
+            "is scheduled for v1.14.0 — not v1.13.0."
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI surface coverage
+# ---------------------------------------------------------------------------
+#
+# Click cannot distinguish "omitted" from "explicitly passed None" at the
+# Python signature level — omission always sets format_style=None on the
+# wrapped function. To honour the "warn ONLY on explicit None" Shape B
+# constraint at the CLI surface, the CLI exposes ``--format-style none`` as
+# a literal choice that triggers the warning. Bare omission stays silent.
+
+
+class TestCLIDeprecationWarning:
+    """Shape B coverage for the ``octave write`` CLI entrypoint."""
+
+    def _invoke(self, path: str, *extra_args: str) -> tuple[int, str]:
+        """Run the CLI write command and return (exit_code, combined_output).
+
+        ``mix_stderr=True`` is the CliRunner default but we make it
+        explicit so the DeprecationWarning text (written to stderr by
+        Python's warnings module under ``-W default``) is captured.
+        """
+        runner = CliRunner()
+        args = ["write", path, "--changes", '{"KEY":"v2"}', *extra_args]
+        # Force the warnings module to actually emit (default filters may
+        # suppress DeprecationWarning depending on Python invocation).
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", DeprecationWarning)
+            result = runner.invoke(cli, args)
+        deprecation_messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+        return result.exit_code, "\n".join(deprecation_messages)
+
+    def test_deprecation_warning_fires_on_explicit_format_style_none(self) -> None:
+        """``--format-style none`` MUST emit a DeprecationWarning."""
+        path = _make_tmp_file('===TEST===\nKEY::"v1"\n===END===\n')
+        try:
+            exit_code, deprecation_text = self._invoke(path, "--format-style", "none")
+            assert exit_code == 0, "CLI write should still succeed (the warning is non-fatal)"
+            assert "--format-style=none" in deprecation_text or "format_style" in deprecation_text, (
+                f"Expected a DeprecationWarning mentioning the format_style flag; " f"got: {deprecation_text!r}"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_no_warning_when_flag_omitted(self) -> None:
+        """Omitting ``--format-style`` MUST NOT emit a DeprecationWarning."""
+        path = _make_tmp_file('===TEST===\nKEY::"v1"\n===END===\n')
+        try:
+            exit_code, deprecation_text = self._invoke(path)
+            assert exit_code == 0
+            assert deprecation_text == "", (
+                f"Unexpected DeprecationWarning when --format-style was omitted: " f"{deprecation_text!r}"
+            )
+        finally:
+            os.unlink(path)
+
+    @pytest.mark.parametrize("style", ["preserve", "expanded", "compact"])
+    def test_no_warning_on_explicit_valid_style(self, style: str) -> None:
+        """Any explicit valid ``--format-style`` value MUST be silent."""
+        path = _make_tmp_file('===TEST===\nKEY::"v1"\n===END===\n')
+        try:
+            exit_code, deprecation_text = self._invoke(path, "--format-style", style)
+            assert exit_code == 0
+            assert deprecation_text == "", (
+                f"Unexpected DeprecationWarning when --format-style={style}: " f"{deprecation_text!r}"
+            )
+        finally:
+            os.unlink(path)
+
+    def test_behavior_unchanged_when_explicit_none_vs_omitted(self) -> None:
+        """v1.13.0 contract at the CLI: ``--format-style none`` produces the
+        same output bytes as omitting the flag. The warning fires but the
+        behaviour does NOT flip until v1.14.0.
+        """
+        initial = '===TEST===\nKEY::"v1"\nOTHER::"stable"\n===END===\n'
+
+        path_omitted = _make_tmp_file(initial)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                self._invoke(path_omitted)
+            output_omitted = Path(path_omitted).read_bytes()
+        finally:
+            os.unlink(path_omitted)
+
+        path_explicit = _make_tmp_file(initial)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                self._invoke(path_explicit, "--format-style", "none")
+            output_explicit = Path(path_explicit).read_bytes()
+        finally:
+            os.unlink(path_explicit)
+
+        assert output_omitted == output_explicit, (
+            "v1.13.0 contract violated: --format-style=none and omitted "
+            "--format-style produced different output bytes. The default "
+            "flip is scheduled for v1.14.0 — not v1.13.0."
+        )

--- a/tests/unit/test_format_style_deprecation.py
+++ b/tests/unit/test_format_style_deprecation.py
@@ -251,3 +251,129 @@ class TestCLIDeprecationWarning:
             "--format-style produced different output bytes. The default "
             "flip is scheduled for v1.14.0 — not v1.13.0."
         )
+
+
+# ---------------------------------------------------------------------------
+# CE + CRS CONDITIONAL on PR #422: schema-level regression
+# ---------------------------------------------------------------------------
+#
+# The MCP input schema is the protocol-boundary contract. If the
+# ``format_style`` schema description claims Strategy C semantics (the
+# pre-PR-#418 narrow short-circuit) or references GH#377 as
+# "tracked separately" (#377 IS the Strategy A work, now landed), then
+# JSON-RPC clients see stale metadata while the Python-side runtime
+# behaves correctly — a silent protocol-level lie.
+#
+# Worse: if the schema declares ``"type": "string"`` (enum-only) without
+# a null variant, JSON-RPC clients passing explicit ``null`` are
+# rejected at the JSON Schema boundary BEFORE reaching the Python-side
+# DeprecationWarning code, making the Shape B deprecation contract
+# unreachable for protocol clients.
+
+
+class TestFormatStyleInputSchema:
+    """Schema-level regression: protocol-boundary metadata must reflect reality.
+
+    These checks guard against the schema going stale again as the
+    underlying ``format_style`` semantics evolve. They assert the
+    invariants the CE + CRS CONDITIONAL findings on PR #422 surfaced.
+    """
+
+    def _format_style_schema(self) -> dict:
+        """Return the ``format_style`` property dict from the MCP input schema."""
+        schema = WriteTool().get_input_schema()
+        properties = schema["properties"]
+        assert "format_style" in properties, "format_style missing from input schema"
+        return properties["format_style"]
+
+    def test_description_reflects_strategy_a_not_strategy_c(self) -> None:
+        """Description MUST describe Strategy A semantics, not the pre-PR-#418 Strategy C."""
+        desc = self._format_style_schema().get("description", "")
+        # Strategy A markers that MUST be present.
+        assert "Strategy A" in desc, (
+            "format_style schema description does not mention 'Strategy A' — "
+            "JSON-RPC clients still see stale Strategy-C metadata. "
+            "See CE+CRS CONDITIONAL on PR #422."
+        )
+        # Pre-PR-#418 phrases that MUST NOT be present.
+        for stale_marker in ("Strategy C", "parse-equality", "AST-equal to"):
+            assert stale_marker not in desc, (
+                f"format_style schema description contains stale Strategy-C "
+                f"phrase {stale_marker!r}. The schema must be updated to "
+                f"reflect Strategy A semantics (PR #418). "
+                f"See CE+CRS CONDITIONAL on PR #422."
+            )
+
+    def test_description_does_not_claim_gh_377_is_tracked_separately(self) -> None:
+        """GH#377 IS the Strategy A work landed in PR #418; the schema must not
+        claim it is still tracked elsewhere as outstanding."""
+        desc = self._format_style_schema().get("description", "")
+        # The literal "tracked separately as #377" phrasing from the
+        # pre-PR-#418 schema description.
+        assert "tracked separately as #377" not in desc, (
+            "format_style schema description still claims '#377 tracked "
+            "separately' — but GH#377 IS the Strategy A work, now landed "
+            "in PR #418. See CE+CRS CONDITIONAL on PR #422."
+        )
+
+    def test_description_surfaces_v1_13_0_deprecation_contract(self) -> None:
+        """The Shape B deprecation contract MUST be visible at the protocol boundary.
+
+        Without this, JSON-RPC clients have no warning at the schema level
+        that explicit ``null`` is deprecated and the v1.14.0 default flip
+        is coming.
+        """
+        desc = self._format_style_schema().get("description", "")
+        assert "DEPRECATED" in desc or "Deprecated" in desc or "deprecated" in desc, (
+            "format_style schema description does not surface the Shape B "
+            "deprecation contract. The protocol-boundary metadata must "
+            "match docstring + CHANGELOG visibility."
+        )
+        assert "v1.14.0" in desc, (
+            "format_style schema description does not name the v1.14.0 "
+            "flip target version. The protocol-boundary metadata must "
+            "match docstring + CHANGELOG visibility."
+        )
+
+    def test_schema_type_admits_null(self) -> None:
+        """The JSON Schema type MUST admit ``null`` so JSON-RPC clients
+        passing explicit ``null`` reach the Python-side DeprecationWarning
+        instead of being rejected at the schema boundary.
+        """
+        type_field = self._format_style_schema().get("type")
+        assert type_field is not None, "format_style schema missing 'type'"
+        if isinstance(type_field, str):
+            pytest.fail(
+                f"format_style schema declares type={type_field!r} (scalar "
+                f"string). JSON-RPC clients passing explicit null would be "
+                f"rejected at the schema boundary BEFORE reaching the "
+                f"Python-side DeprecationWarning. The type must be a list "
+                f"that includes 'null'. See CE+CRS CONDITIONAL on PR #422."
+            )
+        # type is a list — assert null is one of the admitted variants.
+        assert "null" in type_field, (
+            f"format_style schema type {type_field!r} does not include "
+            f"'null'. JSON-RPC clients passing explicit null would be "
+            f"rejected at the schema boundary."
+        )
+        # And 'string' is still admitted for the normal enum values.
+        assert "string" in type_field, (
+            f"format_style schema type {type_field!r} dropped 'string' — " f"normal enum values would now be rejected."
+        )
+
+    def test_schema_enum_admits_none(self) -> None:
+        """The enum MUST include ``None`` as a valid value alongside the
+        three string options so JSON-RPC clients passing literal null
+        validate successfully and reach the Python-side warning.
+        """
+        enum = self._format_style_schema().get("enum")
+        assert enum is not None, "format_style schema missing 'enum'"
+        assert None in enum, (
+            f"format_style schema enum {enum!r} does not include None. "
+            f"Explicit null from a JSON-RPC client would fail enum "
+            f"validation before reaching the DeprecationWarning. "
+            f"See CE+CRS CONDITIONAL on PR #422."
+        )
+        # And the three valid string values are still present.
+        for value in ("preserve", "expanded", "compact"):
+            assert value in enum, f"format_style schema enum dropped {value!r}"


### PR DESCRIPTION
## Summary

ADR-0006 Sprint 2 final implementation PR. Lands the **Shape B**
`format_style=None` deprecation contract (T10) and the v1.13.0
documentation set (T11). Sets up the v1.14.0 default flip from full
canonical re-emit to span-aware `"preserve"` mode without breaking
v1.13.0 callers.

* **T10 — `DeprecationWarning` on explicit `format_style=None`.**
  Fires at both public entrypoints (MCP `octave_write` tool, CLI
  `octave write` command). Omitting the parameter is silent — Shape B's
  rationale (don't spam every caller). The CLI exposes
  `--format-style none` as a literal Click choice that maps to the
  explicit-None path, since Click cannot otherwise distinguish "omitted"
  from "explicit None".
* **T11 — v1.13.0 documentation.** CHANGELOG entry covering Strategy A
  (#418), META admission (#419), and the Shape B deprecation; `docs/api.md`
  NFC contract precondition note for `baseline_bytes` (HC-1/HC-2/HC-3);
  `docs/usage.md` migration matrix covering v1.12 → v1.13 → v1.14 caller
  upgrade paths.

## Test plan

- [x] 12 new tests in `tests/unit/test_format_style_deprecation.py`
      covering all four Shape B invariants at both MCP and CLI surfaces:
      `pytest.warns(DeprecationWarning)` for the positive cases;
      `warnings.simplefilter("error", DeprecationWarning)` for the
      negative cases; byte-shape equivalence between explicit-None and
      omitted (enforces hard constraint #1: no behaviour flip in v1.13.0).
- [x] `uv run pytest tests/ -q --no-cov` — **3169 passed**, 11 skipped,
      1 xfailed (was 3157 baseline; +12 new).
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run black --check src tests` — clean (200 files).
- [x] `uv run mypy src/ --ignore-missing-imports` — clean (53 files).

## Hard constraints honored

1. **No default flip in v1.13.0.** Output bytes under `format_style=None`
   (explicit or omitted) are identical to today. The v1.14.0 flip is
   advisory-only in this release.
2. **Warning fires ONLY on explicit None, NOT on omission.** MCP surface
   uses `"format_style" in kwargs and kwargs["format_style"] is None`.
   CLI surface uses the new `--format-style none` literal choice.
3. **All public entrypoints get the warning.** MCP tool and CLI both
   covered; internal `_emit_with_style` does not (correct — it is not a
   public surface).
4. **CHANGELOG explicitly states the v1.14.0 flip plan.** Addendum §5.5
   contract surface satisfied.
5. **Existing tests stay GREEN.** All 3157 prior tests still pass; 12
   new tests added.

## References

- ADR-0006 Sprint 2 addendum §5.1 + §5.4 (Shape B rationale)
- ADR-0006 Sprint 2 addendum §5.5 (CHANGELOG contract surface)
- DUAL_KEY decision: HUMAN sign-off 2026-05-13
- PR #418 — Strategy A span-aware preserve mode engine (the underlying
  implementation that the deprecation contract sets up the default flip
  for)
- PR #419 — META audit-marker admission (GH#384)
- PR #421 — Sprint 2 EC coordination (EC-1 + EC-2 SATISFIED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deprecation warning when callers pass `format_style=None` explicitly at both the MCP `octave_write` tool and the `octave write` CLI, without changing behavior in v1.13.0. Also updates the MCP input schema to accept `null` and document Strategy A, and expands docs for the v1.14.0 default flip and the NFC `baseline_bytes` contract.

- **New Features**
  - MCP: `WriteTool.execute(..., format_style=None)` warns only on explicit `None`; omission and valid strings stay silent. Input schema now allows `null` (`type: ["string","null"]`, enum includes `None`) and its description reflects Strategy A and the v1.14.0 flip.
  - CLI: adds `--format-style none` to map to `None` and trigger the same warning; omitting `--format-style` remains silent. `--help` text updated to Strategy A semantics.
  - Docs: CHANGELOG v1.13.0 entry; `docs/api.md` updates `"preserve"` to Strategy A, adds the NFC `baseline_bytes` and `spans_valid_for_baseline` contracts; `docs/usage.md` includes the v1.12 → v1.13 → v1.14 matrix and upgrade guidance.
  - Tests: add coverage for explicit-None warnings, no-warning cases, byte-for-byte equivalence between explicit `None` and omission, and schema-level checks (Strategy A description, `null` type, `None` in enum).

- **Migration**
  - Keep canonical re-emit past v1.14.0: pass `format_style="expanded"`.
  - Opt in to the future default now: pass `format_style="preserve"`.
  - Accept the future default silently: omit `format_style` (or omit `--format-style` in the CLI).

<sup>Written for commit 77a97723b7206f9aee2856a8bc403eadfe16ebed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

