### PR TITLE
skills update in line with hestai-mcp

### DIFF
--- a/src/octave_mcp/resources/skills/octave-mythology/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-mythology/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: octave-mythology
-description: Functional mythological compression for OCTAVE (Olympian Common Text And Vocabulary Engine) documents. Semantic shorthand for LLM audiences, not prose decoration
+description: Functional mythological compression for OCTAVE documents. Semantic shorthand for LLM audiences, not prose decoration
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["mythology", "archetype", "SISYPHEAN", "ICARIAN", "semantic compression", "evidence-based", "mythological domains", "OCTAVE mythology", "PROMETHEAN", "functional mythology", "compression patterns"]
-version: "1.2.1"
+version: "1.3.0"
 ---
 
 ===OCTAVE_MYTHOLOGY===
 META:
   TYPE::SKILL
-  VERSION::"1.2.1"
+  VERSION::"1.3.0"
   STATUS::ACTIVE
   PURPOSE::"Functional mythological semantic compression for OCTAVE documents"
+  OCTAVE::"Olympian Common Text And Vocabulary Engine — Semantic DSL for LLMs"
   PRINCIPLE::"Compression shorthand for LLM audiences, not ceremonial prose"
   EVIDENCE::[
     "60-70% token reduction vs natural language",

--- a/src/octave_mcp/resources/skills/octave-ultra-mythic/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-ultra-mythic/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: octave-ultra-mythic
-description: Ultra-high density compression using mythological atoms and semantic shorthand for OCTAVE (Olympian Common Text And Vocabulary Engine). Preserves soul and constraints at 60% compression for identity transmission, binding protocols, and extreme token scarcity.
+description: Ultra-high density compression using mythological atoms and semantic shorthand. Preserves soul and constraints at 60% compression for identity transmission, binding protocols, and extreme token scarcity.
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["ultra mythic", "mythological compression", "semantic atoms", "identity compression", "binding passport", "cognitive passport", "60% compression", "soul preservation"]
-version: "1.2.1"
+version: "1.3.0"
 ---
 
 ===OCTAVE_ULTRA_MYTHIC===
 META:
   TYPE::SKILL
-  VERSION::"1.2.1"
+  VERSION::"1.3.0"
   STATUS::ACTIVE
   PURPOSE::"Ultra-high density compression using mythological atoms for identity and knowledge preservation"
+  OCTAVE::"Olympian Common Text And Vocabulary Engine — Semantic DSL for LLMs"
   REQUIRES::[octave-literacy, octave-mythology]
   TIER::ULTRA_MYTHIC
   SPEC_REFERENCE::octave-data-spec.oct.md


### PR DESCRIPTION
Update skills to align with hestai-MCP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `octave-mythology` and `octave-ultra-mythic` skill specs with `hestai-mcp`. Bumps to 1.3.0, trims descriptions, and adds `OCTAVE` DSL metadata for consistent MCP parsing.

<sup>Written for commit 2ad6923a01e834bebbc77eb2ef558dace4a95579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/468?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

