### PR TITLE
fix(schema): add PAUSED to DEBATE_TRANSCRIPT STATUS enum (GH-423)

### DIFF
--- a/src/octave_mcp/resources/specs/schemas/debate_transcript.oct.md
+++ b/src/octave_mcp/resources/specs/schemas/debate_transcript.oct.md
@@ -14,7 +14,7 @@ FIELDS:
   THREAD_ID::["example-debate-001"∧REQ→§INDEXER]
   TOPIC::["The topic of the debate"∧REQ→§SELF]
   MODE::["fixed"∧REQ∧ENUM[fixed,mediated]→§SELF]
-  STATUS::["active"∧REQ∧ENUM[active,synthesis,closed]→§SELF]
+  STATUS::["active"∧REQ∧ENUM[active,paused,synthesis,closed]→§SELF]
   PARTICIPANTS::[[Wind,Wall,Door]∧REQ∧TYPE[LIST]→§SELF]
   TURNS::[[turn1,turn2]∧REQ∧TYPE[LIST]→§SELF]
   SYNTHESIS::["Final synthesis from Door agent"∧OPT→§SELF]
@@ -33,7 +33,7 @@ USAGE_NOTES::[
   "THREAD_ID: Unique identifier for the debate, used for indexing and retrieval",
   "TOPIC: Human-readable description of what the debate is about",
   "MODE: 'fixed' for strict rotation, 'mediated' for flexible speaker selection",
-  "STATUS: 'active' during debate, 'synthesis' when Door is finalizing, 'closed' when complete",
+  "STATUS: 'active' during debate, 'paused' when awaiting human interjection, 'synthesis' when Door is finalizing, 'closed' when complete",
   "PARTICIPANTS: List of roles participating (typically Wind, Wall, Door)",
   "TURNS: Array of turn records with role, content, and optional cognition metadata",
   "SYNTHESIS: Final resolution from Door agent when debate closes"

--- a/tests/unit/test_debate_schema.py
+++ b/tests/unit/test_debate_schema.py
@@ -120,6 +120,46 @@ class TestDebateSchemaLoading:
         assert "synthesis" in raw, "STATUS should include 'synthesis' value"
         assert "closed" in raw, "STATUS should include 'closed' value"
 
+    def test_debate_schema_status_enum_includes_paused(self):
+        """STATUS enum MUST include 'paused' (GH-423).
+
+        debate-hall-mcp actively emits ``STATUS::paused`` for debates in the
+        human-interject state. Before GH-423, the DEBATE_TRANSCRIPT STATUS
+        enum was constrained to ``[active, synthesis, closed]`` only, producing
+        a live false negative in octave_validate against an active consumer.
+
+        North Star compliance:
+        - I5 SCHEMA_SOVEREIGNTY: validation status must reflect reality.
+        - I1 SYNTACTIC_FIDELITY: existing enum values retain identical semantics
+          (non-regression covered by ``test_debate_schema_status_has_enum``).
+        - I4 TRANSFORM_AUDITABILITY: this test documents the enum addition.
+        """
+        schema = load_schema_by_name("DEBATE_TRANSCRIPT")
+        assert schema is not None
+        assert "STATUS" in schema.fields
+
+        status_field = schema.fields["STATUS"]
+
+        # Prefer the parsed pattern when available
+        if status_field.pattern is not None and status_field.pattern.constraints:
+            for constraint in status_field.pattern.constraints.constraints:
+                if hasattr(constraint, "values"):
+                    assert (
+                        "paused" in constraint.values
+                    ), f"STATUS enum must include 'paused' (GH-423), got {constraint.values}"
+                    # Non-regression: prior values must still be present
+                    for prior in ("active", "synthesis", "closed"):
+                        assert prior in constraint.values, (
+                            f"STATUS enum lost prior value '{prior}'; " f"got {constraint.values}"
+                        )
+                    return
+
+        # Fallback: assert against raw schema text
+        raw = status_field.raw_value or ""
+        assert "paused" in raw, f"STATUS raw value must include 'paused' (GH-423): {raw!r}"
+        for prior in ("active", "synthesis", "closed"):
+            assert prior in raw, f"STATUS raw value lost prior value '{prior}': {raw!r}"
+
     def test_debate_schema_has_version(self):
         """Debate schema should have version defined."""
         schema = load_schema_by_name("DEBATE_TRANSCRIPT")


### PR DESCRIPTION
Closes #423.

## Summary

`DEBATE_TRANSCRIPT` schema's STATUS enum was missing `paused`, the value
`debate-hall-mcp` actively emits for debates in the human-interject state
(`DebateStatus.PAUSED = "paused"` in `state.py`). This produced a live
false negative in `octave_validate` against an active consumer.

This PR adds `paused` to the STATUS ENUM in canonical lifecycle order
(`active -> paused -> synthesis -> closed`) and adds a regression test
asserting both the new value and non-regression of prior values.

This is the first PR of the pre-v1.13.0 Schema Sweep Sprint (MICRO tier).
Six additional schema PRs (#420, #424, #425, #426, #427, #428) follow.
Scope strictly bounded to GH-423; no other sprint issues bundled.

## North Star compliance

- **I5 SCHEMA_SOVEREIGNTY**: `octave_validate` now surfaces validation
  status truthfully for paused debates (previously silent false negative).
- **I1 SYNTACTIC_FIDELITY**: existing enum values (`active`, `synthesis`,
  `closed`) retain identical semantics; `paused` inserted at lifecycle
  position between `active` and `synthesis`, no rename, no semantic shift.
- **I4 TRANSFORM_AUDITABILITY**: change is paired with a dedicated
  regression test (`test_debate_schema_status_enum_includes_paused`)
  documenting the transform and asserting non-regression of prior values.
  RED-then-GREEN commit history preserved per `tdd-discipline` pattern.

## Empirical evidence

- Consumer source: `/Volumes/HestAI-Projects/debate-hall-mcp/src/debate_hall_mcp/state.py:164`
  defines `PAUSED = "paused"`.
- Verified across `orchestrator.py` (8 emission sites), `decision.py`,
  `tools/orchestrate.py`, ADR-0002 (latent async auto-orchestration),
  and `tests/unit/test_speed_mode.py`.

## Quality gates

Local on Python 3.14 venv:

- `ruff check .` -> All checks passed
- `black --check .` -> 207 files unchanged
- `mypy src/` -> Success: no issues found in 53 source files
- `pytest` -> **3175 passed, 11 skipped, 1 xfailed** (was 3157 baseline)

Note: pytest reports a benign `INTERNALERROR` in the `pytest_cov` HTML
report step (missing `htmlfiles/index.html` in venv site-packages); test
outcomes themselves are unaffected. Surfacing to HO for separate triage.

## Test plan

- [x] RED test fails on current schema for the right reason (raw_value
      missing `paused`)
- [x] GREEN test passes after enum addition
- [x] Existing `test_debate_schema_status_has_enum` still passes
      (non-regression of `active`/`synthesis`/`closed`)
- [x] Full pytest suite green (3175 passed)
- [x] `ruff` / `black` / `mypy` green

## Review chain (TIER_2_STANDARD)

This PR requests the following review chain per the sprint protocol:

- **TMG** (test-methodology-guardian / goose): validate RED-GREEN test
  semantics and non-regression coverage of prior enum values.
- **CRS** (code-review-specialist / gemini): review schema delta and
  test coverage breadth.
- **CE** (critical-engineer / codex): validate I1/I4/I5 compliance and
  confirm no scope creep into other six sprint PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `paused` to the `DEBATE_TRANSCRIPT` `STATUS` enum to match `debate-hall-mcp` emissions and stop false negatives in `octave_validate`.

- **Bug Fixes**
  - Enum now includes `paused` (order: `active` → `paused` → `synthesis` → `closed`); usage notes clarify “awaiting human interjection”.
  - Added a regression test to assert `paused` and preserve `active`, `synthesis`, `closed`.

<sup>Written for commit 251b58befc05945088eac36532ae21a824c33d64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

