### PR TITLE
feat(schema): add AGENT_DEFINITION schema for .hestai-sys/library/agents/*.oct.md (GH-424)

### DIFF
--- a/src/octave_mcp/resources/specs/schemas/agent_definition.oct.md
+++ b/src/octave_mcp/resources/specs/schemas/agent_definition.oct.md
@@ -1,0 +1,55 @@
+===AGENT_DEFINITION===
+META:
+  TYPE::SCHEMA
+  VERSION::"1.0"
+  STATUS::ACTIVE
+  PURPOSE::"Schema for HestAI agent definition files at .hestai-sys/library/agents/*.oct.md. Validates the canonical multi-section envelope (META, §1::IDENTITY, §2::OPERATIONAL_BEHAVIOR, §3::CAPABILITIES, §4::INTERACTION_RULES) shared by 33+ on-disk agents. WAVE_2 of pre-v1.13.0 Schema Sweep (GH-424)."
+POLICY:
+  VERSION::"1.0"
+  UNKNOWN_FIELDS::WARN
+  TARGETS::[
+    "§1::IDENTITY",
+    "§2::OPERATIONAL_BEHAVIOR",
+    "§3::CAPABILITIES",
+    "§4::INTERACTION_RULES",
+    "§SELF"
+  ]
+FIELDS:
+  ROLE::["AGENT_ROLE_IDENTIFIER"∧REQ→§SELF]
+  COGNITION::["LOGOS"∧REQ∧ENUM[LOGOS,ETHOS,PATHOS]→§SELF]
+  ARCHETYPE::[["Archetype list"]∧OPT∧TYPE[LIST]→§SELF]
+  MODEL_TIER::["PREMIUM"∧OPT∧ENUM[PREMIUM,STANDARD]→§SELF]
+  MISSION::["MISSION_STATEMENT"∧REQ→§SELF]
+  PRINCIPLES::[["Principle list"]∧OPT∧TYPE[LIST]→§SELF]
+  AUTHORITY_ULTIMATE::[["Authority items"]∧OPT∧TYPE[LIST]→§SELF]
+  AUTHORITY_BLOCKING::[["Authority items"]∧OPT∧TYPE[LIST]→§SELF]
+  AUTHORITY_ADVISORY::[["Authority items"]∧OPT∧TYPE[LIST]→§SELF]
+  AUTHORITY_NO_OVERRIDE::["Boundary statement"∧OPT→§SELF]
+  AUTHORITY_MANDATE::["Accountability statement"∧REQ→§SELF]
+  AUTHORITY_ACCOUNTABILITY::["Accountability domain"∧OPT→§SELF]
+  CONDUCT::["Operational conduct block"∧OPT→§SELF]
+  SKILLS::[["Skill references"]∧OPT∧TYPE[LIST]→§SELF]
+  PATTERNS::[["Pattern references"]∧OPT∧TYPE[LIST]→§SELF]
+  CHASSIS::[["Chassis skill references"]∧OPT∧TYPE[LIST]→§SELF]
+  PROFILES::[["Profile entries"]∧OPT∧TYPE[LIST]→§SELF]
+  GRAMMAR::["Grammar block"∧OPT→§SELF]
+USAGE_NOTES::[
+  "TYPE: Agent definition documents declare META.TYPE::AGENT_DEFINITION at the envelope level. The schema name AGENT_DEFINITION matches this TYPE so the validator activates the deep section schema path.",
+  "ROLE: Uppercase identifier matching the agent's role; convention is one role per file (e.g., IMPLEMENTATION_LEAD, HOLISTIC_ORCHESTRATOR).",
+  "COGNITION: Reasoning style — LOGOS (convergent/Door), ETHOS (validation/Wall), PATHOS (divergent/Wind). Links to library/cognitions/<name>.oct.md for kernel decompression.",
+  "ARCHETYPE: List of archetype<qualifier> entries (e.g., HEPHAESTUS<implementation_craft>). Archetypes operate as analytical lenses, not personas.",
+  "MODEL_TIER: PREMIUM for deep reasoning agents; STANDARD for mechanical execution agents. Optional — defaults are role-dependent.",
+  "MISSION: Single-line mission compound joined by ⊕ (e.g., TECHNICAL_LEADERSHIP⊕CODE_QUALITY). Captures the agent's domain mandate.",
+  "PRINCIPLES: Ordered list of operating principles. Authoring convention is 3–6 entries.",
+  "AUTHORITY_ULTIMATE: Domains over which the agent has final say (e.g., Code_implementation). Composes with AUTHORITY_BLOCKING and AUTHORITY_ADVISORY.",
+  "AUTHORITY_BLOCKING: Conditions under which the agent MUST halt downstream work (e.g., Untested_code, CI_failures).",
+  "AUTHORITY_ADVISORY: Domains where the agent may advise but not block.",
+  "AUTHORITY_NO_OVERRIDE: Boundary statement — what the agent cannot unilaterally override even within its mandate.",
+  "AUTHORITY_MANDATE: Single-line accountability statement. REQUIRED — every agent must declare what it is accountable for.",
+  "AUTHORITY_ACCOUNTABILITY: Optional named accountability domain (e.g., 12 critical domains for critical-engineer).",
+  "CONDUCT: §2::OPERATIONAL_BEHAVIOR block holding TONE/PROTOCOL/OUTPUT/VERIFICATION/INTEGRATION sub-blocks. Free-form internal structure across agents.",
+  "SKILLS / PATTERNS: §3::CAPABILITIES references — must point to real on-disk skills/patterns (no phantom references).",
+  "CHASSIS / PROFILES: Alternative §3 shape used by chassis-profile agents (agent-expert, octave-secretary). Either {SKILLS,PATTERNS} or {CHASSIS,PROFILES} is acceptable.",
+  "GRAMMAR: §4::INTERACTION_RULES block with MUST_USE and MUST_NOT regex lists enforcing output discipline (e.g., '^\\[ANALYSIS\\]')."
+]
+===END===

--- a/tests/unit/test_agent_definition_schema.py
+++ b/tests/unit/test_agent_definition_schema.py
@@ -36,18 +36,9 @@ import pytest
 
 from octave_mcp.schemas.loader import load_schema_by_name
 
-
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _AGENTS_DIR = _REPO_ROOT / ".hestai-sys" / "library" / "agents"
-_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "src"
-    / "octave_mcp"
-    / "resources"
-    / "specs"
-    / "schemas"
-    / "agent_definition.oct.md"
-)
+_SCHEMA_PATH = _REPO_ROOT / "src" / "octave_mcp" / "resources" / "specs" / "schemas" / "agent_definition.oct.md"
 
 
 def _agent_files() -> list[Path]:
@@ -97,9 +88,7 @@ class TestAgentDefinitionSchemaLoading:
             if field.pattern is not None and field.pattern.constraints:
                 assert field.is_required, f"{name} should be REQ via pattern"
             else:
-                assert "REQ" in (field.raw_value or ""), (
-                    f"{name} should carry REQ in raw value: {field.raw_value!r}"
-                )
+                assert "REQ" in (field.raw_value or ""), f"{name} should carry REQ in raw value: {field.raw_value!r}"
 
     def test_schema_has_version(self) -> None:
         """Schema should declare an explicit version."""
@@ -145,9 +134,7 @@ META:
         )
         assert result["valid"] is False
         error_messages = [e.get("message", "") for e in result.get("validation_errors", [])]
-        assert any("ROLE" in msg for msg in error_messages), (
-            f"Error should mention ROLE. Got: {error_messages}"
-        )
+        assert any("ROLE" in msg for msg in error_messages), f"Error should mention ROLE. Got: {error_messages}"
 
     def test_missing_authority_mandate_is_invalid(self) -> None:
         """An agent missing AUTHORITY_MANDATE must fail validation."""
@@ -177,9 +164,9 @@ META:
         )
         assert result["valid"] is False
         error_messages = [e.get("message", "") for e in result.get("validation_errors", [])]
-        assert any("AUTHORITY_MANDATE" in msg for msg in error_messages), (
-            f"Error should mention AUTHORITY_MANDATE. Got: {error_messages}"
-        )
+        assert any(
+            "AUTHORITY_MANDATE" in msg for msg in error_messages
+        ), f"Error should mention AUTHORITY_MANDATE. Got: {error_messages}"
 
     def test_missing_mission_is_invalid(self) -> None:
         """An agent missing MISSION must fail validation."""
@@ -203,9 +190,9 @@ META:
     MUST_USE::[]
 ===END==="""
         result = _validate_content(content)
-        assert result["validation_status"] == "INVALID", (
-            f"Missing MISSION should be INVALID. Got: {result.get('validation_status')}"
-        )
+        assert (
+            result["validation_status"] == "INVALID"
+        ), f"Missing MISSION should be INVALID. Got: {result.get('validation_status')}"
         assert result["valid"] is False
 
 
@@ -295,9 +282,7 @@ class TestExistingAgentFilesValidate:
         "agent_filename",
         sorted(KNOWN_AUTHORITY_MANDATE_GAPS),
     )
-    def test_known_gap_agent_files_surface_authority_mandate_diagnostic(
-        self, agent_filename: str
-    ) -> None:
+    def test_known_gap_agent_files_surface_authority_mandate_diagnostic(self, agent_filename: str) -> None:
         """Known-gap agents surface the AUTHORITY_MANDATE E003 diagnostic.
 
         Pins the schema sovereignty signal (PROD::I5): the schema is doing
@@ -319,11 +304,8 @@ class TestExistingAgentFilesValidate:
         )
         errors = result.get("validation_errors", [])
         e003_authority_errors = [
-            e
-            for e in errors
-            if e.get("code") == "E003" and "AUTHORITY_MANDATE" in e.get("message", "")
+            e for e in errors if e.get("code") == "E003" and "AUTHORITY_MANDATE" in e.get("message", "")
         ]
         assert e003_authority_errors, (
-            f"{agent_filename}: expected E003/AUTHORITY_MANDATE diagnostic, "
-            f"got errors={errors!r}"
+            f"{agent_filename}: expected E003/AUTHORITY_MANDATE diagnostic, " f"got errors={errors!r}"
         )

--- a/tests/unit/test_agent_definition_schema.py
+++ b/tests/unit/test_agent_definition_schema.py
@@ -242,17 +242,36 @@ META:
         assert result["valid"] is True
 
 
+# Empirically-surfaced gaps in the existing agent corpus (WAVE_2 finding).
+# These two files genuinely lack AUTHORITY_MANDATE — every other on-disk
+# agent declares one. Tracked as a follow-up gap to be filled in upstream
+# (agent-expert authoring), NOT by relaxing the schema. Honours HEPHAESTUS
+# bias (anvil of real input surfaces real defects) and ATLAS bias (do not
+# weaken load-bearing schema fields to paper over upstream omissions).
+KNOWN_AUTHORITY_MANDATE_GAPS: frozenset[str] = frozenset(
+    {
+        "ideator.oct.md",
+        "synthesizer.oct.md",
+    }
+)
+
+
 class TestExistingAgentFilesValidate:
     """Integration: every on-disk agent file validates clean against the schema.
 
     Each ``.hestai-sys/library/agents/*.oct.md`` file is the empirical ground
-    truth for the schema. If any file fails validation, the schema is wrong
-    (forge it on the anvil of real input — HEPHAESTUS bias).
+    truth for the schema. Files NOT on the known-gap allowlist must validate
+    clean (forge it on the anvil of real input — HEPHAESTUS bias).
+
+    The known-gap allowlist (``KNOWN_AUTHORITY_MANDATE_GAPS``) records agents
+    surfaced as structurally incomplete by this schema. They are pinned by a
+    second test to ensure the AUTHORITY_MANDATE diagnostic remains visible
+    (PROD::I5 SCHEMA_SOVEREIGNTY).
     """
 
     @pytest.mark.parametrize(
         "agent_path",
-        _agent_files(),
+        [p for p in _agent_files() if p.name not in KNOWN_AUTHORITY_MANDATE_GAPS],
         ids=lambda p: p.name,
     )
     def test_existing_agent_file_validates(self, agent_path: Path) -> None:
@@ -271,3 +290,40 @@ class TestExistingAgentFilesValidate:
                 f"  total_errors={len(errors)}"
             )
         assert result["valid"] is True
+
+    @pytest.mark.parametrize(
+        "agent_filename",
+        sorted(KNOWN_AUTHORITY_MANDATE_GAPS),
+    )
+    def test_known_gap_agent_files_surface_authority_mandate_diagnostic(
+        self, agent_filename: str
+    ) -> None:
+        """Known-gap agents surface the AUTHORITY_MANDATE E003 diagnostic.
+
+        Pins the schema sovereignty signal (PROD::I5): the schema is doing
+        its job by reporting the structural omission. If this test starts
+        failing because the file now validates clean, the gap has been
+        closed upstream and the entry should be removed from
+        ``KNOWN_AUTHORITY_MANDATE_GAPS``.
+        """
+        agent_path = _AGENTS_DIR / agent_filename
+        if not agent_path.exists():
+            pytest.skip(f"{agent_filename} no longer exists on disk")
+
+        content = agent_path.read_text(encoding="utf-8")
+        result = _validate_content(content)
+
+        assert result.get("validation_status") == "INVALID", (
+            f"{agent_filename} unexpectedly validates clean — gap may be closed. "
+            f"Remove from KNOWN_AUTHORITY_MANDATE_GAPS."
+        )
+        errors = result.get("validation_errors", [])
+        e003_authority_errors = [
+            e
+            for e in errors
+            if e.get("code") == "E003" and "AUTHORITY_MANDATE" in e.get("message", "")
+        ]
+        assert e003_authority_errors, (
+            f"{agent_filename}: expected E003/AUTHORITY_MANDATE diagnostic, "
+            f"got errors={errors!r}"
+        )

--- a/tests/unit/test_agent_definition_schema.py
+++ b/tests/unit/test_agent_definition_schema.py
@@ -1,0 +1,273 @@
+"""Tests for AGENT_DEFINITION schema validation (Issue #424, WAVE_2 Schema Sweep).
+
+TDD RED phase: These tests define expected behavior for agent definition
+file validation via ``octave_validate --schema AGENT_DEFINITION``.
+
+Agent definition files at ``.hestai-sys/library/agents/*.oct.md`` share the
+envelope structure:
+
+- META block with ``TYPE::AGENT_DEFINITION``, ``VERSION``, ``PURPOSE``,
+  ``CONTRACT``.
+- ``§1::IDENTITY`` (ROLE, COGNITION, ARCHETYPE, MODEL_TIER, MISSION,
+  PRINCIPLES, AUTHORITY_*).
+- ``§2::OPERATIONAL_BEHAVIOR`` (CONDUCT block with TONE/PROTOCOL).
+- ``§3::CAPABILITIES`` (CHASSIS/PROFILES or SKILLS/PATTERNS).
+- ``§4::INTERACTION_RULES`` (GRAMMAR with MUST_USE/MUST_NOT regex lists).
+
+North Star compliance:
+- PROD::I1 SYNTACTIC_FIDELITY — schema sources round-trip via the Shape F
+  sanctuary (covered automatically by
+  ``tests/integration/test_schema_write_idempotency.py``).
+- PROD::I4 TRANSFORM_AUDITABILITY — every validation receipt is auditable.
+- PROD::I5 SCHEMA_SOVEREIGNTY — validation_status surfaces clearly.
+
+Pre-existing limitations honoured by these tests:
+- octave_validate ENUM constraints are PARTIAL per #435; tests do NOT
+  depend on ENUM rejection. REQ enforcement is verified for the
+  negative-path coverage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from octave_mcp.schemas.loader import load_schema_by_name
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_AGENTS_DIR = _REPO_ROOT / ".hestai-sys" / "library" / "agents"
+_SCHEMA_PATH = (
+    _REPO_ROOT
+    / "src"
+    / "octave_mcp"
+    / "resources"
+    / "specs"
+    / "schemas"
+    / "agent_definition.oct.md"
+)
+
+
+def _agent_files() -> list[Path]:
+    if not _AGENTS_DIR.is_dir():
+        return []
+    return sorted(_AGENTS_DIR.glob("*.oct.md"))
+
+
+def _validate_content(content: str) -> dict:
+    """Helper to validate content through the MCP validate tool."""
+    from octave_mcp.mcp.validate import ValidateTool
+
+    tool = ValidateTool()
+    return asyncio.run(tool.execute(content=content, schema="AGENT_DEFINITION"))
+
+
+class TestAgentDefinitionSchemaLoading:
+    """Test loading AGENT_DEFINITION schema from specs/schemas/."""
+
+    def test_schema_file_exists(self) -> None:
+        """AGENT_DEFINITION schema source file should exist."""
+        assert _SCHEMA_PATH.exists(), f"Schema file not found at {_SCHEMA_PATH}"
+
+    def test_load_schema_by_name(self) -> None:
+        """``load_schema_by_name`` should find AGENT_DEFINITION schema."""
+        schema = load_schema_by_name("AGENT_DEFINITION")
+        assert schema is not None, "Should find AGENT_DEFINITION schema"
+        assert schema.name == "AGENT_DEFINITION"
+
+    def test_schema_has_required_identity_fields(self) -> None:
+        """AGENT_DEFINITION schema should declare core required identity fields.
+
+        These four fields constitute the minimum identity envelope: who the
+        agent is (ROLE), how it reasons (COGNITION), what it does (MISSION),
+        and its accountability statement (AUTHORITY_MANDATE).
+        """
+        schema = load_schema_by_name("AGENT_DEFINITION")
+        assert schema is not None
+
+        required = {"ROLE", "COGNITION", "MISSION", "AUTHORITY_MANDATE"}
+        missing = required - set(schema.fields.keys())
+        assert not missing, f"Schema missing required identity fields: {missing}"
+
+        for name in required:
+            field = schema.fields[name]
+            # Either parsed constraint or raw_value text should mark REQ
+            if field.pattern is not None and field.pattern.constraints:
+                assert field.is_required, f"{name} should be REQ via pattern"
+            else:
+                assert "REQ" in (field.raw_value or ""), (
+                    f"{name} should carry REQ in raw value: {field.raw_value!r}"
+                )
+
+    def test_schema_has_version(self) -> None:
+        """Schema should declare an explicit version."""
+        schema = load_schema_by_name("AGENT_DEFINITION")
+        assert schema is not None
+        assert schema.version is not None
+        assert schema.version != ""
+
+
+class TestAgentDefinitionMalformedRejection:
+    """Negative path: deliberately malformed AGENT_DEFINITION files reject.
+
+    These tests do NOT depend on ENUM enforcement (per known limitation
+    #435). They depend solely on REQ enforcement, which the validator
+    implements via per-section coverage + envelope-level checks.
+    """
+
+    def test_missing_role_is_invalid(self) -> None:
+        """An agent missing ROLE must fail validation."""
+        content = """===BROKEN_AGENT===
+META:
+  TYPE::AGENT_DEFINITION
+  VERSION::"1.0.0"
+  PURPOSE::"Test agent missing ROLE"
+  CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
+§1::IDENTITY
+  COGNITION::LOGOS
+  MISSION::TEST_MISSION
+  AUTHORITY_MANDATE::"Test mandate"
+§2::OPERATIONAL_BEHAVIOR
+  CONDUCT:
+    TONE::"Test"
+§3::CAPABILITIES
+  SKILLS::[]
+§4::INTERACTION_RULES
+  GRAMMAR:
+    MUST_USE::[]
+===END==="""
+        result = _validate_content(content)
+        assert result["validation_status"] == "INVALID", (
+            f"Missing ROLE should be INVALID. Got: {result.get('validation_status')}; "
+            f"errors={result.get('validation_errors')}"
+        )
+        assert result["valid"] is False
+        error_messages = [e.get("message", "") for e in result.get("validation_errors", [])]
+        assert any("ROLE" in msg for msg in error_messages), (
+            f"Error should mention ROLE. Got: {error_messages}"
+        )
+
+    def test_missing_authority_mandate_is_invalid(self) -> None:
+        """An agent missing AUTHORITY_MANDATE must fail validation."""
+        content = """===BROKEN_AGENT===
+META:
+  TYPE::AGENT_DEFINITION
+  VERSION::"1.0.0"
+  PURPOSE::"Test agent missing AUTHORITY_MANDATE"
+  CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
+§1::IDENTITY
+  ROLE::BROKEN_AGENT
+  COGNITION::LOGOS
+  MISSION::TEST_MISSION
+§2::OPERATIONAL_BEHAVIOR
+  CONDUCT:
+    TONE::"Test"
+§3::CAPABILITIES
+  SKILLS::[]
+§4::INTERACTION_RULES
+  GRAMMAR:
+    MUST_USE::[]
+===END==="""
+        result = _validate_content(content)
+        assert result["validation_status"] == "INVALID", (
+            f"Missing AUTHORITY_MANDATE should be INVALID. "
+            f"Got: {result.get('validation_status')}; errors={result.get('validation_errors')}"
+        )
+        assert result["valid"] is False
+        error_messages = [e.get("message", "") for e in result.get("validation_errors", [])]
+        assert any("AUTHORITY_MANDATE" in msg for msg in error_messages), (
+            f"Error should mention AUTHORITY_MANDATE. Got: {error_messages}"
+        )
+
+    def test_missing_mission_is_invalid(self) -> None:
+        """An agent missing MISSION must fail validation."""
+        content = """===BROKEN_AGENT===
+META:
+  TYPE::AGENT_DEFINITION
+  VERSION::"1.0.0"
+  PURPOSE::"Test agent missing MISSION"
+  CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
+§1::IDENTITY
+  ROLE::BROKEN_AGENT
+  COGNITION::LOGOS
+  AUTHORITY_MANDATE::"Test mandate"
+§2::OPERATIONAL_BEHAVIOR
+  CONDUCT:
+    TONE::"Test"
+§3::CAPABILITIES
+  SKILLS::[]
+§4::INTERACTION_RULES
+  GRAMMAR:
+    MUST_USE::[]
+===END==="""
+        result = _validate_content(content)
+        assert result["validation_status"] == "INVALID", (
+            f"Missing MISSION should be INVALID. Got: {result.get('validation_status')}"
+        )
+        assert result["valid"] is False
+
+
+class TestAgentDefinitionMinimalValid:
+    """Positive path: a hand-crafted minimal valid agent passes validation."""
+
+    def test_minimal_valid_agent_validates(self) -> None:
+        """A minimal AGENT_DEFINITION carrying every REQ field validates."""
+        content = """===MINIMAL_AGENT===
+META:
+  TYPE::AGENT_DEFINITION
+  VERSION::"1.0.0"
+  PURPOSE::"Minimal agent definition for schema validation coverage"
+  CONTRACT::HOLOGRAPHIC<JIT_GRAMMAR_COMPILATION>
+§1::IDENTITY
+  ROLE::MINIMAL_AGENT
+  COGNITION::LOGOS
+  MISSION::TEST_FIDELITY
+  AUTHORITY_MANDATE::"Verify the schema accepts the minimum envelope"
+§2::OPERATIONAL_BEHAVIOR
+  CONDUCT:
+    TONE::"Technical, Precise"
+§3::CAPABILITIES
+  SKILLS::[]
+§4::INTERACTION_RULES
+  GRAMMAR:
+    MUST_USE::[]
+===END==="""
+        result = _validate_content(content)
+        assert result["validation_status"] == "VALIDATED", (
+            f"Minimal valid agent should VALIDATE. "
+            f"Got: {result.get('validation_status')}; errors={result.get('validation_errors')}"
+        )
+        assert result["valid"] is True
+
+
+class TestExistingAgentFilesValidate:
+    """Integration: every on-disk agent file validates clean against the schema.
+
+    Each ``.hestai-sys/library/agents/*.oct.md`` file is the empirical ground
+    truth for the schema. If any file fails validation, the schema is wrong
+    (forge it on the anvil of real input — HEPHAESTUS bias).
+    """
+
+    @pytest.mark.parametrize(
+        "agent_path",
+        _agent_files(),
+        ids=lambda p: p.name,
+    )
+    def test_existing_agent_file_validates(self, agent_path: Path) -> None:
+        """Each on-disk agent file should validate clean against AGENT_DEFINITION."""
+        content = agent_path.read_text(encoding="utf-8")
+        result = _validate_content(content)
+
+        # Surface the first error compactly to make failures easy to diagnose.
+        if result.get("validation_status") != "VALIDATED":
+            errors = result.get("validation_errors", [])
+            first = errors[0] if errors else "<no error returned>"
+            pytest.fail(
+                f"{agent_path.name} did not validate clean against AGENT_DEFINITION.\n"
+                f"  validation_status={result.get('validation_status')!r}\n"
+                f"  first_error={first!r}\n"
+                f"  total_errors={len(errors)}"
+            )
+        assert result["valid"] is True


### PR DESCRIPTION
## Summary

WAVE_2 of the pre-v1.13.0 Schema Sweep Sprint. Adds a new `AGENT_DEFINITION`
schema codifying the canonical envelope structure shared by 33+ on-disk
agent definition files at `.hestai-sys/library/agents/*.oct.md`. Closes #424.

- New schema source at the canonical path:
  `src/octave_mcp/resources/specs/schemas/agent_definition.oct.md`
- Schema authored holographically (`∧REQ`, `∧OPT`, `→§SELF`, `ENUM[...]`,
  `TYPE[LIST]`) consistent with `debate_transcript.oct.md` /
  `cognition_definition.oct.md` conventions.
- 42 new tests in `tests/unit/test_agent_definition_schema.py` covering
  schema loading, REQ enforcement (positive + negative), and integration
  against every on-disk agent file.
- Idempotency CI gate (`tests/integration/test_schema_write_idempotency.py`)
  auto-discovers the new schema via its `*.oct.md` glob — passes
  without modification.

## Schema Coverage

REQUIRED fields enforced via `∧REQ`:
- `ROLE` (envelope identity)
- `COGNITION` (LOGOS / ETHOS / PATHOS, ENUM declared but per #435 not
  asserted in tests)
- `MISSION` (mandate compound)
- `AUTHORITY_MANDATE` (accountability statement)

OPTIONAL fields recognised: `ARCHETYPE`, `MODEL_TIER`, `PRINCIPLES`,
`AUTHORITY_ULTIMATE`/`BLOCKING`/`ADVISORY`/`NO_OVERRIDE`/`ACCOUNTABILITY`,
`CONDUCT`, `SKILLS`, `PATTERNS`, `CHASSIS`, `PROFILES`, `GRAMMAR`.

## Validation Sample (33 on-disk files)

31 of 33 files validate clean against the new schema:

| Outcome | Count | Files |
|---|---|---|
| VALIDATED | 31 | agent-expert, agent-expert-v9, code-review-specialist, completion-architect, complexity-guard, critical-engineer, design-architect, edge-optimizer, error-architect, ho-liaison, holistic-orchestrator, implementation-lead, north-star-architect, octave-secretary, octave-specialist, principal-engineer, quality-observer, requirements-steward, security-specialist, skills-expert, smartsuite-expert, solution-steward, standards-reviewer, supabase-expert, system-steward, task-decomposer, technical-architect, test-infrastructure-steward, test-methodology-guardian, universal-test-engineer, validator, visual-architect |
| INVALID (known gap) | 2 | `ideator.oct.md`, `synthesizer.oct.md` |

**Rationale for known-gap files:** both `ideator.oct.md` and
`synthesizer.oct.md` genuinely lack `AUTHORITY_MANDATE` on disk today.
Every other agent declares one. Rather than weaken the REQ on a
load-bearing accountability field, the gap is pinned in
`KNOWN_AUTHORITY_MANDATE_GAPS` with a dedicated test asserting that the
schema continues to surface the diagnostic. This honours PROD::I5
SCHEMA_SOVEREIGNTY: the validator REPORTS missing structure rather than
silently accepting it. Closing the upstream gap is agent-expert's
prerogative via standard agent-file amendment.

## North Star Compliance

- **PROD::I1 SYNTACTIC_FIDELITY** — schema source round-trips through the
  Shape F holographic sanctuary (PR #431). Every `∧REQ→§SELF` chain is
  preserved verbatim. Confirmed by the idempotency CI gate (see below).
- **PROD::I4 TRANSFORM_AUDITABILITY** — E003 validation receipts surface
  per-field with stable codes; the per-section validator visits every
  block, recording coverage. The known-gap diagnostic is reproducible.
- **PROD::I5 SCHEMA_SOVEREIGNTY** — `validation_status` is visible in
  every test assertion; the schema's job is to report structural reality,
  and it does (see known-gap finding above).

## Idempotency CI Gate

`tests/integration/test_schema_write_idempotency.py` auto-discovers the
new schema via `Path.glob('*.oct.md')`. With this PR applied the gate
collects 11 items (vs 9 previously); all pass. No modifications needed
to the gate itself — the precedent established by PR #431 holds.

```
$ uv run pytest tests/integration/test_schema_write_idempotency.py -q --no-cov
11 passed in 0.29s
```

## Pre-existing Limitations Honoured

- octave_validate ENUM constraints are PARTIAL per #435 — tests assert
  REQ enforcement only, not ENUM rejection. The schema still DECLARES
  ENUMs (`COGNITION::ENUM[LOGOS,ETHOS,PATHOS]`, `MODEL_TIER::ENUM[
  PREMIUM,STANDARD]`) for documentation and future-validator coverage.
- octave_write diff_unified renders with cosmetic line-wrap per #436 —
  purely display; the on-disk content is correct (idempotency CI gate
  proves byte-stability).

## Quality Gates

| Gate | Result |
|---|---|
| ruff check | All checks passed |
| black --check | All done — 210 files would be left unchanged |
| mypy (this PR's files) | Success: no issues found in 1 source file |
| pytest (full suite) | 3245 passed, 11 skipped, 1 xfailed in 9.78s |
| Idempotency gate | 11 passed (new schema auto-discovered) |

## Commit Trail (TDD-discipline)

1. `test(schema): RED — AGENT_DEFINITION schema and validator coverage missing (GH-424)`
2. `feat(schema): add AGENT_DEFINITION schema for .hestai-sys/library/agents/*.oct.md (GH-424)`
3. `style(schema): apply black formatting to AGENT_DEFINITION tests (GH-424)`

## Reviewers Requested — TIER_2_STANDARD

- **TMG** (test-methodology-guardian) — validate test semantics, RED→GREEN
  ordering, known-gap allowlist discipline.
- **CRS** (code-review-specialist) — review schema authoring against
  existing schema patterns; check known-gap allowlist isn't masking
  real defects.
- **CE** (critical-engineer) — production-readiness review:
  validation_status visibility, schema sovereignty, no relaxation of
  load-bearing REQ fields to paper over upstream gaps.

## Test Plan

- [x] RED tests confirmed failing before schema authored
- [x] GREEN: 42 new tests pass against new schema
- [x] All 31 non-gap agent files validate clean
- [x] 2 known-gap files surface AUTHORITY_MANDATE diagnostic
- [x] Idempotency CI gate auto-discovers new schema and passes
- [x] Full test suite (3245 tests) passes with no regressions
- [x] ruff / black / mypy clean on changed files

## Out of Scope (deferred to follow-ups)

- Closing the ideator/synthesizer AUTHORITY_MANDATE gap (agent-expert
  authoring task; tracked by the pinned-diagnostic test).
- Vocabulary registration for AGENT vocabulary (suggested in #424 step 4)
  — `vocabularies/registry.oct.md` does not yet exist as a structured
  registration target; schema-level enforcement of COGNITION /
  MODEL_TIER ENUMs is sufficient for v1.13.0. A separate issue can
  formalise vocabulary registry if needed.
- DECISION_LOG schema (#425) — separate WAVE_2 PR, NOT bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `AGENT_DEFINITION` schema for `.hestai-sys/library/agents/*.oct.md`, defining the canonical agent envelope and validating 31 of 33 agents. Addresses GH-424 and integrates with existing validation and idempotency gates.

- **New Features**
  - New schema at `src/octave_mcp/resources/specs/schemas/agent_definition.oct.md`.
  - Enforces required fields: `ROLE`, `COGNITION`, `MISSION`, `AUTHORITY_MANDATE`.
  - Declares optional fields for identity, capabilities, and interaction rules; ENUMs documented.
  - 42 tests added covering schema loading, REQ enforcement, minimal pass, and all on-disk agents.
  - Two known gaps (`ideator.oct.md`, `synthesizer.oct.md`) intentionally fail for missing `AUTHORITY_MANDATE`.

- **Migration**
  - No code changes required; idempotency gate auto-discovers the schema.
  - To make all agents pass, add `AUTHORITY_MANDATE` to `ideator.oct.md` and `synthesizer.oct.md`.
  - Validate agents locally with `octave_validate --schema AGENT_DEFINITION`.

<sup>Written for commit 1f3e5b1f8434377ae05f24d6311e09245684452c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

