### PR TITLE
feat(schema): wire TURN_SCHEMA into DEBATE_TRANSCRIPT validator (closes #427)

### DIFF
--- a/src/octave_mcp/core/schema_extractor.py
+++ b/src/octave_mcp/core/schema_extractor.py
@@ -257,6 +257,12 @@ class SchemaDefinition:
     frontmatter: dict[str, FrontmatterFieldDef] = field(default_factory=dict)
     default_target: str | None = None
     warnings: list[SchemaExtractionWarning] = field(default_factory=list)
+    # GH-427: Per-item sub-schema for repeated structures. The DEBATE_TRANSCRIPT
+    # schema declares ``TURN_SCHEMA:`` describing the structure each TURN must
+    # satisfy. When populated the validator enforces that each child block of
+    # the matching repeated-structure parent (TURNS) conforms to this sub-schema.
+    # ``None`` means the schema does not declare a TURN_SCHEMA block.
+    turn_schema: dict[str, FieldDefinition] | None = None
 
 
 def _extract_policy(sections: list[Any]) -> tuple[PolicyDefinition, str | None]:
@@ -347,6 +353,55 @@ def _extract_fields(sections: list[Any]) -> tuple[dict[str, FieldDefinition], li
                         warnings.append(warning)
 
     return fields, warnings
+
+
+def _extract_turn_schema(
+    sections: list[Any],
+) -> tuple[dict[str, FieldDefinition] | None, list[SchemaExtractionWarning]]:
+    """Extract TURN_SCHEMA block as a per-item sub-schema (GH-427).
+
+    DEBATE_TRANSCRIPT declares a ``TURN_SCHEMA:`` block describing the
+    structure each TURN entry must satisfy (ROLE REQ ENUM, CONTENT REQ,
+    TURN_INDEX REQ, SPEAKER OPT, etc.). Prior to GH-427 this block was silently
+    discarded by ``_extract_fields`` — only the top-level ``FIELDS:`` block
+    reached the validator, leaving documented-but-not-enforced contract drift
+    (PROD::I5 SCHEMA_SOVEREIGNTY violation).
+
+    This helper parses each TURN_SCHEMA child Assignment as a holographic
+    pattern field, reusing ``_parse_field_assignment`` so the validator can
+    apply standard constraint evaluation (REQ, ENUM, TYPE, etc.) per turn
+    without bespoke logic.
+
+    Args:
+        sections: List of document sections.
+
+    Returns:
+        Tuple of (turn_schema dict or None, warnings list).
+        Returns ``(None, [])`` when no TURN_SCHEMA block is present so callers
+        can distinguish "schema declares no per-item structure" from "schema
+        declares an empty per-item structure".
+    """
+    turn_fields: dict[str, FieldDefinition] = {}
+    warnings: list[SchemaExtractionWarning] = []
+    found = False
+
+    for section in sections:
+        if isinstance(section, Block) and section.key == "TURN_SCHEMA":
+            found = True
+            for child in section.children:
+                if isinstance(child, Assignment):
+                    field_def, warning = _parse_field_assignment(child)
+                    if field_def:
+                        turn_fields[field_def.name] = field_def
+                    if warning:
+                        # Re-scope warning path under TURN_SCHEMA so audit
+                        # trails distinguish it from FIELDS-level warnings.
+                        warning.field_path = f"TURN_SCHEMA.{field_def.name if field_def else '?'}"
+                        warnings.append(warning)
+
+    if not found:
+        return None, warnings
+    return turn_fields, warnings
 
 
 def _parse_field_assignment(
@@ -719,6 +774,12 @@ def extract_schema_from_document(doc: Document) -> SchemaDefinition:
     # Extract FRONTMATTER block (Issue #244: Zone 2 validation)
     frontmatter = _extract_frontmatter_defs(doc.sections)
 
+    # GH-427: Extract TURN_SCHEMA block as per-item sub-schema (e.g., for
+    # DEBATE_TRANSCRIPT). None when the schema does not declare one.
+    turn_schema, turn_warnings = _extract_turn_schema(doc.sections)
+    if turn_warnings:
+        warnings = warnings + turn_warnings
+
     return SchemaDefinition(
         name=name,
         version=version,
@@ -727,4 +788,5 @@ def extract_schema_from_document(doc: Document) -> SchemaDefinition:
         frontmatter=frontmatter,
         default_target=default_target,
         warnings=warnings,
+        turn_schema=turn_schema,
     )

--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -282,10 +282,7 @@ def _validate_turn_schema(
                 errors.append(
                     ValidationError(
                         code="E_TURN_FIELD",
-                        message=(
-                            f"Turn '{turn_key}' is missing required TURN_SCHEMA "
-                            f"field '{req_name}' (GH-427)."
-                        ),
+                        message=(f"Turn '{turn_key}' is missing required TURN_SCHEMA " f"field '{req_name}' (GH-427)."),
                         field_path=f"{turn_path_prefix}.{req_name}",
                     )
                 )
@@ -298,9 +295,7 @@ def _validate_turn_schema(
                 continue
 
             value = turn_fields[fname]
-            result = fdef.pattern.constraints.evaluate(
-                value=value, path=f"{turn_path_prefix}.{fname}"
-            )
+            result = fdef.pattern.constraints.evaluate(value=value, path=f"{turn_path_prefix}.{fname}")
             if not result.valid:
                 for err in result.errors:
                     # Wrap constraint failures under the stable E_TURN_FIELD

--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -317,6 +317,34 @@ def _validate_turn_schema(
         # TURN_INDEX uniqueness invariant.
         if "TURN_INDEX" in turn_fields:
             ti_value = turn_fields["TURN_INDEX"]
+            # CE rework: guard the duplicate-tracking dict lookup against
+            # non-hashable TURN_INDEX values (e.g. a malformed
+            # ``TURN_INDEX::[1,2]`` parses as ``ListValue`` — an unhashable
+            # dataclass). Without this guard, the ``in seen_turn_indices``
+            # probe raised ``TypeError: unhashable type`` and escaped the
+            # validator entirely, bypassing the INVALID envelope contract
+            # and silently breaking PROD::I5 SCHEMA_SOVEREIGNTY
+            # (validation_status_visible_in_output).
+            try:
+                hash(ti_value)
+            except TypeError:
+                errors.append(
+                    ValidationError(
+                        code="E_TURN_INDEX_TYPE",
+                        message=(
+                            f"Turn '{turn_key}' TURN_INDEX value {ti_value!r} "
+                            f"is not a hashable scalar (got "
+                            f"{type(ti_value).__name__}); TURN_INDEX must be a "
+                            f"scalar value to participate in uniqueness "
+                            f"enforcement (GH-427 CE rework)."
+                        ),
+                        field_path=f"{turn_path_prefix}.TURN_INDEX",
+                    )
+                )
+                # Skip duplicate tracking for this turn and continue with
+                # remaining siblings — the surfaced error is sufficient to
+                # mark the document INVALID.
+                continue
             if ti_value in seen_turn_indices:
                 errors.append(
                     ValidationError(

--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -15,10 +15,11 @@ from difflib import unified_diff
 from pathlib import Path
 from typing import Any
 
+from octave_mcp.core.constraints import RequiredConstraint
 from octave_mcp.core.emitter import emit
 from octave_mcp.core.gbnf_compiler import GBNFCompiler
 from octave_mcp.core.grammar import parse_with_warnings
-from octave_mcp.core.grammar.cst import Assignment, ASTNode
+from octave_mcp.core.grammar.cst import Assignment, ASTNode, Block
 from octave_mcp.core.literal_zone_audit import build_literal_zone_repair_log
 from octave_mcp.core.repair import repair
 from octave_mcp.core.schema_extractor import SchemaDefinition
@@ -84,9 +85,18 @@ def _build_deep_section_schemas(
     # nodes in doc.sections (e.g., THREAD_ID::..., TOPIC::... in DEBATE_TRANSCRIPT).
     # Without this, envelope-style documents produce empty section_schemas and
     # _check_required_field_coverage falsely flags all required fields as missing.
+    #
+    # GH-427: Also collect envelope-level Block keys (e.g., TURNS: as a Block
+    # rather than as an inline list). Without this, structured DEBATE_TRANSCRIPT
+    # documents that emit TURNS as a Block (the canonical shape for per-turn
+    # validation under TURN_SCHEMA) would falsely surface
+    # ``Field 'TURNS' is required but missing`` even though the Block is the
+    # whole point of the per-turn enforcement contract.
     envelope_keys: set[str] = set()
     for node in doc.sections:
         if isinstance(node, Assignment) and node.key != "META":
+            envelope_keys.add(node.key)
+        elif isinstance(node, Block) and node.key != "META":
             envelope_keys.add(node.key)
 
     if envelope_keys:
@@ -176,6 +186,156 @@ def _check_required_field_coverage(
                         field_path=field_name,
                     )
                 )
+
+    return errors
+
+
+def _validate_turn_schema(
+    doc: Any,
+    schema_definition: SchemaDefinition,
+) -> list[ValidationError]:
+    """Validate per-turn structure against TURN_SCHEMA (GH-427).
+
+    The DEBATE_TRANSCRIPT schema declares a ``TURN_SCHEMA:`` block describing
+    the contract each TURN entry must satisfy. Prior to GH-427 this block was
+    documented but not enforced — malformed TURN entries (missing REQ ROLE,
+    duplicate TURN_INDEX, out-of-enum ROLE) silently validated clean.
+
+    This helper closes the gap by:
+
+    1. Locating a top-level ``TURNS:`` Block in the document.
+    2. Treating each child Block of TURNS as one turn entry.
+    3. For each turn:
+       - Checking every REQ field declared in ``schema_definition.turn_schema``
+         is present (emits ``E_TURN_FIELD`` when absent).
+       - Evaluating the holographic constraint chain (ENUM, TYPE, REGEX, etc.)
+         on each present turn field, wrapping any constraint failures as
+         ``E_TURN_FIELD`` so the per-turn error code remains stable for
+         downstream tooling (I4 TRANSFORM_AUDITABILITY: stable error IDs).
+    4. Tracking ``TURN_INDEX`` values across all turns and emitting
+       ``E_TURN_INDEX`` on any duplicate (uniqueness invariant).
+
+    Args:
+        doc: Parsed Document AST.
+        schema_definition: Loaded SchemaDefinition whose ``turn_schema`` is the
+            per-item sub-schema. Caller MUST verify ``turn_schema is not None``
+            before invoking this helper — passing ``None`` is a programming
+            error and surfaces as no-op.
+
+    Returns:
+        List of ``ValidationError`` instances. Empty when no TURNS block is
+        present (lenient: turn-level validation only fires when the document
+        commits to the structured shape) or when every turn validates clean.
+    """
+    errors: list[ValidationError] = []
+
+    turn_schema = schema_definition.turn_schema
+    if not turn_schema:
+        return errors
+
+    # Locate the top-level TURNS: Block. If TURNS is emitted as a flat list
+    # assignment instead, per-turn validation cannot run (turn structure is
+    # opaque); we intentionally do not surface a warning here — the FIELDS-level
+    # TYPE[LIST] constraint already covers the "TURNS is present in some shape"
+    # contract, and treating bare lists as enforceable would conflict with the
+    # documented schema fixture ``TURNS::[[turn1,turn2]∧...]``.
+    turns_block: Block | None = None
+    for node in doc.sections:
+        if isinstance(node, Block) and node.key == "TURNS":
+            turns_block = node
+            break
+
+    if turns_block is None:
+        return errors
+
+    # Pre-compute REQ field names from turn_schema for O(1) lookup.
+    required_turn_fields = {
+        fname
+        for fname, fdef in turn_schema.items()
+        if fdef.pattern
+        and fdef.pattern.constraints
+        and any(isinstance(c, RequiredConstraint) for c in fdef.pattern.constraints.constraints)
+    }
+
+    # Track TURN_INDEX values across all turns for uniqueness enforcement.
+    seen_turn_indices: dict[Any, str] = {}
+
+    for child in turns_block.children:
+        if not isinstance(child, Block):
+            # Skip non-Block children (e.g., stray Assignments inside TURNS:).
+            # A stricter policy could surface these as warnings, but the issue
+            # acceptance criteria only require per-turn field enforcement.
+            continue
+
+        turn_key = child.key
+        turn_path_prefix = f"TURNS.{turn_key}"
+
+        # Collect field assignments for this turn.
+        turn_fields: dict[str, Any] = {}
+        for grandchild in child.children:
+            if isinstance(grandchild, Assignment):
+                turn_fields[grandchild.key] = grandchild.value
+
+        # REQ field coverage check.
+        for req_name in required_turn_fields:
+            if req_name not in turn_fields:
+                errors.append(
+                    ValidationError(
+                        code="E_TURN_FIELD",
+                        message=(
+                            f"Turn '{turn_key}' is missing required TURN_SCHEMA "
+                            f"field '{req_name}' (GH-427)."
+                        ),
+                        field_path=f"{turn_path_prefix}.{req_name}",
+                    )
+                )
+
+        # Per-field constraint evaluation (ENUM, TYPE, REGEX, etc.).
+        for fname, fdef in turn_schema.items():
+            if fname not in turn_fields:
+                continue  # absent fields handled above (REQ) or skipped (OPT)
+            if not fdef.pattern or not fdef.pattern.constraints:
+                continue
+
+            value = turn_fields[fname]
+            result = fdef.pattern.constraints.evaluate(
+                value=value, path=f"{turn_path_prefix}.{fname}"
+            )
+            if not result.valid:
+                for err in result.errors:
+                    # Wrap constraint failures under the stable E_TURN_FIELD
+                    # code so per-turn enforcement uses ONE discriminant
+                    # regardless of which underlying constraint fired. The
+                    # original code is preserved in the message tail for
+                    # diagnostic depth.
+                    errors.append(
+                        ValidationError(
+                            code="E_TURN_FIELD",
+                            message=(
+                                f"Turn '{turn_key}' field '{fname}' failed "
+                                f"TURN_SCHEMA constraint [{err.code}]: {err.message}"
+                            ),
+                            field_path=err.path,
+                        )
+                    )
+
+        # TURN_INDEX uniqueness invariant.
+        if "TURN_INDEX" in turn_fields:
+            ti_value = turn_fields["TURN_INDEX"]
+            if ti_value in seen_turn_indices:
+                errors.append(
+                    ValidationError(
+                        code="E_TURN_INDEX",
+                        message=(
+                            f"Duplicate TURN_INDEX value {ti_value!r} across "
+                            f"turns '{seen_turn_indices[ti_value]}' and "
+                            f"'{turn_key}' (GH-427: TURN_INDEX must be unique)."
+                        ),
+                        field_path=f"{turn_path_prefix}.TURN_INDEX",
+                    )
+                )
+            else:
+                seen_turn_indices[ti_value] = turn_key
 
     return errors
 
@@ -715,6 +875,14 @@ class ValidateTool(BaseTool):
             if section_schemas is not None and schema_definition is not None and doc.meta.get("TYPE") == schema_name:
                 coverage_errors = _check_required_field_coverage(schema_definition, section_schemas, doc=doc)
                 validation_errors.extend(coverage_errors)
+
+            # GH-427: Per-turn TURN_SCHEMA enforcement for DEBATE_TRANSCRIPT and
+            # any other schema declaring a ``TURN_SCHEMA:`` block. Prior to this
+            # hook the block was extracted but never consulted, leaving a
+            # documented-but-not-enforced contract drift (PROD::I5).
+            if schema_definition is not None and schema_definition.turn_schema:
+                turn_errors = _validate_turn_schema(doc, schema_definition)
+                validation_errors.extend(turn_errors)
 
             if validation_errors:
                 # Convert errors to dicts for reporting

--- a/src/octave_mcp/resources/specs/schemas/debate_transcript.oct.md
+++ b/src/octave_mcp/resources/specs/schemas/debate_transcript.oct.md
@@ -1,15 +1,13 @@
 ===DEBATE_TRANSCRIPT===
 META:
   TYPE::SCHEMA
-  VERSION::"1.0"
+  VERSION::"1.1"
   STATUS::ACTIVE
   PURPOSE::"Schema for debate-hall-mcp debate transcripts. Enables OCTAVE validation and archival of structured debates with Wind/Wall/Door cognition patterns."
-
 POLICY:
   VERSION::"1.0"
   UNKNOWN_FIELDS::WARN
-  TARGETS::[§INDEXER, §SELF]
-
+  TARGETS::["§INDEXER","§SELF"]
 FIELDS:
   THREAD_ID::["example-debate-001"∧REQ→§INDEXER]
   TOPIC::["The topic of the debate"∧REQ→§SELF]
@@ -20,22 +18,23 @@ FIELDS:
   SYNTHESIS::["Final synthesis from Door agent"∧OPT→§SELF]
   MAX_ROUNDS::[4∧OPT∧TYPE[NUMBER]→§SELF]
   MAX_TURNS::[12∧OPT∧TYPE[NUMBER]→§SELF]
-
 TURN_SCHEMA:
-  ROLE::["Wind"∧REQ∧ENUM[Wind,Wall,Door]→§SELF]
+  ROLE::["Wind"∧REQ∧ENUM[Wind,Wall,Door,Synthesis,Human,Mediator]→§SELF]
   CONTENT::["The turn content"∧REQ→§SELF]
+  TURN_INDEX::[1∧REQ∧TYPE[NUMBER]→§SELF]
+  SPEAKER::["agent-id"∧OPT→§SELF]
   COGNITION::["PATHOS"∧OPT∧ENUM[PATHOS,ETHOS,LOGOS]→§SELF]
   AGENT_ROLE::["impl-lead"∧OPT→§SELF]
   MODEL::["claude-sonnet"∧OPT→§SELF]
   TIMESTAMP::["2025-01-01T00:00:00Z"∧OPT∧ISO8601→§SELF]
-
 USAGE_NOTES::[
   "THREAD_ID: Unique identifier for the debate, used for indexing and retrieval",
   "TOPIC: Human-readable description of what the debate is about",
   "MODE: 'fixed' for strict rotation, 'mediated' for flexible speaker selection",
   "STATUS: 'active' during debate, 'paused' when awaiting human interjection, 'synthesis' when Door is finalizing, 'closed' when complete",
   "PARTICIPANTS: List of roles participating (typically Wind, Wall, Door)",
-  "TURNS: Array of turn records with role, content, and optional cognition metadata",
-  "SYNTHESIS: Final resolution from Door agent when debate closes"
+  "TURNS: Array of turn records with role, content, and optional cognition metadata. When emitted as a structured TURNS: block, each child block is validated against TURN_SCHEMA per GH-427.",
+  "SYNTHESIS: Final resolution from Door agent when debate closes",
+  "TURN_SCHEMA: Per-turn structural contract enforced by the validator (GH-427). ROLE/CONTENT/TURN_INDEX are required per turn; TURN_INDEX values must be unique across the transcript. Expanded ROLE enum (Wind|Wall|Door|Synthesis|Human|Mediator) covers debate-hall-mcp consumer reality."
 ]
 ===END===

--- a/tests/unit/test_debate_schema.py
+++ b/tests/unit/test_debate_schema.py
@@ -165,7 +165,7 @@ class TestDebateSchemaLoading:
         schema = load_schema_by_name("DEBATE_TRANSCRIPT")
         assert schema is not None
         assert schema.version is not None
-        assert schema.version == "1.0"
+        assert schema.version == "1.1"
 
 
 class TestDebateSchemaValidation:

--- a/tests/unit/test_debate_turn_schema_enforcement.py
+++ b/tests/unit/test_debate_turn_schema_enforcement.py
@@ -153,7 +153,7 @@ PARTICIPANTS::[Wind, Wall, Door]
 
 TURNS:
   T1:
-    CONTENT::No role declared — should be rejected.
+    CONTENT::No role declared, should be rejected.
     TURN_INDEX::1
   T2:
     ROLE::Wall

--- a/tests/unit/test_debate_turn_schema_enforcement.py
+++ b/tests/unit/test_debate_turn_schema_enforcement.py
@@ -281,6 +281,87 @@ def test_validator_returns_envelope_with_expected_keys(fixture: str, name: str) 
     assert "validation_status" in result, f"fixture={name} envelope missing validation_status"
 
 
+# ---------------------------------------------------------------------------
+# CE rework — non-hashable TURN_INDEX must not crash the validator.
+#
+# Codex review on PR #442 surfaced an uncaught ``TypeError: unhashable type``
+# raised at validate.py:320 when a malformed TURN entry declares
+# ``TURN_INDEX::[1,2]``. The parser produces a ``ListValue`` (an unhashable
+# dataclass), and the duplicate-tracking ``dict`` lookup blew up before the
+# validator could emit an INVALID envelope. This is a direct PROD::I5
+# SCHEMA_SOVEREIGNTY violation: validation status was invisible because the
+# exception escaped the validator entirely.
+# ---------------------------------------------------------------------------
+
+
+NON_HASHABLE_TURN_INDEX_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-list-turn-index
+TOPIC::TURN_SCHEMA enforcement non-hashable TURN_INDEX
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall, Door]
+
+TURNS:
+  T1:
+    ROLE::Wind
+    CONTENT::First turn with a malformed list TURN_INDEX.
+    TURN_INDEX::[1, 2]
+  T2:
+    ROLE::Wall
+    CONTENT::Second turn with a well-formed scalar TURN_INDEX.
+    TURN_INDEX::3
+===END==="""
+
+
+class TestTurnIndexNonHashableGuard:
+    """CE rework: non-hashable TURN_INDEX values must NOT crash the validator.
+
+    PROD::I5 SCHEMA_SOVEREIGNTY mandates validation_status_visible_in_output.
+    An uncaught TypeError makes status invisible. The validator MUST emit a
+    visible INVALID envelope (E_TURN_INDEX_TYPE or equivalent) and skip the
+    duplicate-tracking step for that turn, then continue processing siblings.
+    """
+
+    def test_list_turn_index_returns_invalid_not_typeerror(self) -> None:
+        """A ``TURN_INDEX::[1, 2]`` (ListValue) must return an INVALID envelope.
+
+        Prior to the CE-rework fix this raised
+        ``TypeError: unhashable type: 'ListValue'`` from the duplicate-tracking
+        dict lookup at validate.py:320. The contract is: malformed schema
+        input → visible INVALID envelope, never an exception.
+        """
+        # The validator MUST NOT raise. If the guard is missing, the
+        # underlying TypeError propagates through asyncio.run and fails here
+        # with an unhandled exception rather than an assertion message.
+        result = _run_validate(NON_HASHABLE_TURN_INDEX_TRANSCRIPT)
+        assert result["validation_status"] == "INVALID", (
+            f"Expected INVALID for non-hashable TURN_INDEX, got "
+            f"{result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+        codes = {err.get("code") for err in result.get("validation_errors") or []}
+        # Accept either the specific E_TURN_INDEX_TYPE code or the stable
+        # E_TURN_FIELD wrapper — both are valid per the CE-rework scope.
+        assert codes & {"E_TURN_INDEX_TYPE", "E_TURN_FIELD"}, (
+            f"Expected E_TURN_INDEX_TYPE or E_TURN_FIELD for non-hashable " f"TURN_INDEX; got codes={codes!r}"
+        )
+
+    def test_list_turn_index_does_not_block_sibling_turns(self) -> None:
+        """The non-hashable guard MUST skip only the offending turn's
+        duplicate-tracking step. Sibling turns with valid scalar TURN_INDEX
+        values continue to participate in per-turn validation.
+        """
+        # Simply asserting no exception is sufficient — the previous test
+        # covers the INVALID envelope shape; this test pins the
+        # 'continue, do not break' contract.
+        result = _run_validate(NON_HASHABLE_TURN_INDEX_TRANSCRIPT)
+        assert "validation_status" in result
+
+
 def test_schema_source_declares_turn_schema_block() -> None:
     """The schema source MUST continue to declare a TURN_SCHEMA block (I1 fidelity)."""
     text = SCHEMA_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_debate_turn_schema_enforcement.py
+++ b/tests/unit/test_debate_turn_schema_enforcement.py
@@ -30,7 +30,6 @@ import pytest
 from octave_mcp.mcp.validate import ValidateTool
 from octave_mcp.schemas.loader import load_schema_by_name
 
-
 SCHEMA_PATH = (
     Path(__file__).parent.parent.parent
     / "src"
@@ -66,9 +65,7 @@ class TestTurnSchemaExtraction:
         )
         # Required turn fields per GH-427 acceptance criteria.
         for required_key in ("ROLE", "CONTENT", "TURN_INDEX"):
-            assert required_key in turn_schema, (
-                f"turn_schema must declare REQ field '{required_key}' (GH-427)."
-            )
+            assert required_key in turn_schema, f"turn_schema must declare REQ field '{required_key}' (GH-427)."
         # Optional fields preserved.
         assert "SPEAKER" in turn_schema, "turn_schema must declare OPT field 'SPEAKER' (GH-427)."
 
@@ -88,8 +85,7 @@ class TestTurnSchemaExtraction:
         raw = role_field.raw_value or ""
         for required_value in ("Wind", "Wall", "Door", "Synthesis", "Human", "Mediator"):
             assert required_value in raw, (
-                f"TURN_SCHEMA.ROLE enum must include '{required_value}' "
-                f"(GH-427 expanded enum); got raw={raw!r}"
+                f"TURN_SCHEMA.ROLE enum must include '{required_value}' " f"(GH-427 expanded enum); got raw={raw!r}"
             )
 
 
@@ -232,18 +228,14 @@ class TestTurnSchemaValidatorEnforcement:
         # E_TURN_FIELD is the GH-427 enforcement code for missing REQ turn fields.
         codes = {err.get("code") for err in validation_errors}
         assert "E_TURN_FIELD" in codes, (
-            f"Expected E_TURN_FIELD validation error for missing ROLE; "
-            f"got codes={codes!r}"
+            f"Expected E_TURN_FIELD validation error for missing ROLE; " f"got codes={codes!r}"
         )
         # Field path must be specific enough to identify the offending turn.
         offending = [
-            err
-            for err in validation_errors
-            if err.get("code") == "E_TURN_FIELD" and "ROLE" in (err.get("field") or "")
+            err for err in validation_errors if err.get("code") == "E_TURN_FIELD" and "ROLE" in (err.get("field") or "")
         ]
         assert offending, (
-            "Missing-ROLE error must reference the ROLE field path; "
-            f"got validation_errors={validation_errors!r}"
+            "Missing-ROLE error must reference the ROLE field path; " f"got validation_errors={validation_errors!r}"
         )
 
     def test_duplicate_turn_index_is_rejected(self) -> None:
@@ -256,8 +248,7 @@ class TestTurnSchemaValidatorEnforcement:
         )
         codes = {err.get("code") for err in result.get("validation_errors", [])}
         assert "E_TURN_INDEX" in codes, (
-            f"Expected E_TURN_INDEX validation error for duplicate TURN_INDEX; "
-            f"got codes={codes!r}"
+            f"Expected E_TURN_INDEX validation error for duplicate TURN_INDEX; " f"got codes={codes!r}"
         )
 
     def test_invalid_role_enum_is_rejected(self) -> None:
@@ -271,8 +262,7 @@ class TestTurnSchemaValidatorEnforcement:
         codes = {err.get("code") for err in result.get("validation_errors", [])}
         # E_TURN_FIELD wraps per-turn constraint violations including enum.
         assert "E_TURN_FIELD" in codes, (
-            f"Expected E_TURN_FIELD validation error for invalid ROLE enum; "
-            f"got codes={codes!r}"
+            f"Expected E_TURN_FIELD validation error for invalid ROLE enum; " f"got codes={codes!r}"
         )
 
 

--- a/tests/unit/test_debate_turn_schema_enforcement.py
+++ b/tests/unit/test_debate_turn_schema_enforcement.py
@@ -362,6 +362,188 @@ class TestTurnIndexNonHashableGuard:
         assert "validation_status" in result
 
 
+# ---------------------------------------------------------------------------
+# TMG rework — explicit coverage of REQ fields and boundary cases.
+#
+# TMG verdict on PR #442 flagged four missing coverage gaps:
+#   1. Missing CONTENT (REQ) — validator must reject a TURN with no CONTENT.
+#   2. Missing TURN_INDEX (REQ) — validator must reject a TURN with no
+#      TURN_INDEX.
+#   3. Empty TURNS block — must be a graceful INVALID OR a deliberate-policy
+#      VALIDATED; either way it must be documented and pinned.
+#   4. Single-turn bounds — a well-formed single-TURN debate must validate.
+#
+# These tests pin the empirical observed behaviour at the time of the CE
+# rework so any future drift surfaces as a test failure rather than a silent
+# semantic shift.
+# ---------------------------------------------------------------------------
+
+
+MISSING_CONTENT_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-missing-content
+TOPIC::TURN_SCHEMA enforcement missing CONTENT
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall]
+
+TURNS:
+  T1:
+    ROLE::Wind
+    TURN_INDEX::1
+===END==="""
+
+
+MISSING_TURN_INDEX_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-missing-turn-index
+TOPIC::TURN_SCHEMA enforcement missing TURN_INDEX
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall]
+
+TURNS:
+  T1:
+    ROLE::Wind
+    CONTENT::Turn without a TURN_INDEX.
+===END==="""
+
+
+EMPTY_TURNS_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-empty-turns
+TOPIC::TURN_SCHEMA enforcement empty TURNS block
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind]
+
+TURNS:
+
+===END==="""
+
+
+SINGLE_TURN_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-single-turn
+TOPIC::TURN_SCHEMA enforcement single-turn bounds
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind]
+
+TURNS:
+  T1:
+    ROLE::Wind
+    CONTENT::Only turn in the transcript.
+    TURN_INDEX::1
+===END==="""
+
+
+class TestTurnSchemaCoverageRework:
+    """TMG rework: pin REQ-field coverage and boundary cases for PR #442."""
+
+    def test_missing_content_is_rejected(self) -> None:
+        """A TURN with no CONTENT MUST surface an E_TURN_FIELD validation error.
+
+        CONTENT is REQ in the DEBATE_TRANSCRIPT TURN_SCHEMA; a turn that
+        omits it must produce a visible INVALID envelope pointing at the
+        offending field path.
+        """
+        result = _run_validate(MISSING_CONTENT_TRANSCRIPT)
+        assert result["validation_status"] == "INVALID", (
+            f"Expected INVALID for missing CONTENT, got "
+            f"{result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+        validation_errors = result.get("validation_errors") or []
+        codes = {err.get("code") for err in validation_errors}
+        assert "E_TURN_FIELD" in codes, f"Expected E_TURN_FIELD for missing CONTENT; got codes={codes!r}"
+        offending = [
+            err
+            for err in validation_errors
+            if err.get("code") == "E_TURN_FIELD" and "CONTENT" in (err.get("field") or "")
+        ]
+        assert offending, (
+            "Missing-CONTENT error must reference the CONTENT field path; "
+            f"got validation_errors={validation_errors!r}"
+        )
+
+    def test_missing_turn_index_is_rejected(self) -> None:
+        """A TURN with no TURN_INDEX MUST surface an E_TURN_FIELD validation error.
+
+        TURN_INDEX is REQ in the DEBATE_TRANSCRIPT TURN_SCHEMA; omission
+        must surface a visible INVALID envelope pinned to the TURN_INDEX
+        field path.
+        """
+        result = _run_validate(MISSING_TURN_INDEX_TRANSCRIPT)
+        assert result["validation_status"] == "INVALID", (
+            f"Expected INVALID for missing TURN_INDEX, got "
+            f"{result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+        validation_errors = result.get("validation_errors") or []
+        codes = {err.get("code") for err in validation_errors}
+        assert "E_TURN_FIELD" in codes, f"Expected E_TURN_FIELD for missing TURN_INDEX; got codes={codes!r}"
+        offending = [
+            err
+            for err in validation_errors
+            if err.get("code") == "E_TURN_FIELD" and "TURN_INDEX" in (err.get("field") or "")
+        ]
+        assert offending, (
+            "Missing-TURN_INDEX error must reference the TURN_INDEX field path; "
+            f"got validation_errors={validation_errors!r}"
+        )
+
+    def test_empty_turns_block_is_graceful(self) -> None:
+        """A DEBATE_TRANSCRIPT with TURNS: but no child turns is deliberate-policy
+        VALIDATED.
+
+        Rationale: an empty TURNS block is structurally well-formed — it
+        commits to the structured shape but contains zero entries, which
+        violates no REQ per-turn invariant (there are no turns to fail).
+        The validator MUST NOT raise on this shape, and MUST surface a
+        visible terminal validation_status. The pinned-here policy is
+        VALIDATED with empty validation_errors; if future product policy
+        decides empty TURNS should be INVALID, this test must be updated
+        in the same commit that flips the policy so the choice is explicit.
+        """
+        result = _run_validate(EMPTY_TURNS_TRANSCRIPT)
+        # Boundary contract: must surface a terminal status, never crash.
+        assert "validation_status" in result, f"Empty TURNS envelope missing validation_status: {result!r}"
+        # Deliberate-policy: empty block validates clean.
+        assert result["validation_status"] == "VALIDATED", (
+            f"Empty TURNS policy is VALIDATED (no turns → no REQ violations); "
+            f"got {result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+
+    def test_single_turn_positive_validates(self) -> None:
+        """A well-formed single-TURN debate MUST validate clean.
+
+        Pins the lower-bound of the per-turn enforcement: the validator
+        must not produce false-positive errors on a transcript that
+        contains exactly one well-formed turn.
+        """
+        result = _run_validate(SINGLE_TURN_TRANSCRIPT)
+        assert result["status"] == "success", result
+        assert result["validation_status"] == "VALIDATED", (
+            f"Expected VALIDATED for single-turn positive, got "
+            f"{result['validation_status']}: "
+            f"errors={result.get('validation_errors')!r}"
+        )
+
+
 def test_schema_source_declares_turn_schema_block() -> None:
     """The schema source MUST continue to declare a TURN_SCHEMA block (I1 fidelity)."""
     text = SCHEMA_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_debate_turn_schema_enforcement.py
+++ b/tests/unit/test_debate_turn_schema_enforcement.py
@@ -1,0 +1,300 @@
+"""GH-427 RED — DEBATE_TRANSCRIPT TURN_SCHEMA enforcement.
+
+The schema source ``src/octave_mcp/resources/specs/schemas/debate_transcript.oct.md``
+declares a ``TURN_SCHEMA:`` block describing the structure of each TURN entry
+(ROLE REQ ENUM, CONTENT REQ, TURN_INDEX REQ, SPEAKER OPT). Prior to GH-427 the
+schema extractor consumed only the top-level ``FIELDS:`` block and the
+validator visitor had no concept of per-turn structure, so malformed TURN
+entries (missing ROLE, duplicate TURN_INDEX, etc.) silently validated clean —
+a documented false negative against North Star invariants:
+
+* PROD::I1 SYNTACTIC_FIDELITY — well-formed transcripts must continue to
+  validate (non-regression).
+* PROD::I4 TRANSFORM_AUDITABILITY — validation status must reflect the
+  declared turn-level contract.
+* PROD::I5 SCHEMA_SOVEREIGNTY — a documented schema field block that the
+  validator does not enforce is a sovereignty leak.
+
+These tests pin the post-fix contract. They are intentionally written
+BEFORE the schema/extractor/validator wiring lands so the RED commit captures
+the documented-but-not-enforced gap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from octave_mcp.mcp.validate import ValidateTool
+from octave_mcp.schemas.loader import load_schema_by_name
+
+
+SCHEMA_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src"
+    / "octave_mcp"
+    / "resources"
+    / "specs"
+    / "schemas"
+    / "debate_transcript.oct.md"
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema-source extraction contract
+# ---------------------------------------------------------------------------
+
+
+class TestTurnSchemaExtraction:
+    """The loaded SchemaDefinition MUST expose a parsed turn schema."""
+
+    def test_loaded_schema_exposes_turn_schema(self) -> None:
+        """``SchemaDefinition`` MUST surface ``turn_schema`` as a dict of
+        FieldDefinition objects extracted from the source ``TURN_SCHEMA:``
+        block. Before GH-427 this attribute did not exist; the source block
+        was silently discarded by ``_extract_fields``.
+        """
+        schema = load_schema_by_name("DEBATE_TRANSCRIPT")
+        assert schema is not None
+
+        turn_schema = getattr(schema, "turn_schema", None)
+        assert turn_schema is not None, (
+            "DEBATE_TRANSCRIPT.SchemaDefinition.turn_schema must be populated "
+            "(GH-427 enforcement of the documented TURN_SCHEMA: block)."
+        )
+        # Required turn fields per GH-427 acceptance criteria.
+        for required_key in ("ROLE", "CONTENT", "TURN_INDEX"):
+            assert required_key in turn_schema, (
+                f"turn_schema must declare REQ field '{required_key}' (GH-427)."
+            )
+        # Optional fields preserved.
+        assert "SPEAKER" in turn_schema, "turn_schema must declare OPT field 'SPEAKER' (GH-427)."
+
+    def test_turn_schema_role_enum_includes_expanded_values(self) -> None:
+        """ROLE enum MUST cover Wind|Wall|Door|Synthesis|Human|Mediator per
+        the GH-427 issue body. The pre-existing schema source only declared
+        Wind|Wall|Door which is a strict subset of consumer reality
+        (debate-hall-mcp emits Synthesis, Human, and Mediator turns).
+        """
+        schema = load_schema_by_name("DEBATE_TRANSCRIPT")
+        assert schema is not None
+
+        turn_schema = getattr(schema, "turn_schema", None)
+        assert turn_schema is not None, "turn_schema must be populated for GH-427"
+
+        role_field = turn_schema["ROLE"]
+        raw = role_field.raw_value or ""
+        for required_value in ("Wind", "Wall", "Door", "Synthesis", "Human", "Mediator"):
+            assert required_value in raw, (
+                f"TURN_SCHEMA.ROLE enum must include '{required_value}' "
+                f"(GH-427 expanded enum); got raw={raw!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Validator visitor enforcement (positive + negative cases)
+# ---------------------------------------------------------------------------
+
+
+def _run_validate(content: str, *, profile: str = "STANDARD") -> dict:
+    """Execute ValidateTool against DEBATE_TRANSCRIPT and return the envelope."""
+    tool = ValidateTool()
+    return asyncio.run(
+        tool.execute(
+            content=content,
+            schema="DEBATE_TRANSCRIPT",
+            profile=profile,
+        )
+    )
+
+
+WELL_FORMED_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-positive
+TOPIC::TURN_SCHEMA enforcement positive case
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall, Door]
+
+TURNS:
+  T1:
+    ROLE::Wind
+    CONTENT::Open the possibility space.
+    TURN_INDEX::1
+    SPEAKER::wind-agent
+  T2:
+    ROLE::Wall
+    CONTENT::Stress-test against constraints.
+    TURN_INDEX::2
+  T3:
+    ROLE::Door
+    CONTENT::Synthesise the third way.
+    TURN_INDEX::3
+
+SYNTHESIS::Emergent third way captured.
+===END==="""
+
+
+MISSING_ROLE_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-missing-role
+TOPIC::TURN_SCHEMA enforcement missing ROLE
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall, Door]
+
+TURNS:
+  T1:
+    CONTENT::No role declared — should be rejected.
+    TURN_INDEX::1
+  T2:
+    ROLE::Wall
+    CONTENT::Second turn is well-formed.
+    TURN_INDEX::2
+===END==="""
+
+
+DUPLICATE_TURN_INDEX_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-duplicate-index
+TOPIC::TURN_SCHEMA enforcement duplicate TURN_INDEX
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall, Door]
+
+TURNS:
+  T1:
+    ROLE::Wind
+    CONTENT::First turn.
+    TURN_INDEX::1
+  T2:
+    ROLE::Wall
+    CONTENT::Second turn with colliding index.
+    TURN_INDEX::1
+===END==="""
+
+
+INVALID_ROLE_ENUM_TRANSCRIPT = """===DEBATE_TRANSCRIPT===
+META:
+  TYPE::DEBATE_TRANSCRIPT
+  VERSION::"1.0"
+
+THREAD_ID::test-debate-gh427-bad-role
+TOPIC::TURN_SCHEMA enforcement invalid ROLE enum
+MODE::fixed
+STATUS::closed
+PARTICIPANTS::[Wind, Wall, Door]
+
+TURNS:
+  T1:
+    ROLE::Heretic
+    CONTENT::Not a permitted ROLE.
+    TURN_INDEX::1
+===END==="""
+
+
+class TestTurnSchemaValidatorEnforcement:
+    """Acceptance criteria from GH-427."""
+
+    def test_well_formed_transcript_validates(self) -> None:
+        """Existing well-formed transcripts MUST continue to validate clean."""
+        result = _run_validate(WELL_FORMED_TRANSCRIPT)
+        assert result["status"] == "success", result
+        # I5: schema sovereignty — VALIDATED is the only acceptable terminal
+        # status when no errors are present.
+        assert result["validation_status"] == "VALIDATED", (
+            f"Expected VALIDATED, got {result['validation_status']}: "
+            f"errors={result.get('validation_errors')!r} "
+            f"warnings={result.get('warnings')!r}"
+        )
+
+    def test_missing_role_is_rejected(self) -> None:
+        """A turn missing the REQ ROLE field MUST surface a validation error."""
+        result = _run_validate(MISSING_ROLE_TRANSCRIPT)
+        # Either the top-level status indicates failure, or validation_errors
+        # carries the documented error code. Be explicit and check both.
+        assert result["validation_status"] == "INVALID", (
+            f"Expected INVALID for missing ROLE, got {result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+        validation_errors = result.get("validation_errors") or []
+        # E_TURN_FIELD is the GH-427 enforcement code for missing REQ turn fields.
+        codes = {err.get("code") for err in validation_errors}
+        assert "E_TURN_FIELD" in codes, (
+            f"Expected E_TURN_FIELD validation error for missing ROLE; "
+            f"got codes={codes!r}"
+        )
+        # Field path must be specific enough to identify the offending turn.
+        offending = [
+            err
+            for err in validation_errors
+            if err.get("code") == "E_TURN_FIELD" and "ROLE" in (err.get("field") or "")
+        ]
+        assert offending, (
+            "Missing-ROLE error must reference the ROLE field path; "
+            f"got validation_errors={validation_errors!r}"
+        )
+
+    def test_duplicate_turn_index_is_rejected(self) -> None:
+        """Two turns sharing TURN_INDEX MUST surface a validation error."""
+        result = _run_validate(DUPLICATE_TURN_INDEX_TRANSCRIPT)
+        assert result["validation_status"] == "INVALID", (
+            f"Expected INVALID for duplicate TURN_INDEX, got "
+            f"{result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+        codes = {err.get("code") for err in result.get("validation_errors", [])}
+        assert "E_TURN_INDEX" in codes, (
+            f"Expected E_TURN_INDEX validation error for duplicate TURN_INDEX; "
+            f"got codes={codes!r}"
+        )
+
+    def test_invalid_role_enum_is_rejected(self) -> None:
+        """A ROLE value outside the declared ENUM MUST surface a validation error."""
+        result = _run_validate(INVALID_ROLE_ENUM_TRANSCRIPT)
+        assert result["validation_status"] == "INVALID", (
+            f"Expected INVALID for out-of-enum ROLE, got "
+            f"{result['validation_status']}: "
+            f"validation_errors={result.get('validation_errors')!r}"
+        )
+        codes = {err.get("code") for err in result.get("validation_errors", [])}
+        # E_TURN_FIELD wraps per-turn constraint violations including enum.
+        assert "E_TURN_FIELD" in codes, (
+            f"Expected E_TURN_FIELD validation error for invalid ROLE enum; "
+            f"got codes={codes!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "fixture,name",
+    [
+        (WELL_FORMED_TRANSCRIPT, "well_formed"),
+        (MISSING_ROLE_TRANSCRIPT, "missing_role"),
+        (DUPLICATE_TURN_INDEX_TRANSCRIPT, "duplicate_index"),
+        (INVALID_ROLE_ENUM_TRANSCRIPT, "invalid_enum"),
+    ],
+)
+def test_validator_returns_envelope_with_expected_keys(fixture: str, name: str) -> None:
+    """All envelopes MUST surface validation_status — never crash on TURN_SCHEMA inputs."""
+    result = _run_validate(fixture)
+    assert "validation_status" in result, f"fixture={name} envelope missing validation_status"
+
+
+def test_schema_source_declares_turn_schema_block() -> None:
+    """The schema source MUST continue to declare a TURN_SCHEMA block (I1 fidelity)."""
+    text = SCHEMA_PATH.read_text(encoding="utf-8")
+    assert "TURN_SCHEMA:" in text, (
+        "debate_transcript.oct.md must continue to declare TURN_SCHEMA: "
+        "(GH-427 enforces this block; do not regress the source)."
+    )


### PR DESCRIPTION
## Summary

Wires the documented but previously unparsed TURN_SCHEMA into the DEBATE_TRANSCRIPT validator. Closes #427.

WAVE_3 of the Schema Sweep Sprint (pre-v1.13.0). Branch was salvaged after the implementing agent was killed mid-autofix; the substantive RED→GREEN commits are preserved verbatim, and the final commit is the safe black-only autofix.

## Changes

- **RED** (`5173a4c`): regression test reproducing the documented-but-not-enforced gap on TURN_SCHEMA.
- **GREEN** (`bb3e254`): validator implementation enforcing TURN_SCHEMA on each DEBATE_TRANSCRIPT TURN entry. Required fields (`ROLE`, `CONTENT`, `TURN_INDEX`) trigger `E_TURN_FIELD` when missing; per-turn ENUM/constraint failures wrap under the same stable code; duplicate `TURN_INDEX` triggers `E_TURN_INDEX`.
- **Lint** (`eb1ae73`): black autofix, no semantic changes.

## North Star compliance

- **I1 SYNTACTIC_FIDELITY**: validator alters validation status only; no content mutation.
- **I4 TRANSFORM_AUDITABILITY**: stable error codes (`E_TURN_FIELD`, `E_TURN_INDEX`) for every detected violation.
- **I5 SCHEMA_SOVEREIGNTY**: validation_status now visible on TURN-level violations (previously documented but silent).

## Test plan

- [x] `tests/unit/test_debate_turn_schema_enforcement.py` — RED→GREEN parametrised over missing-REQ, duplicate-index, invalid-enum cases
- [x] `tests/integration/test_schema_write_idempotency.py` — green (schema-corpus auto-discovery via glob unchanged)
- [x] ruff, black, mypy clean on touched files
- [x] Pre-existing limitations honoured: ENUM enforcement gap (#435), SCHEMA_REQUIRED_EXCEPTIONS not yet consumed (#439), diff_unified cosmetic (#436)

## Known pre-existing limitations (not blockers)

- Full ENUM enforcement is PARTIAL per #435 — ROLE enum failures wrap under `E_TURN_FIELD` rather than a dedicated ENUM code.
- `E_NESTED_INLINE_MAP` write-gate asymmetry per newly-filed #440 — unrelated to this PR.

## Review chain (TIER_2_STANDARD)

Requesting CE + CRS + TMG + SR per holistic-orchestration QUALITY_GATES.

🤖 Salvaged via Claude Code HO from killed implementation-lead agent

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the documented `TURN_SCHEMA` for DEBATE_TRANSCRIPT with per‑turn validation on structured `TURNS:` blocks and bumps the schema to v1.1. Requires `ROLE`, `CONTENT`, and `TURN_INDEX` on each turn and enforces unique `TURN_INDEX`; closes #427.

- **New Features**
  - Parse `TURN_SCHEMA` into `SchemaDefinition.turn_schema` and validate each child under `TURNS:`; missing required fields and constraint failures surface as `E_TURN_FIELD`; duplicate indices as `E_TURN_INDEX`.
  - Required‑field coverage counts block keys, so a `TURNS:` block satisfies REQ `TURNS`.
  - Schema v1.1: expanded `ROLE` enum (Wind, Wall, Door, Synthesis, Human, Mediator), new required `TURN_INDEX` (NUMBER), optional `SPEAKER`, usage notes updated.
  - Per‑turn checks run only when `TURNS:` is a block; flat list `TURNS` is unchanged.

- **Bug Fixes**
  - Guard duplicate tracking against non‑hashable `TURN_INDEX` values (e.g., lists); emit `E_TURN_INDEX_TYPE` and continue instead of raising.
  - Update unit test to expect schema version `1.1`.

<sup>Written for commit 03244e6474346aa35d37060cab074c51c6d07e34. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/442?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

