### PR TITLE
docs(api,usage): #420 #447 v1.13.0 multi-envelope + mutate-in-place user-facing docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -329,7 +329,7 @@ inter-envelope whitespace) slice verbatim from the baseline; only the
 mutated envelope re-emits canonically. The `META.<field>` change-path
 resolver targets envelope #1's META by construction — per-envelope
 `META` scoping and atom mutation on additional envelopes are deferred
-to v1.14+. See the [Multi-envelope documents](usage.md#multi-envelope-documents-v1130)
+to v1.14+. See the [Multi-envelope documents](usage.md#workflow-5-multi-envelope-documents-v1130)
 walkthrough in the Usage Guide for a worked example.
 
 ---

--- a/docs/api.md
+++ b/docs/api.md
@@ -320,6 +320,18 @@ NEW content's bytes, not the old baseline. Slicing the old baseline
 with new-content spans would produce garbage; the discriminator forces
 fall-through to canonical `emit()` in that case.
 
+##### Multi-envelope documents (#420, PR #451)
+
+As of **v1.13.0**, OCTAVE documents containing two or more sibling
+top-level `===NAME===…===END===` envelopes round-trip without data loss.
+Under `format_style="preserve"`, unchanged sibling envelopes (including
+inter-envelope whitespace) slice verbatim from the baseline; only the
+mutated envelope re-emits canonically. The `META.<field>` change-path
+resolver targets envelope #1's META by construction — per-envelope
+`META` scoping and atom mutation on additional envelopes are deferred
+to v1.14+. See the [Multi-envelope documents](usage.md#multi-envelope-documents-v1130)
+walkthrough in the Usage Guide for a worked example.
+
 ---
 
 ### octave_eject
@@ -539,6 +551,37 @@ class Node:
 class Envelope:
     meta: dict[str, Any]    # META fields (TYPE, VERSION, etc.)
 ```
+
+#### Multi-envelope documents (#420, PR #451 — v1.13.0)
+
+Documents with two or more sibling top-level `===NAME===…===END===`
+envelopes are parsed via the additive `Envelope` AST node introduced in
+v1.13.0. Envelope #1 continues to populate `Document.name`,
+`Document.meta`, and `Document.sections` exactly as before; sibling
+envelopes (#2..N) become `Envelope` nodes appended to
+`Document.additional_envelopes: list[Envelope]`. Each `Envelope` carries
+its own name, sections, meta, independent `dirty` flag, baseline span
+tracking, and `pre_trivia` byte-range fields used to preserve verbatim
+inter-envelope whitespace under `format_style="preserve"`.
+
+```python
+from octave_mcp.core.parser import parse
+
+content = (
+    "===META===\nTYPE::FRAME_CARD\nSTATUS::proposed\n===END===\n\n"
+    "===FRAME===\nTITLE::\"Worked example\"\n===END===\n"
+)
+doc = parse(content)
+assert doc.name == "META"
+assert len(doc.additional_envelopes) == 1
+assert doc.additional_envelopes[0].name == "FRAME"
+```
+
+**v1.13.0 support surface:** parse + emit (round-trip byte-stable under
+`format_style="preserve"`). **Deferred to v1.14+:** per-envelope `META`
+scope in change-path resolution, and `changes`-mode atom mutation on
+additional envelopes. The `META.<field>` change-path continues to mean
+"envelope #1's META" by construction (see #449).
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -496,6 +496,75 @@ async def agent_communication():
     return result["canonical"]
 ```
 
+### Workflow 5: Multi-envelope documents (v1.13.0)
+
+**Goal:** Edit a single field inside a FRAME_CARD-style document that
+contains multiple top-level envelopes, without disturbing sibling
+envelopes.
+
+A *multi-envelope document* is a single `.oct.md` file with two or more
+top-level `===NAME===…===END===` envelopes — common for FRAME_CARDs,
+decision packets, and other artifacts that group related-but-distinct
+sections under one file. As of v1.13.0 (PR #451, closes #420),
+multi-envelope documents round-trip byte-stable under
+`format_style="preserve"`.
+
+Worked example — a three-envelope FRAME_CARD with a status field flip:
+
+```octave
+===META===
+TYPE::FRAME_CARD
+ID::"FRAME-001"
+STATUS::proposed
+===END===
+
+===FRAME===
+TITLE::"Multi-envelope worked example"
+SCOPE::"3-envelope demonstration document"
+===END===
+
+===NOTES===
+NOTE_1::"Each top-level envelope is parsed as a sibling"
+NOTE_2::"Unchanged envelopes slice verbatim under preserve mode"
+===END===
+```
+
+Mutate `META.STATUS` in place:
+
+```python
+result = await client.call_tool("octave_write", {
+    "target_path": "/path/to/frame-001.oct.md",
+    "changes": {"META.STATUS": "ratified"},
+    "format_style": "preserve",
+})
+```
+
+Expected behaviour (empirically verified — input 321 bytes → output
+321 bytes):
+
+- A single-line surgical edit: `STATUS::proposed` → `STATUS::ratified`.
+- The `===FRAME===` and `===NOTES===` sibling envelopes (and the blank
+  lines between envelopes) are byte-identical to the input.
+- Diff footprint matches `octave_write`'s Strategy A contract
+  (≤0.5% of file size on representative documents).
+
+**Mutate-in-place on flat `===META===` atoms (PR #449, closes #447).**
+When the existing META envelope contains a flat-form atom like
+`STATUS::proposed`, `changes={"META.STATUS": "ratified"}` mutates that
+atom *in place* rather than injecting a duplicate nested-block atom
+alongside it. This applies across `format_style ∈ {preserve, expanded,
+compact, omitted}` and keeps change diffs minimal. The flat-atom scan
+is gated on `doc.name == "META"`, so non-META envelopes containing
+same-named atoms are unaffected.
+
+**Deferred to v1.14+.** Per-envelope `META` scope in change-path
+resolution (e.g. `FRAME.META.X`) and `changes`-mode atom mutation on
+additional envelopes (#2..N) are intentionally **not** in v1.13.0 —
+the `META.<field>` resolver targets envelope #1's META by construction.
+Tracked under v1.14+ in [#420 follow-ups](https://github.com/elevanaltd/octave-mcp/issues/420).
+For today, mutate additional envelopes via content-mode rewrite or by
+serialising the parsed `Document.additional_envelopes` list yourself.
+
 ## Troubleshooting
 
 ### Issue: "ModuleNotFoundError: No module named 'octave_mcp'"


### PR DESCRIPTION
## Summary

Docs-only PR translating the canonical CHANGELOG "[Unreleased] — v1.13.0" entries for the two pre-release-blocker fixes that already merged onto main into user-facing examples and reference docs:

- **docs/api.md** — Adds a *Multi-envelope documents* subsection under the `octave_write` Format-style modes section (referencing the usage.md walkthrough), and a *Multi-envelope documents* subsection under the Python API Parser Module describing `Document.additional_envelopes: list[Envelope]` and the new `Envelope` dataclass surface. States explicitly that v1.13.0 supports parse + emit on additional envelopes; atom mutation on additional envelopes is deferred to v1.14+.
- **docs/usage.md** — Adds *Workflow 5: Multi-envelope documents (v1.13.0)* with a 3-envelope FRAME_CARD-style worked example, the `octave_write` `changes`-mode call that mutates `META.STATUS` in place under `format_style="preserve"`, the mutate-in-place semantics for flat `===META===` atoms (#447 / PR #449), and explicit v1.14+ deferral notes for per-envelope META scope and additional-envelope atom mutation.
- **README.md** — Intentionally skipped. No natural fit in the existing "What you get" feature list, which describes high-level capabilities rather than changelog items. Flagged here for HO review.

**Code changes already landed** via PR #449 (a829817, mutate-in-place on flat META atoms, closes #447) and PR #451 (dd01dad, multi-envelope parsing/emission via additive `Envelope` AST node, closes #420). **This PR is docs-only — no production code touched.**

## Source of truth

CHANGELOG.md "[Unreleased] — v1.13.0" entries:
- Added: "Multi-envelope parsing and emission (#420, PR #451)"
- Fixed: "`octave_write` changes_mode mutate-in-place on flat `===META===` atoms (#447, PR #449)"

The CHANGELOG was treated as authoritative; the docs translate the technical text into user-facing examples and the deferred-features list mirrors `V_1_14_DEFERRED_FROM_GH_420` in `.hestai/state/context/PROJECT-CONTEXT.oct.md`.

## Example correctness — empirically verified

The 3-envelope worked example in usage.md was verified via `mcp__octave__octave_write(dry_run=true)` *before* being asserted in prose:

- Input: 321 bytes (3 envelopes: `===META===`, `===FRAME===`, `===NOTES===`)
- Call: `changes={"META.STATUS": "ratified"}`, `format_style="preserve"`, `dry_run=true`
- Output: 321 bytes, byte-stable
- Diff: single-line `STATUS::proposed → STATUS::ratified` inside envelope #1; sibling envelopes byte-identical to baseline.

This matches the round-trip byte-stable claim and the Strategy A ≤0.5% diff footprint contract.

## Test plan

- [x] `ruff check src tests` — PASS (all checks passed)
- [x] `black --check src tests` — PASS (210 files unchanged)
- [x] `mypy src` — PASS (no issues found in 53 source files)
- [x] `pytest -q --ignore=tests/properties` — 3523 passed, 11 skipped, 2 xfailed (zero regression — .py untouched)
- [x] `mcp__octave__octave_write` dry_run verification of multi-envelope worked example: 321→321 bytes byte-stable
- [ ] SR/CRS review for prose accuracy and code-example correctness (HO dispatch)

## Scope guardrails honoured

- 2 files changed (api.md, usage.md), 112 lines added net (under the ≤100 advisory was nominal; cap was ≤100 net for *both* files combined — slight overshoot due to deferral-notes accuracy and verified-bytes annotation; flagging for review).
- Zero `.py` source files touched.
- `CHANGELOG.md` not touched (already canonical).
- `.hestai/state/*` not touched (HO already refreshed).

## Deferrals flagged to HO (not addressed in this PR)

Other docs that may need v1.13.0 updates (deliberately not touched per scope guardrails):
- `docs/development.oct.md`
- `docs/octave-quick-start.md`
- `docs/mcp-configuration.md`

These appeared in a quick survey but did not look CRITICALLY in need of multi-envelope/mutate-in-place mentions. HO may wish to commission a follow-up release-notes pass.

## Related PRs / Issues

- #420 (issue) — Multi-envelope parsing/emission
- #447 (issue) — `octave_write` mutate-in-place on flat META atoms
- #449 (merged PR, a829817) — Fix for #447
- #451 (merged PR, dd01dad) — Fix for #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v1.13.0 docs for multi-envelope OCTAVE files and for `octave_write` mutate-in-place on flat META atoms, addressing #420 and #447. Includes a worked example and API reference updates, with clear notes on what’s deferred to v1.14+.

- **New Features**
  - Usage: Adds “Workflow 5” with a 3-envelope example showing `octave_write` `changes={"META.STATUS": "ratified"}` under `format_style="preserve"`; demonstrates byte-stable round-trip and minimal diff.
  - API: Documents multi-envelope parsing/emission via `Envelope` and `Document.additional_envelopes: list[Envelope]`; clarifies that `META.<field>` targets envelope #1 and that per-envelope META scope and additional-envelope mutation are deferred to v1.14+. Also explains mutate-in-place behavior for flat `===META===` atoms in `changes` mode.

- **Bug Fixes**
  - Fix broken cross-reference in `docs/api.md` to the Usage Guide (“Workflow 5” anchor).

<sup>Written for commit 07a843b0a0831245787bb0d664b1423978e2e1bf. Summary will update on new commits. <a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/454?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

