### PR TITLE
chore(release): v1.13.1 — write.py STRATEGY_S1 refactor (god-object decomposition, no behaviour change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-05-28 - "write.py STRATEGY_S1 refactor (god-object decomposition)"
+
+### Changed
+- **STRATEGY_S1 incremental refactor of `src/octave_mcp/mcp/write.py` god object (#459).** The 4887-LOC mutation entrypoint module is decomposed into five cohesive peer modules with **zero behaviour change** and **byte-identical output** on all 3614 baseline tests preserved throughout the four-PR sequence:
+  - **CLUSTER_A** (#463, PR #467) — `write_detection.py` (946 LOC): pure-text detection helpers and W-code warning emitters (`_detect_annotation_too_long`, `_detect_snake_case_blob`, literal-zone/holographic span scanners, lenient repair).
+  - **CLUSTER_B** (#464, PR #469) — `write_metrics.py` (55 LOC): AST `StructuralMetrics` dataclass + `extract_structural_metrics`.
+  - **CLUSTER_D** (#465, PR #471) — `write_format.py` (537 LOC): format-style pipeline (`_emit_with_style`, `_compact_pass`, `_expand_pass`, NFC byte threading, baseline span dispatch) — the Strategy A preserve-mode home.
+  - **CLUSTER_C** (#466, PR #473) — `write_mutation.py` (240 LOC): op-dispatch + AST mutation primitives (`_normalize_value_for_ast`, `_mark_dirty`, `$op` envelope, dirty-flag bookkeeping) — the v1.14.0 hybrid-fix home.
+- After the sequence, `write.py` is **3197 LOC** (down 1690, or 35%). WriteTool external API unchanged. Test counts unchanged (3614 passing, 11 skipped, 3 xfailed). Root architectural pattern `ABSENT_DOMAIN_MUTATION_LAYER` identified in the diagnostic remains; STRATEGY_S3 DocumentMutator extraction deferred to v1.15.0+ pending v1.14.0 evidence (#460).
+
 ### Added
 - **Skills now name `TELEGRAPHIC_PHRASE` (follow-up to #453).** Added the atom + canonical contrast example to `octave-compression/SKILL.md` §4 (R3a) and a cross-ref in `octave-literacy/SKILL.md` §2. Closes the primer-vs-skill gap so agents loading skills-only see the same positive value-form example primers carry.
 
@@ -1016,7 +1026,8 @@ the architectural separation of the OCTAVE language specification from implement
 - Non-reasoning document processing
 - Deterministic, idempotent transformations
 
-[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.13.0...HEAD
+[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.13.1...HEAD
+[1.13.1]: https://github.com/elevanaltd/octave-mcp/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.11.0...v1.12.0
 [1.11.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.10.0...v1.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "1.13.0"
+version = "1.13.1"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v1.13.1 release-prep PR. Packages the STRATEGY_S1 incremental refactor of `src/octave_mcp/mcp/write.py` (parent #459), already merged via four atomic child PRs:

- **#467** (CLUSTER_A, #463) — extract `write_detection.py` (946 LOC): pure-text detection helpers + W-code warning emitters.
- **#469** (CLUSTER_B, #464) — extract `write_metrics.py` (55 LOC): AST `StructuralMetrics` dataclass + `extract_structural_metrics`.
- **#471** (CLUSTER_D, #465) — extract `write_format.py` (537 LOC): format-style pipeline — Strategy A preserve-mode home.
- **#473** (CLUSTER_C, #466) — extract `write_mutation.py` (240 LOC): op-dispatch + AST mutation primitives — v1.14.0 hybrid-fix home.

**LOC delta:** `write.py` 4887 → **3197** (down 1690, or 35%). WriteTool external API unchanged. **Zero behaviour change**: the 3614-test pytest baseline is preserved byte-identically throughout the four-PR sequence.

This PR's diff itself is small: version bump in `pyproject.toml`, `uv.lock` re-sync, and a single dated `[1.13.1]` `### Changed` block in `CHANGELOG.md` with updated reference links (Keep-a-Changelog hygiene per PR #458 precedent).

Files changed:
- `pyproject.toml` — `version = "1.13.0"` → `"1.13.1"`
- `uv.lock` — `octave-mcp` package pin re-synced to `1.13.1`
- `CHANGELOG.md` — new `[1.13.1] - 2026-05-28` section + ref-link block update

## Out of scope

- **Tagging** — operator does this post-merge.
- **`publish.yml`** — not triggered by this PR.
- **#460 (v1.14.0 hybrid-fix)** — separate release after v1.13.1 ships.
- Root architectural pattern `ABSENT_DOMAIN_MUTATION_LAYER` remains; STRATEGY_S3 DocumentMutator extraction deferred to v1.15.0+ pending v1.14.0 evidence.

## Test plan

- [x] `pyproject.toml` bumped to `1.13.1`
- [x] `uv.lock` re-synced via `uv sync --all-extras`
- [x] `.venv/bin/python -c "from octave_mcp import __version__; print(__version__)"` → `1.13.1`
- [x] `.venv/bin/python -m pytest -q` → **3614 passed, 11 skipped, 3 xfailed** (matches expected baseline byte-identically; no regressions)
- [x] `.venv/bin/python -m ruff check src tests` → All checks passed
- [x] `.venv/bin/python -m black --check src tests` → 216 files would be left unchanged
- [x] `.venv/bin/python -m mypy src` → Success: no issues found in 57 source files
- [x] CHANGELOG ref-link sanity grep returns 3 lines in descending order: `[Unreleased]` → `[1.13.1]` → `[1.13.0]`
- [ ] CI green
- [ ] Review gate approval (T2 expected per #458 precedent: GOVERNANCE+ROUTINE_CODE facets)

## Review tier

**T2** per `/review`. Diff is small (version bump + CHANGELOG only) — the actual code changes already shipped via the four merged child PRs (#467, #469, #471, #473), each independently reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.13.1, bundling the STRATEGY_S1 refactor of `src/octave_mcp/mcp/write.py` (god-object decomposition) with no behavior changes. This PR bumps the version and updates the changelog; the refactor shipped in earlier PRs.

- **Refactors**
  - Decomposed `write.py` into `write_detection.py`, `write_metrics.py`, `write_format.py`, and `write_mutation.py`.
  - LOC: 4887 → 3197 (-35%); API unchanged; tests unchanged (3614 pass, 11 skipped, 3 xfailed).

- **Dependencies**
  - `pyproject.toml` version set to `1.13.1`.
  - `uv.lock` re-synced for `octave-mcp` `1.13.1`.
  - `CHANGELOG.md` adds `[1.13.1]` and updates reference links.

<sup>Written for commit c397def4a0d8fe4b046a9d300a5f6f38e835a05c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/474?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

