### PR TITLE
chore(release): v1.13.0 — Strategy A + META audit + multi-envelope + mutate-in-place + W_SNAKE_CASE_BLOB + primer discipline

### DIFF
--- a/.hestai/north-star/000-OCTAVE-MCP-NORTH-STAR-SUMMARY.oct.md
+++ b/.hestai/north-star/000-OCTAVE-MCP-NORTH-STAR-SUMMARY.oct.md
@@ -5,7 +5,7 @@ META:
   PROJECT::"OCTAVE-MCP"
   STATUS::APPROVED
   APPROVED_DATE::"2025-12-28"
-  UPDATED::"2026-02-22"
+  UPDATED::"2026-05-27"
   FULL_DOC::".hestai/north-star/000-OCTAVE-MCP-NORTH-STAR.md"
   COMPRESSION_TIER::AGGRESSIVE
   LOSS_PROFILE::"drop_narrative_preserve_protocol⊕examples"
@@ -26,7 +26,7 @@ INTERPRETATION_LITERAL_ZONES::exemption_from_normalization_preserves_meaning
 STATUS::ENFORCED
 I2::DETERMINISTIC_ABSENCE
 STATEMENT::"distinguish_absent∨"
-RATIONALE::downstream_must_know_didnt_check_vs_not_there
+RATIONALE::"downstream must know — didn't check vs. not there"
 INTERPRETATION_LITERAL_ZONES::empty_code_block_distinct_from_absent
 STATUS::ENFORCED
 I3::MIRROR_CONSTRAINT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1013,7 +1013,9 @@ the architectural separation of the OCTAVE language specification from implement
 - Non-reasoning document processing
 - Deterministic, idempotent transformations
 
-[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.13.0...HEAD
+[1.13.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.10.0...v1.11.0
 [1.10.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.9.6...v1.10.0
 [1.9.6]: https://github.com/elevanaltd/octave-mcp/compare/v1.9.5...v1.9.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This release lands the Strategy A span-aware preserve-mode engine (#418), the ME
 - **Notice.** v1.14.0 will flip the `format_style` default. Callers asserting byte-shape of `octave_write` outputs SHOULD review their integration and pin a `format_style` value explicitly before the v1.14.0 upgrade.
 
 ### Fixed
+- **North Star summary I2 `RATIONALE` self-application cleanup (#457).** The sole project-owned offender surfaced by the new `W_SNAKE_CASE_BLOB` advisory (in `.hestai/north-star/000-OCTAVE-MCP-NORTH-STAR-SUMMARY.oct.md:29`) is rewritten from snake-blob to quoted English prose (`"downstream must know — didn't check vs. not there"`), bringing octave-mcp's own `.oct.md` corpus to zero `W_SNAKE_CASE_BLOB` warnings.
 - **`octave_write` changes_mode mutate-in-place on flat `===META===` atoms (#447, PR #449).** When `changes={"META.<field>": <value>}` targets a flat-form atom inside a `===META===` envelope (e.g. existing `STATUS::proposed`), the resolver now mutates that atom in-place instead of injecting a duplicate nested-block atom alongside it. Behaviour verified across `format_style ∈ {preserve, expanded, compact, omitted}`. The flat-atom scan is strictly gated on `doc.name == "META"`, so non-META envelopes with same-named flat atoms (e.g. `===DOC===\nSTATUS::content\n===END===`) are not affected and continue to route via the existing `doc.meta` create path. `$op DELETE` against flat META atoms is covered by the same code path and pinned by regression tests.
 
 ### Migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to OCTAVE-MCP will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v1.13.0 — "Strategy A Span-Aware Preserve" (ADR-0006 SR2)
+## [Unreleased]
+
+## [1.13.0] - 2026-05-27 - "Strategy A Span-Aware Preserve" (ADR-0006 SR2)
 
 This release lands the Strategy A span-aware preserve-mode engine (#418), the META audit-marker admission policy (#419, GH#384), and the Shape B `format_style` deprecation rollout (PR-4 / addendum §5). The default `format_style` does **not** flip in this release — see "Deprecated" below for the v1.14.0 plan.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "1.12.0"
+version = "1.13.0"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/unit/test_gh452_snake_case_blob.py
+++ b/tests/unit/test_gh452_snake_case_blob.py
@@ -288,6 +288,14 @@ class TestSnakeCaseBlobDetectorUnit:
 
     # --- Known v1 miss --------------------------------------------------
 
+    # strict=False (was strict=True) per CE non-blocking advisory on PR #456:
+    # https://github.com/elevanaltd/octave-mcp/pull/456#issuecomment-4550543834
+    # The assertion is phrased for the v2 contract (W_SNAKE_CASE_BLOB in codes).
+    # Under v1 the token does not trip either trigger → xfail. When v2 refines
+    # the heuristic to catch this token the test would XPASS, and strict=True
+    # would convert XPASS into a suite failure (time bomb). strict=False makes
+    # the eventual XPASS a warning instead, signalling "v2 closed the gap"
+    # without breaking CI.
     @pytest.mark.xfail(
         reason=(
             "v1 known miss per operator contract 4549996376: "
@@ -296,7 +304,7 @@ class TestSnakeCaseBlobDetectorUnit:
             "meet either the bulk trigger (>40 chars) or the semantic trigger "
             "(>=2 stopwords). v2 may close this with a refined heuristic."
         ),
-        strict=True,
+        strict=False,
     )
     def test_known_v1_miss_progressive_replacement(self):
         """Documented v1 limitation — caught by skill review, not validator."""

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Roll v1.13.0 from `[Unreleased]` to a dated entry and bump `pyproject.toml` 1.12.0 → 1.13.0. This release bundles all v1.13.0 work merged to `origin/main`:

- **#418** — Strategy A span-aware preserve mode engine (ADR-0006 SR2-T2 PR-3; subsumes #248 annotation drift)
- **#419** — META audit-marker admission Option C (#384, `W_META_AUDIT`)
- **#420 (PR #451)** — multi-envelope parsing and emission via additive `Envelope` AST node
- **#447 (PR #449)** — `octave_write` `changes_mode` mutate-in-place on flat `===META===` atoms
- **#452 (PR #456)** — `W_SNAKE_CASE_BLOB` advisory warning for snake-case prose blobs in reasoning fields
- **#453 (PR #455)** — primer authoring discipline: canonical operator legends + `TELEGRAPHIC_PHRASE` naming
- **#457** — North Star summary I2 `RATIONALE` self-application cleanup (W_SNAKE_CASE_BLOB self-application) — folded in as commit 3 below

Also addresses the CE non-blocking advisory on PR #456 ([comment 4550543834](https://github.com/elevanaltd/octave-mcp/pull/456#issuecomment-4550543834)) by flipping `strict=True` → `strict=False` on `test_known_v1_miss_progressive_replacement` to prevent a future XPASS time-bomb when v2 refines the heuristic.

## Commits

1. `test(validate): #452 fix W_SNAKE_CASE_BLOB v2 xfail time-bomb (CE advisory)` — `tests/unit/test_gh452_snake_case_blob.py`
2. `chore(release): v1.13.0 - bundle #418 #419 #420 #447 #452 #453` — `pyproject.toml`, `CHANGELOG.md`, `uv.lock`
3. `docs(north-star): #457 fix I2 RATIONALE snake-blob in North Star summary (W_SNAKE_CASE_BLOB self-application)` — `.hestai/north-star/000-OCTAVE-MCP-NORTH-STAR-SUMMARY.oct.md`, `CHANGELOG.md`

## Out of scope

- **Tagging:** reserved to operator post-merge (`PROJECT-CONTEXT::NEXT_ACTIONS::tag_v_1_13_0_on_operator_signal`).
- **`publish.yml` workflow:** NOT triggered by this PR — operator-driven post-tag.
- **Primers / `.hestai-sys/library/skills/**`:** untouched (downstream territory).

## Test plan

- [x] `.venv/bin/python -m pytest -q` — **3614 passed, 11 skipped, 3 xfailed**
- [x] `.venv/bin/python -m ruff check src tests` — clean
- [x] `.venv/bin/python -m black --check src tests` — clean
- [x] `.venv/bin/python -m mypy src` — clean (no issues, 53 source files)
- [x] `.venv/bin/python -c "from octave_mcp import __version__; print(__version__)"` → `1.13.0`
- [x] CHANGELOG entries cross-checked against merged-PR ledger (I3 Mirror Constraint: no net-new entries added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
