### PR TITLE
fix(write): #447 changes_mode mutate-in-place — preserve existing atom form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This release lands the Strategy A span-aware preserve-mode engine (#418), the ME
 - **Passing `format_style=None` *explicitly* now emits a `DeprecationWarning`** at both the MCP `octave_write` tool surface and the CLI `octave write` command (via the new `--format-style none` literal choice). In **v1.14.0** the default will change from full canonical re-emit to span-aware `"preserve"` mode. To keep the current canonical re-emit behaviour across the flip, pass `format_style="expanded"` explicitly. To opt in to preserve mode now, pass `format_style="preserve"`. **OMITTING the parameter does NOT emit a warning** — that is the supported way to accept the future default silently. See ADR-0006 Sprint 2 addendum §5 Shape B for the rationale.
 - **Notice.** v1.14.0 will flip the `format_style` default. Callers asserting byte-shape of `octave_write` outputs SHOULD review their integration and pin a `format_style` value explicitly before the v1.14.0 upgrade.
 
+### Fixed
+- **`octave_write` changes_mode mutate-in-place on flat `===META===` atoms (#447, PR #449).** When `changes={"META.<field>": <value>}` targets a flat-form atom inside a `===META===` envelope (e.g. existing `STATUS::proposed`), the resolver now mutates that atom in-place instead of injecting a duplicate nested-block atom alongside it. Behaviour verified across `format_style ∈ {preserve, expanded, compact, omitted}`. The flat-atom scan is strictly gated on `doc.name == "META"`, so non-META envelopes with same-named flat atoms (e.g. `===DOC===\nSTATUS::content\n===END===`) are not affected and continue to route via the existing `doc.meta` create path. `$op DELETE` against flat META atoms is covered by the same code path and pinned by regression tests.
+
 ### Migration
 - No code changes required to upgrade from v1.12.0 to v1.13.0. Behaviour on the default path (`format_style` omitted) is byte-identical to v1.12.0.
 - To silence the new `DeprecationWarning` while intentionally keeping v1.12.0 behaviour, replace any `format_style=None` explicit pass with `format_style="expanded"`.
@@ -32,6 +35,7 @@ PR #418 (Strategy A engine) explicitly does NOT subsume #411 defects 1 and 2 (`$
 - **#419** — META audit-marker admission (GH#384 / SR2-T3).
 - **#421** — Sprint 2 EC coordination (EC-1 + EC-2 SATISFIED).
 - **PR-4 (this release)** — Shape B `format_style` deprecation warning + v1.13.0 documentation (T10 + T11).
+- **#449** — `octave_write` changes_mode mutate-in-place on flat `===META===` atoms (closes #447, PR-A of two pre-v1.13.0 release blockers; PR-B = #420 multi-envelope parsing/emission follows separately).
 
 ## [1.12.0] - 2026-05-11 - "Writer/Reader Symmetry" Release (ADR-0006 SR0 + SR1-T1)
 

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -3146,20 +3146,40 @@ class WriteTool(BaseTool):
                 # only when no flat atom exists do we fall through to the
                 # ``doc.meta`` dict path (preserving today's behaviour for
                 # documents whose META is parsed into the dict).
+                #
+                # PR #449 CE REWORK BLOCKING #1: the flat-atom scan MUST be
+                # constrained to the ``===META===`` envelope shape only.
+                # ``META.<field>`` addresses the flat-atom inside an envelope
+                # whose name is "META", NOT any top-level atom with the
+                # matching key anywhere in the document. CE's repro showed
+                # that without this constraint a document like
+                # ``===DOC===\nSTATUS::content_status\n===END===`` would have
+                # its DOC envelope's ``STATUS`` atom silently mutated by
+                # ``changes={"META.STATUS": ...}`` -- a cross-envelope scope
+                # leak. We gate the scan on ``doc.name == "META"`` so that
+                # only true META envelopes participate in the flat-atom path.
                 flat_idx: int | None = None
-                for idx, section in enumerate(doc.sections):
-                    if isinstance(section, Assignment) and section.key == field_name:
-                        flat_idx = idx
-                        break
+                if doc.name == "META":
+                    for idx, section in enumerate(doc.sections):
+                        if isinstance(section, Assignment) and section.key == field_name:
+                            flat_idx = idx
+                            break
 
                 if flat_idx is not None:
                     if _is_delete_sentinel(new_value):
                         # Remove the flat top-level Assignment in place.
                         del doc.sections[flat_idx]
-                        # The sections list shape changed; mark whole-doc
-                        # dirty so the preserve-mode emitter falls back
-                        # to canonical re-emit for this envelope rather
-                        # than slicing the now-stale baseline.
+                        # PR #449 CE REWORK observation #4: the deletion
+                        # mechanism is OMISSION -- removing the Assignment
+                        # node from ``doc.sections`` means the emitter
+                        # cannot re-emit what is no longer there. We also
+                        # mark ``doc.dirty=True`` so the preserve-mode
+                        # emitter cannot splice the now-stale baseline
+                        # bytes for this envelope; instead it re-emits
+                        # canonically, naturally skipping the deleted
+                        # atom. (No section-emission consults
+                        # ``doc.dirty`` directly; the flag fences the
+                        # baseline-slice path in ``emit()`` instead.)
                         doc.dirty = True
                     else:
                         # I1 (Syntactic Fidelity): normalise the value.

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -3132,8 +3132,48 @@ class WriteTool(BaseTool):
             if key.startswith("META."):
                 # Extract the field name after "META."
                 field_name = key[5:]  # Remove "META." prefix
-                if _is_delete_sentinel(new_value):
-                    # Delete field from doc.meta
+
+                # GH #447: I3 (MIRROR_CONSTRAINT) + I1 (SYNTACTIC_FIDELITY)
+                # mutate-in-place contract. When a META envelope was parsed
+                # with FLAT-form atoms (no ``META:`` block prefix), the
+                # parser puts each atom in ``doc.sections`` as a top-level
+                # ``Assignment`` rather than into the ``doc.meta`` dict. The
+                # original ``META.<field>`` resolver wrote unconditionally
+                # to ``doc.meta`` which on emit produced a NEW canonical
+                # ``META:`` block alongside the surviving flat atom —
+                # duplicate-key, form switch, I3 violation. We must locate
+                # the existing flat atom FIRST and mutate it in place;
+                # only when no flat atom exists do we fall through to the
+                # ``doc.meta`` dict path (preserving today's behaviour for
+                # documents whose META is parsed into the dict).
+                flat_idx: int | None = None
+                for idx, section in enumerate(doc.sections):
+                    if isinstance(section, Assignment) and section.key == field_name:
+                        flat_idx = idx
+                        break
+
+                if flat_idx is not None:
+                    if _is_delete_sentinel(new_value):
+                        # Remove the flat top-level Assignment in place.
+                        del doc.sections[flat_idx]
+                        # The sections list shape changed; mark whole-doc
+                        # dirty so the preserve-mode emitter falls back
+                        # to canonical re-emit for this envelope rather
+                        # than slicing the now-stale baseline.
+                        doc.dirty = True
+                    else:
+                        # I1 (Syntactic Fidelity): normalise the value.
+                        normalized_value = _normalize_value_for_ast(new_value)
+                        target_assignment = doc.sections[flat_idx]
+                        assert isinstance(target_assignment, Assignment)
+                        target_assignment.value = normalized_value
+                        # PR-2 T6: paired-write — mark only this leaf
+                        # dirty so the preserve-mode emitter re-emits
+                        # just this atom and splices the rest of the
+                        # envelope verbatim.
+                        _mark_dirty(target_assignment)
+                elif _is_delete_sentinel(new_value):
+                    # No flat atom; fall through to doc.meta dict deletion.
                     if field_name in doc.meta:
                         del doc.meta[field_name]
                     # PR-2 T6: per-key META dirty map captures the

--- a/tests/integration/test_write_preserve_nested.py
+++ b/tests/integration/test_write_preserve_nested.py
@@ -425,3 +425,161 @@ class TestPreserveParserRepairPropagation:
         assert (
             getattr(block, "body_dirty", False) is False
         ), "body_dirty was set on a clean parse — parser-side over-propagation regression"
+
+
+# ---------------------------------------------------------------------------
+# GH #447: changes_mode resolver must mutate existing FLAT META atom in place
+# rather than injecting a new nested ``META:`` block alongside it.
+# ---------------------------------------------------------------------------
+#
+# Pre-fix repro: a META envelope containing flat-form atoms (no ``META:`` block
+# prefix) parses such atoms as top-level ``Assignment`` nodes in
+# ``doc.sections``, with ``doc.meta`` left EMPTY. The ``META.<field>``
+# resolver branch in ``_apply_changes`` unconditionally wrote to
+# ``doc.meta[field]``, which on emit produced a NEW canonical
+# ``META:\n  STATUS::ratified`` block, while the original flat ``STATUS::``
+# Assignment in ``doc.sections`` remained untouched. Net result: duplicate
+# atoms with conflicting values, and an I3 (MIRROR_CONSTRAINT) +
+# I1 (SYNTACTIC_FIDELITY) violation under ``format_style="preserve"``.
+#
+# The fix locates the existing flat-form Assignment for the META field and
+# mutates it in place BEFORE falling back to the ``doc.meta`` dict path,
+# preserving the atom's source form across all four ``format_style`` modes
+# (``preserve``, ``expanded``, ``compact``, and omitted/default).
+
+
+def _run_write_changes_omitted(content: str, changes: dict) -> tuple[str, str]:
+    """Variant of ``_run_write_changes`` that does NOT pass ``format_style``.
+
+    Required by GH #447 acceptance criterion 3 — the mutate-in-place
+    contract must hold across ``format_style ∈ {preserve, expanded,
+    compact, omitted}``. The "omitted" case exercises today's default
+    (canonical re-emit) code path; the resolver must still find the
+    existing flat atom and not duplicate it.
+    """
+    tool = WriteTool()
+
+    async def _execute() -> tuple[str, str]:
+        with tempfile.NamedTemporaryFile(suffix=".oct.md", mode="w", delete=False, encoding="utf-8") as f:
+            f.write(content)
+            path = f.name
+        try:
+            result = await tool.execute(target_path=path, changes=changes)
+            with open(path, encoding="utf-8") as fp:
+                written = fp.read()
+            return result.get("status", "<missing>"), written
+        finally:
+            os.unlink(path)
+
+    return asyncio.run(_execute())
+
+
+class TestGH447ChangesModeMutateInPlace:
+    """GH #447 regression: ``META.<field>`` change must mutate existing flat atom.
+
+    Document shape under test (issue body repro):
+
+        ===META===
+        TYPE::FRAME_CARD
+        ID::TEST_CARD
+        STATUS::proposed
+        ===END===
+
+    With ``changes={"META.STATUS": "ratified"}`` the resolver MUST:
+      (a) mutate the existing ``STATUS::proposed`` flat atom in place;
+      (b) introduce NO new ``STATUS`` atom (no duplicate key);
+      (c) preserve atom form when ``format_style="preserve"`` (flat stays flat);
+      (d) hold across ``format_style ∈ {preserve, expanded, compact, omitted}``.
+    """
+
+    _SINGLE_ENVELOPE_FLAT = "===META===\n" "TYPE::FRAME_CARD\n" "ID::TEST_CARD\n" "STATUS::proposed\n" "===END===\n"
+
+    def _assert_mutate_in_place(self, written: str, *, expect_flat: bool) -> None:
+        """Shared assertion bundle for the four format_style variants."""
+        # (a) new value present
+        assert "STATUS::ratified" in written, (
+            "META.STATUS resolver did NOT land the new value. " f"file is: {written!r}"
+        )
+        # (b) old value gone — the existing atom must be mutated, not duplicated
+        assert "STATUS::proposed" not in written, (
+            "GH #447 regression: original flat STATUS::proposed atom "
+            "survived alongside the new value (duplicate-key shape). "
+            f"file is: {written!r}"
+        )
+        # No duplicate STATUS atom anywhere in output.
+        assert written.count("STATUS::") == 1, (
+            f"GH #447 regression: expected exactly one STATUS:: atom, "
+            f"found {written.count('STATUS::')}; file is: {written!r}"
+        )
+        # The injected nested-block META:\n  STATUS:: form must NOT appear
+        # when an existing flat atom is being mutated.
+        if expect_flat:
+            # (c) atom form unchanged — flat stays flat under preserve
+            assert "META:\n  STATUS::" not in written, (
+                "GH #447 regression: resolver injected a nested-block "
+                "META: form instead of mutating the flat atom in place. "
+                f"file is: {written!r}"
+            )
+            # The flat atom must remain at the top level of the envelope.
+            assert "\nSTATUS::ratified" in written or written.startswith("STATUS::ratified"), (
+                "GH #447 regression: flat-form STATUS atom lost its " f"flat shape. file is: {written!r}"
+            )
+        # Sibling atoms unchanged.
+        assert "TYPE::FRAME_CARD" in written
+        assert "ID::TEST_CARD" in written
+
+    def test_gh447_preserve_mutates_flat_meta_atom_in_place(self) -> None:
+        status, written = _run_write_changes(
+            content=self._SINGLE_ENVELOPE_FLAT,
+            changes={"META.STATUS": "ratified"},
+            format_style="preserve",
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        self._assert_mutate_in_place(written, expect_flat=True)
+
+    def test_gh447_expanded_does_not_duplicate_meta_atom(self) -> None:
+        status, written = _run_write_changes(
+            content=self._SINGLE_ENVELOPE_FLAT,
+            changes={"META.STATUS": "ratified"},
+            format_style="expanded",
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        # Under expanded canonical re-emit the atom may legitimately be
+        # promoted to a ``META:`` block, but it MUST NOT coexist with the
+        # original flat atom — that is the #447 bug.
+        self._assert_mutate_in_place(written, expect_flat=False)
+
+    def test_gh447_compact_does_not_duplicate_meta_atom(self) -> None:
+        status, written = _run_write_changes(
+            content=self._SINGLE_ENVELOPE_FLAT,
+            changes={"META.STATUS": "ratified"},
+            format_style="compact",
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        self._assert_mutate_in_place(written, expect_flat=False)
+
+    def test_gh447_omitted_format_style_does_not_duplicate_meta_atom(self) -> None:
+        """No-format_style call exercises today's default canonical re-emit path.
+
+        The resolver still must NOT inject a duplicate atom; the existing
+        flat atom MUST be located and mutated before any nested-block
+        fallback fires.
+        """
+        status, written = _run_write_changes_omitted(
+            content=self._SINGLE_ENVELOPE_FLAT,
+            changes={"META.STATUS": "ratified"},
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        self._assert_mutate_in_place(written, expect_flat=False)
+
+    def test_gh447_preserve_unchanged_siblings_intact(self) -> None:
+        """The mutate-in-place fix must NOT disturb sibling flat atoms."""
+        status, written = _run_write_changes(
+            content=self._SINGLE_ENVELOPE_FLAT,
+            changes={"META.STATUS": "ratified"},
+            format_style="preserve",
+        )
+        assert status == "success"
+        # Each sibling atom appears exactly once and unchanged.
+        assert written.count("TYPE::FRAME_CARD") == 1
+        assert written.count("ID::TEST_CARD") == 1

--- a/tests/integration/test_write_preserve_nested.py
+++ b/tests/integration/test_write_preserve_nested.py
@@ -583,3 +583,109 @@ class TestGH447ChangesModeMutateInPlace:
         # Each sibling atom appears exactly once and unchanged.
         assert written.count("TYPE::FRAME_CARD") == 1
         assert written.count("ID::TEST_CARD") == 1
+
+    # ------------------------------------------------------------------ #
+    # CE REWORK regression tests (PR #449 CE BLOCKING findings)          #
+    # ------------------------------------------------------------------ #
+
+    # CE BLOCKING #1: cross-envelope scope leak. The original fix's
+    # flat-atom scan at write.py:3149 iterated ALL ``doc.sections`` rather
+    # than being constrained to the ``===META===`` envelope shape. With a
+    # document whose envelope is NOT META (e.g. ``===DOC===``) but which
+    # happens to carry a same-named flat atom (``STATUS::content_status``),
+    # the resolver silently mutated that other envelope's content. Per the
+    # GH #447 contract, ``META.<field>`` means "the flat-atom inside the
+    # ``===META===`` envelope" -- not "any top-level atom with the matching
+    # key anywhere in the document".
+    _NON_META_ENVELOPE_WITH_FLAT_STATUS = "===DOC===\nSTATUS::content_status\n===END===\n"
+
+    def test_gh447_meta_field_does_not_leak_into_non_meta_envelope(self) -> None:
+        """CE BLOCKING #1: META.<field> change MUST NOT mutate a non-META envelope.
+
+        Repro shape from CE rework:
+
+            ===DOC===
+            STATUS::content_status
+            ===END===
+
+        With ``changes={"META.STATUS": "meta_status"}`` the resolver MUST NOT
+        silently rewrite ``STATUS::meta_status`` inside ``===DOC===``. The
+        original content's ``STATUS::content_status`` atom (which lives in the
+        DOC envelope, not META) is OUT OF SCOPE for a ``META.<field>`` change.
+        """
+        status, written = _run_write_changes(
+            content=self._NON_META_ENVELOPE_WITH_FLAT_STATUS,
+            changes={"META.STATUS": "meta_status"},
+            format_style="preserve",
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        # The DOC envelope's pre-existing flat atom MUST NOT be mutated to
+        # the META.STATUS value -- that is CE's exact BLOCKING repro.
+        assert "STATUS::meta_status" not in written or "STATUS::content_status" in written, (
+            "CE BLOCKING #1 regression: META.STATUS resolver leaked into "
+            "the ===DOC=== envelope and silently overwrote its STATUS atom. "
+            f"file is: {written!r}"
+        )
+        # The DOC envelope's pre-existing flat STATUS atom must survive intact.
+        assert "STATUS::content_status" in written, (
+            "CE BLOCKING #1 regression: the DOC envelope's original "
+            "STATUS::content_status atom was destroyed by an unrelated "
+            f"META.<field> change. file is: {written!r}"
+        )
+        # The ===DOC=== envelope wrapper must remain.
+        assert "===DOC===" in written
+
+    def test_gh447_meta_field_delete_on_flat_meta_envelope(self) -> None:
+        """CE BLOCKING #3 (also CRS gap): ``{"$op": "DELETE"}`` on a flat META atom.
+
+        Document shape: single ``===META===`` envelope with flat atoms.
+        Change: ``{"META.STATUS": {"$op": "DELETE"}}``.
+
+        Expected: the ``STATUS::proposed`` atom is removed entirely; no
+        duplicate remains anywhere in the output; no ``META:`` block stub
+        appears alongside the now-empty slot.
+        """
+        status, written = _run_write_changes(
+            content=self._SINGLE_ENVELOPE_FLAT,
+            changes={"META.STATUS": {"$op": "DELETE"}},
+            format_style="preserve",
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        # The atom must be gone, in every form.
+        assert "STATUS::proposed" not in written, (
+            "CE BLOCKING #3 regression: $op DELETE failed to remove the "
+            f"original flat STATUS atom. file is: {written!r}"
+        )
+        assert "STATUS::" not in written, (
+            "CE BLOCKING #3 regression: $op DELETE left a STATUS:: atom "
+            f"(possibly a duplicate, possibly the original). file is: {written!r}"
+        )
+        # No stray nested-block META: fragment with STATUS inside it.
+        assert "META:" not in written or "STATUS" not in written.split("META:", 1)[1], (
+            "CE BLOCKING #3 regression: $op DELETE left a stub " f"META: block referencing STATUS. file is: {written!r}"
+        )
+        # Sibling atoms must still be intact and not duplicated.
+        assert written.count("TYPE::FRAME_CARD") == 1
+        assert written.count("ID::TEST_CARD") == 1
+
+    def test_gh447_meta_field_delete_does_not_leak_into_non_meta_envelope(self) -> None:
+        """CE BLOCKING #1 + #3 cross-product: DELETE on META.<field> must not
+        delete a same-named flat atom from a non-META envelope.
+
+        Repro shape: ``===DOC===`` envelope with ``STATUS::content_status``.
+        Change: ``{"META.STATUS": {"$op": "DELETE"}}``.
+        Expected: DOC's flat atom survives (META.STATUS isn't its address).
+        """
+        status, written = _run_write_changes(
+            content=self._NON_META_ENVELOPE_WITH_FLAT_STATUS,
+            changes={"META.STATUS": {"$op": "DELETE"}},
+            format_style="preserve",
+        )
+        assert status == "success", f"WriteTool failed: status={status!r}"
+        # The DOC envelope's flat STATUS atom MUST survive: META.STATUS does
+        # not address it.
+        assert "STATUS::content_status" in written, (
+            "CE BLOCKING #1 regression (DELETE variant): the DOC envelope's "
+            "STATUS::content_status atom was deleted by an unrelated "
+            f"META.<field> DELETE change. file is: {written!r}"
+        )


### PR DESCRIPTION
## Rework rationale (CE BLOCKING — commit 12f153f)

PR #449 was REWORKED following CE BLOCKING findings on the original
implementation. CE constructed a concrete reproducer demonstrating that
the flat-atom resolver at `write.py:3149` had over-broad scope:

```
===DOC===
STATUS::content_status
===END===
```

With `changes={"META.STATUS": "meta_status"}` the original fix silently
mutated `STATUS::meta_status` inside `===DOC===` — a cross-envelope
write violating I3 (MIRROR_CONSTRAINT). Per the GH #447 contract,
`META.<field>` addresses "the flat-atom inside the `===META===`
envelope", **not** "any top-level atom with the matching key anywhere
in the document".

**Fix (commit 12f153f):** the flat-atom scan is now gated on
`doc.name == "META"`. When the document's envelope is not META, the
scan is skipped and the resolver falls through to the existing
`doc.meta` dict path. Same envelope-aware constraint applies to the
`$op DELETE` path.

**New regression tests** (TestGH447ChangesModeMutateInPlace, +3):

- `test_gh447_meta_field_does_not_leak_into_non_meta_envelope` —
  CE's exact repro; DOC's STATUS survives a META.STATUS change.
- `test_gh447_meta_field_delete_on_flat_meta_envelope` — missing
  flat-META `{"$op": "DELETE"}` regression (CRS + CE both flagged).
- `test_gh447_meta_field_delete_does_not_leak_into_non_meta_envelope` —
  cross-product; DOC's STATUS survives a META.STATUS DELETE.

Both leak tests fail on the prior PR #449 baseline and pass post-fix.

Also corrected the inaccurate `doc.dirty = True` comment on the
deletion path to describe the actual mechanism (omission from the
sections list + dirty fence on baseline slicing) per CE non-blocking
observation #4. No emit-path wiring changes.

Quality gates re-run:

```
$ ruff check src tests/integration/test_write_preserve_nested.py
                                       → All checks passed!
$ black --check src tests/integration/test_write_preserve_nested.py
                                       → 54 files would be left unchanged.
$ mypy src                             → Success: no issues found in 53 source files
$ PYTHONPATH=src pytest --ignore=tests/properties --ignore=tests/test_spec_validation.py
                                       → 3438 passed, 10 skipped, 2 xfailed
$ PYTHONPATH=src pytest tests/integration/test_write_preserve_nested.py::TestGH447ChangesModeMutateInPlace
                                       → 8 passed (5 original + 3 new)
```

`tests/test_spec_validation.py` has a pre-existing collection error
(`'timeout' not found in markers configuration option`) unrelated to
this PR's diff; verified by re-running the same collection against the
prior commit `edb4dd0`. CI runs the properties suite.

PR-A scope unchanged — #420 (multi-envelope parser/emitter) remains
intentionally out of scope and will land in PR-B.

---

## Summary

Closes #447. PR-A of two-PR serial plan for the v1.13.0 release blocker. PR-B (GH #420 multi-envelope parsing/emission) is intentionally OUT OF SCOPE here and will land separately. **This PR does NOT close #420.**

## The bug (reproduced from #447 body)

`octave_write(changes={"META.STATUS": "ratified"}, format_style="preserve")` against a document containing the existing flat atom `STATUS::proposed` inside the META envelope was injecting a new nested-block form alongside the unmodified original:

```
===META===
META:
  STATUS::ratified           ← newly injected nested-block form
TYPE::FRAME_CARD
ID::TEST_CARD
STATUS::proposed             ← original flat atom, still present, NOT mutated
===END===
```

Both the old flat atom and the new nested-block atom coexisted in the META envelope — `format_style="preserve"` violated end-to-end, with duplicate-key, form switch, and an I3 (MIRROR_CONSTRAINT) + I1 (SYNTACTIC_FIDELITY) violation.

## Root cause

`_apply_changes` in `src/octave_mcp/mcp/write.py` (the `META.<field>` branch) wrote unconditionally to `doc.meta[field]`. When the source META envelope contains FLAT-form atoms (no `META:` block prefix), the parser stores those atoms in `doc.sections` as top-level `Assignment` nodes, with `doc.meta` left empty. The unconditional dict write produced a new canonical `META:` block at emit time while the flat `Assignment` in `doc.sections` survived verbatim.

## Fix

Localized resolver patch in `src/octave_mcp/mcp/write.py` `_apply_changes`. The `META.<field>` branch now:

1. Searches `doc.sections` for an existing flat top-level `Assignment` whose key matches `field_name`.
2. If found, mutates its `.value` in place (or removes it on `$op DELETE`) and marks the leaf dirty so the preserve-mode emitter re-emits just this atom and splices the rest of the envelope verbatim.
3. Only if no flat atom exists does it fall through to the existing `doc.meta` dict path — preserving today's behaviour for documents whose META is parsed into the dict.

No changes to Strategy A engine span infrastructure (PR #418/#419) or any schema-sweep deliverable (PRs #429/#431/#437/#438/#442/#444/#446).

## Test coverage (format_style matrix)

New `TestGH447ChangesModeMutateInPlace` class in `tests/integration/test_write_preserve_nested.py` (5 tests):

- `test_gh447_preserve_mutates_flat_meta_atom_in_place` — `format_style="preserve"`, asserts (a) new value lands, (b) old atom gone, (c) exactly one STATUS:: atom, (d) flat form preserved, (e) sibling atoms unchanged.
- `test_gh447_expanded_does_not_duplicate_meta_atom` — `format_style="expanded"`.
- `test_gh447_compact_does_not_duplicate_meta_atom` — `format_style="compact"`.
- `test_gh447_omitted_format_style_does_not_duplicate_meta_atom` — `format_style` omitted (today's default canonical re-emit path).
- `test_gh447_preserve_unchanged_siblings_intact` — sibling `TYPE`/`ID` atoms unchanged.

All four `format_style ∈ {preserve, expanded, compact, omitted}` variants confirmed RED before the fix and GREEN after.

## #447 acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | `changes={"META.STATUS": "ratified"}` mutates existing atom; no new atom introduced | MET |
| 2 | `format_style="preserve"` honoured end-to-end across the change subtree | MET |
| 3 | Behavior verified across `format_style ∈ {preserve, expanded, compact, omitted}` | MET |
| 4 | Regression test pinning the mutate-in-place contract | MET |

## Quality gates

```
$ ruff check src                       → All checks passed!
$ ruff check tests/integration/...     → All checks passed!
$ black --check src                    → 53 files would be left unchanged.
$ black --check tests/integration/...  → 1 file would be left unchanged.
$ mypy src                             → Success: no issues found in 53 source files
$ PYTHONPATH=src pytest --ignore=tests/properties
                                       → 3471 passed, 11 skipped, 2 xfailed
$ PYTHONPATH=src pytest tests/integration/test_write_preserve_nested.py::TestGH447ChangesModeMutateInPlace
                                       → 5 passed
```

Tests delta: +5 new tests (`TestGH447ChangesModeMutateInPlace`). No regressions to existing test suite. `tests/properties/` skipped locally due to a missing `hypothesis` dependency in the local environment — CI runs them. All other gates verified locally against the worktree source via `PYTHONPATH=src`.

## End-to-end repro after fix

```
diff_unified:
--- original
+++ canonical
@@ -1,5 +1,5 @@
 ===META===
 TYPE::FRAME_CARD
 ID::TEST_CARD
-STATUS::proposed
+STATUS::ratified
 ===END===
```

Single-line diff. Flat form preserved. No nested-block injection.

## Scope discipline

This is PR-A of two. **#420 (multi-envelope parsing/emission + idempotency CI glob widening) is intentionally NOT addressed here** and will land in PR-B. No modifications to:
- the multi-envelope parser AST path
- the idempotency CI glob
- Strategy A engine span infrastructure (PR #418/#419)
- any schema-sweep deliverable (PRs #429/#431/#437/#438/#442/#444/#446)

## Refs

- Closes #447
- Companion (NOT closed by this PR): #420
- Related infrastructure: #377 (Strategy A), #376 (format_style toggle)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate `META` atom emission by mutating flat `===META===` atoms in place when applying `changes`, preserving the original form under `format_style="preserve"` and preventing cross-envelope writes. Closes #447.

- **Bug Fixes**
  - In `_apply_changes`, `META.<field>` now searches `doc.sections` only when `doc.name == "META"`; mutates or deletes the top-level `Assignment` in place, falling back to `doc.meta` if none exists.
  - Supports `{"$op": "DELETE"}` for flat `META` atoms; no nested `META:` block is introduced.
  - Behavior verified across `format_style ∈ {preserve, expanded, compact, omitted}`; added 8 regression tests (incl. non-META leak prevention and DELETE cases).
  - Updated `CHANGELOG.md` to document the fix.

<sup>Written for commit f56f3b000ba1d28c6bd8e67ddbcd92eaf5bc03e3. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

