### PR TITLE
docs: add TELEGRAPHIC_PHRASE naming to compression and literacy skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Skills now name `TELEGRAPHIC_PHRASE` (follow-up to #453).** Added the atom + canonical contrast example to `octave-compression/SKILL.md` §4 (R3a) and a cross-ref in `octave-literacy/SKILL.md` §2. Closes the primer-vs-skill gap so agents loading skills-only see the same positive value-form example primers carry.
+
 ## [1.13.0] - 2026-05-27 - "Strategy A Span-Aware Preserve" (ADR-0006 SR2)
 
 This release lands the Strategy A span-aware preserve-mode engine (#418), the META audit-marker admission policy (#419, GH#384), and the Shape B `format_style` deprecation rollout (PR-4 / addendum §5). The default `format_style` does **not** flip in this release — see "Deprecated" below for the v1.14.0 plan.

--- a/src/octave_mcp/resources/skills/octave-compression/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-compression/SKILL.md
@@ -128,6 +128,7 @@ META:
   R1::"Preserve CAUSALITY — X→Y because Z. Never flatten to X→Y alone."
   R2::"Preserve CONDITIONAL QUALIFIERS — when X, if Y, unless Z carry material risk info"
   R3::"Preserve EXPLICIT TRADEOFFS — GAIN⇌LOSS or GAIN vs LOSS"
+  R3a::TELEGRAPHIC_PHRASE::"quoted value, stopwords dropped, operators carry English connectives — e.g. 'security ⇌ usability' not 'security at odds with usability'"
   R4::"One concrete example per major abstraction — minimum reconstruction anchor"
   R5::"Use mythology as KEY PREFIXES (CHRONOS::audit_6wk) not embedded values — domain labels are reconstruction anchors"
   R6::"Use mythology as PATTERN DESCRIPTORS (SISYPHEAN,ODYSSEAN) for single-token trajectory encoding"

--- a/src/octave_mcp/resources/skills/octave-literacy/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-literacy/SKILL.md
@@ -74,6 +74,7 @@ META:
   LINE_COMMENT::"// — line start or after value"
   ASCII_RULE::"All operators accept both unicode and ASCII. Always emit unicode."
   VS_RULE::"vs requires word boundaries: 'A vs B' valid, 'AvsB' invalid"
+  TELEGRAPHIC_PHRASE::"see octave-compression §4::R3a — operators carry the English connectives inside quoted values"
 §3::CRITICAL_RULES
   R1::"No spaces around :: (KEY::value not KEY :: value)"
   R2::"Indent exactly 2 spaces per level — NO TABS"


### PR DESCRIPTION
## Summary
- Document the TELEGRAPHIC_PHRASE skill name across octave-compression and octave-literacy modules for consistency
- Follow-up to #453 ensuring all relevant skill documentation is properly named and discoverable
- Update CHANGELOG to reflect documentation improvements

## Changes
- **octave-compression/SKILL.md**: Added TELEGRAPHIC_PHRASE skill name reference
- **octave-literacy/SKILL.md**: Added TELEGRAPHIC_PHRASE skill name reference
- **CHANGELOG.md**: Documented this documentation update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented the `TELEGRAPHIC_PHRASE` skill in `octave-compression` and `octave-literacy`, with a cross-ref, so skills-only agents get the same example the primer provides. Updated `CHANGELOG.md`; follow-up to #453.

<sup>Written for commit 5ddc4aa7aaf0ff6c02b96d9066d04bc05dd7767f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/470?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

