### PR TITLE
refactor(mcp/write): #464 extract CLUSTER_B AST metrics → write_metrics.py

### DIFF
--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -17,7 +17,6 @@ import hashlib
 import os
 import re
 import tempfile
-from dataclasses import dataclass, field
 from difflib import unified_diff
 from pathlib import Path
 from typing import Any
@@ -51,6 +50,7 @@ from octave_mcp.mcp.write_detection import (
     _detect_snake_case_blob,
     _detect_unquoted_section_in_values,
 )
+from octave_mcp.mcp.write_metrics import StructuralMetrics, extract_structural_metrics
 from octave_mcp.schemas.loader import (
     BUILTIN_SCHEMA_DEFINITIONS,
     get_builtin_schema,
@@ -147,50 +147,6 @@ _REFUSE_REASON_ARITY = "arity_exceeded"
 # GH#352: Guidance hint for UNVALIDATED status (I5)
 # GH#361r3: Base hint text; available schemas appended dynamically at runtime.
 _VALIDATION_HINT_BASE = "Pass schema='META' (or another schema name) to enable I5 schema validation."
-
-
-@dataclass
-class StructuralMetrics:
-    """Metrics for structural comparison of OCTAVE documents.
-
-    Tracks counts of structural elements to detect potential data loss
-    during normalization or transformation.
-    """
-
-    sections: int = 0  # Count of Section nodes
-    section_markers: set[str] = field(default_factory=set)  # Section IDs found
-    blocks: int = 0  # Count of Block nodes
-    assignments: int = 0  # Count of Assignment nodes
-
-
-def extract_structural_metrics(doc: Document) -> StructuralMetrics:
-    """Extract structural metrics from a parsed OCTAVE document.
-
-    Recursively traverses the AST to count structural elements.
-
-    Args:
-        doc: Parsed Document AST
-
-    Returns:
-        StructuralMetrics with counts of structural elements
-    """
-    metrics = StructuralMetrics()
-
-    def traverse(nodes: list[ASTNode]) -> None:
-        """Recursively count structural elements."""
-        for node in nodes:
-            if isinstance(node, Section):
-                metrics.sections += 1
-                metrics.section_markers.add(node.section_id)
-                traverse(node.children)
-            elif isinstance(node, Block):
-                metrics.blocks += 1
-                traverse(node.children)
-            elif isinstance(node, Assignment):
-                metrics.assignments += 1
-
-    traverse(doc.sections)
-    return metrics
 
 
 def _is_delete_sentinel(value: Any) -> bool:

--- a/src/octave_mcp/mcp/write_metrics.py
+++ b/src/octave_mcp/mcp/write_metrics.py
@@ -1,0 +1,55 @@
+"""AST structural metrics extracted from write.py as part of STRATEGY_S1 (#459/#464)."""
+
+from dataclasses import dataclass, field
+
+from octave_mcp.core.grammar.cst import (
+    Assignment,
+    ASTNode,
+    Block,
+    Document,
+    Section,
+)
+
+
+@dataclass
+class StructuralMetrics:
+    """Metrics for structural comparison of OCTAVE documents.
+
+    Tracks counts of structural elements to detect potential data loss
+    during normalization or transformation.
+    """
+
+    sections: int = 0  # Count of Section nodes
+    section_markers: set[str] = field(default_factory=set)  # Section IDs found
+    blocks: int = 0  # Count of Block nodes
+    assignments: int = 0  # Count of Assignment nodes
+
+
+def extract_structural_metrics(doc: Document) -> StructuralMetrics:
+    """Extract structural metrics from a parsed OCTAVE document.
+
+    Recursively traverses the AST to count structural elements.
+
+    Args:
+        doc: Parsed Document AST
+
+    Returns:
+        StructuralMetrics with counts of structural elements
+    """
+    metrics = StructuralMetrics()
+
+    def traverse(nodes: list[ASTNode]) -> None:
+        """Recursively count structural elements."""
+        for node in nodes:
+            if isinstance(node, Section):
+                metrics.sections += 1
+                metrics.section_markers.add(node.section_id)
+                traverse(node.children)
+            elif isinstance(node, Block):
+                metrics.blocks += 1
+                traverse(node.children)
+            elif isinstance(node, Assignment):
+                metrics.assignments += 1
+
+    traverse(doc.sections)
+    return metrics

--- a/tests/unit/test_write_tool.py
+++ b/tests/unit/test_write_tool.py
@@ -1611,7 +1611,7 @@ class TestStructuralMetrics:
     def test_extract_structural_metrics_counts_sections(self):
         """Test extract_structural_metrics() counts sections correctly."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import extract_structural_metrics
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         # Document with 2 numbered sections
         content = """===TEST===
@@ -1632,7 +1632,7 @@ class TestStructuralMetrics:
     def test_extract_structural_metrics_counts_section_markers(self):
         """Test extract_structural_metrics() identifies section markers."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import extract_structural_metrics
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         # Document with section markers
         content = """===DOC===
@@ -1655,7 +1655,7 @@ class TestStructuralMetrics:
     def test_extract_structural_metrics_counts_blocks(self):
         """Test extract_structural_metrics() counts blocks correctly."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import extract_structural_metrics
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         # Document with 2 blocks
         content = """===TEST===
@@ -1673,7 +1673,7 @@ SECOND_BLOCK:
     def test_extract_structural_metrics_counts_assignments(self):
         """Test extract_structural_metrics() counts assignments correctly."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import extract_structural_metrics
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         # Document with 3 assignments (including nested)
         content = """===TEST===
@@ -1691,7 +1691,8 @@ BLOCK:
     def test_generate_diff_no_changes(self):
         """Test _generate_diff() returns 'No changes' for identical documents."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import WriteTool, extract_structural_metrics
+        from octave_mcp.mcp.write import WriteTool
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         tool = WriteTool()
 
@@ -1705,7 +1706,8 @@ BLOCK:
     def test_generate_diff_detects_section_marker_removal(self):
         """Test _generate_diff() detects section marker removal (W_STRUCT_001)."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import WriteTool, extract_structural_metrics
+        from octave_mcp.mcp.write import WriteTool
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         tool = WriteTool()
 
@@ -1739,7 +1741,8 @@ OTHER::value
     def test_generate_diff_detects_assignment_reduction(self):
         """Test _generate_diff() detects assignment count reduction (W_STRUCT_003)."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import WriteTool, extract_structural_metrics
+        from octave_mcp.mcp.write import WriteTool
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         tool = WriteTool()
 
@@ -1767,7 +1770,8 @@ KEY1::value1
     def test_generate_diff_structural_summary_format(self):
         """Test structural summary format in _generate_diff() response."""
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import WriteTool, extract_structural_metrics
+        from octave_mcp.mcp.write import WriteTool
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         tool = WriteTool()
 
@@ -1837,7 +1841,8 @@ KEY::new
         Fix: Add content_changed parameter that the caller computes and passes in.
         """
         from octave_mcp.core.parser import parse
-        from octave_mcp.mcp.write import WriteTool, extract_structural_metrics
+        from octave_mcp.mcp.write import WriteTool
+        from octave_mcp.mcp.write_metrics import extract_structural_metrics
 
         tool = WriteTool()
 


### PR DESCRIPTION
## Summary

Step 2 of 4 in the STRATEGY_S1 sequence (parent #459). Mechanical VERBATIM extraction of CLUSTER_B AST structural-metrics surface out of `src/octave_mcp/mcp/write.py` into a new dedicated module `src/octave_mcp/mcp/write_metrics.py`.

Closes #464.
Predecessor: #463 / PR #467 (CLUSTER_A — `write_detection.py`).

### Symbols moved
- `StructuralMetrics` dataclass
- `extract_structural_metrics` function (with nested `traverse` helper)

### Behaviour
- No signature change, no rename, no body edit.
- No re-export shim (per #459 acceptance).
- `write.py` imports both symbols from `write_metrics`.
- `tests/unit/test_write_tool.py` import sites updated to the new module path.
- Unused `from dataclasses import dataclass, field` removed from `write.py`.

### LOC delta
- `src/octave_mcp/mcp/write.py`: 3961 → 3917 (-44)
- `src/octave_mcp/mcp/write_metrics.py`: new, 55 LOC (40 LOC code + module docstring + imports)

### Quality gates (all green)
- `ruff`: clean
- `black`: clean
- `mypy`: clean
- `pytest`: **3614 passed**, 11 skipped, 3 xfailed — matches the post-CLUSTER_A baseline exactly (zero regressions, zero test count delta).

PROD::I1 SYNTACTIC_FIDELITY preserved — pure structural relocation.

## Test plan
- [x] Full `pytest -q` suite green (3614 passed)
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] `mypy` clean on changed files
- [x] LOC verified (`wc -l`)
- [x] All importers updated (grep confirmed no stale references)

Tier: T2 (TMG + CRS + CE) — pure mechanical extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved AST structural metrics from `octave_mcp.mcp.write` to `octave_mcp.mcp.write_metrics` to isolate metrics logic and keep `write` focused. Part of STRATEGY_S1 (#459); closes #464.

- **Refactors**
  - Extracted `StructuralMetrics` and `extract_structural_metrics` to `octave_mcp.mcp.write_metrics`; `octave_mcp.mcp.write` now imports them.
  - No signature or body changes; removed unused `dataclasses` import in `octave_mcp.mcp.write`.
  - Updated tests to import from `octave_mcp.mcp.write_metrics`; no re-export shim per #459.

- **Migration**
  - If you import `StructuralMetrics` or `extract_structural_metrics`, update to `from octave_mcp.mcp.write_metrics import ...`.

<sup>Written for commit dd616f211d7c1720fbc0b2406297ab278d5429cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/469?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

