### PR TITLE
docs: fix stale write.py path references post-STRATEGY_S1

### DIFF
--- a/src/octave_mcp/core/holographic.py
+++ b/src/octave_mcp/core/holographic.py
@@ -190,7 +190,7 @@ def _quote_is_unescaped(content: str, quote_index: int) -> bool:
     immediately preceding it has ODD length. An even-length run
     (including zero) means the backslashes pair up as escaped backslashes
     and the quote itself stands unescaped. This matches the GH#361r2
-    convention already used by ``mcp/write.py::_all_section_marks_quoted``
+    convention already used by ``mcp/write_detection.py::_all_section_marks_quoted``
     and is the parity contract pinned by GH-432.
 
     A naive single-character lookback (``content[i - 1] != "\\"``)

--- a/tests/unit/test_holographic_quote_parity.py
+++ b/tests/unit/test_holographic_quote_parity.py
@@ -15,7 +15,7 @@ covered:
   unconditionally and only outside top-level brackets.
 
 The contract (matching GH#361r2 already enforced in
-``mcp/write.py::_all_section_marks_quoted``): a ``"`` is unescaped when
+``mcp/write_detection.py::_all_section_marks_quoted``): a ``"`` is unescaped when
 the run of immediately-preceding backslashes is of even length
 (including zero). It is escaped when the run is of odd length.
 


### PR DESCRIPTION
## Summary

Two docstring/comment references pointed at \`mcp/write.py::_all_section_marks_quoted\`, but that function moved to \`mcp/write_detection.py\` during the CLUSTER_A extraction landed in PR #467 (parent #463/#459).

This is the small loose end I flagged at the end of the v1.13.1 release: the prior IL extraction correctly left these as-is per the DO-NOT-touch-out-of-scope rule for the refactor PRs. Sweeping them now post-release.

## Changes (2 files, +2/−2)

- \`src/octave_mcp/core/holographic.py:193\` — docstring reference path updated
- \`tests/unit/test_holographic_quote_parity.py:18\` — docstring reference path updated

Conceptually the references were still accurate; only the module path drifted.

## Test plan

- [x] \`pytest -q\` — **3614 passed, 11 skipped, 3 xfailed**
- [x] \`ruff check src tests\` — clean
- [x] \`black --check src tests\` — clean
- [x] \`mypy src\` — clean (no issues, 57 source files)

Zero behaviour change. Pure docs/comment edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update two docstring/comment references from `mcp/write.py::_all_section_marks_quoted` to `mcp/write_detection.py::_all_section_marks_quoted` after the module move. No behavior change.

<sup>Written for commit 2608326193d01b112210bbb7a849ee67bcb351d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/477?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

