### PR TITLE
chore(#462): ensure dev tooling (ruff/black/coverage) installs via canonical sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Worktree `.venv` reliably gets the dev toolchain after sync (#462).** Added a PEP-735 `[dependency-groups]` `dev` group to `pyproject.toml` mirroring the existing `[project.optional-dependencies]` `dev` extra. `uv sync` installs the `dev` dependency-group **by default** (no flag required), so `.venv/bin/ruff`, `.venv/bin/black`, `.venv/bin/coverage`, `.venv/bin/mypy`, and the coverage HTML toolchain (`coverage/htmlfiles/`) land in the venv even if a sync invocation omits `--all-extras` — the root of the reported symptom where a worktree `.venv` held only runtime + `http`-extra packages and quality gates fell back to system `ruff`/`black`. The `dev` extra is retained for the `pip install -e ".[dev]"` fallback path, and `uv sync --all-extras` continues to work unchanged. `uv.lock` regenerated to resolve the new group. Empirically verified: a bare `uv sync` into a clean venv now installs all 13 dev packages, and `pytest --cov-report=html` generates `htmlcov/` with no INTERNALERROR. Developer docs (`docs/guides/development-setup.md`, `CONTRIBUTING.md`) updated with the canonical sync command and a verify/repair recipe.
+
+### Changed
+- **Canonical dev-setup command documented as `uv sync --all-extras` (#462).** `CONTRIBUTING.md` and `docs/guides/development-setup.md` now present `uv sync --all-extras` (rather than `uv pip install -e ".[dev]"`) as the canonical install step, and direct quality-gate invocation through `.venv/bin/...` so the project venv is exercised rather than system-installed `ruff`/`black`.
+
 ## [1.13.1] - 2026-05-28 - "write.py STRATEGY_S1 refactor (god-object decomposition)"
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,14 @@ Thank you for your interest in contributing!
 git clone https://github.com/elevanaltd/octave-mcp.git
 cd octave-mcp
 uv venv && source .venv/bin/activate
-uv pip install -e ".[dev]"
+uv sync --all-extras   # installs runtime deps + http extra + dev dependency-group
 ```
 
-See [docs/guides/development-setup.md](docs/guides/development-setup.md) for detailed setup instructions.
+`uv sync` installs the `dev` dependency-group by default, so the toolchain
+(`ruff`, `black`, `pytest-cov`, `mypy`, coverage HTML) is always present in
+`.venv/bin`. Run quality gates via `.venv/bin/...` rather than system binaries.
+
+See [docs/guides/development-setup.md](docs/guides/development-setup.md) for detailed setup instructions (including how to verify/repair a `.venv` missing dev tooling — issue #462).
 
 ## Testing
 

--- a/docs/guides/development-setup.md
+++ b/docs/guides/development-setup.md
@@ -26,6 +26,20 @@ which python      # Should point to .venv/bin/python
 
 ### 2. Install Package in Development Mode
 
+The **canonical** command (installs runtime deps, all extras, and the dev
+dependency-group in one step) is:
+
+```bash
+uv sync --all-extras
+```
+
+`uv sync` installs the `[dependency-groups]` `dev` group **by default** (no flag
+needed); `--all-extras` additionally pulls the `http` extra. Either way the dev
+toolchain (`ruff`, `black`, `pytest-cov`, `mypy`, coverage HTML files) lands in
+`.venv/bin`.
+
+If you are not using `uv`, the pip equivalent is:
+
 ```bash
 pip install -e ".[dev]"
 ```
@@ -33,6 +47,26 @@ pip install -e ".[dev]"
 This installs:
 - **Core**: `mcp>=1.0.0`, `click>=8.0.0`, `pydantic>=2.0.0`
 - **Development**: `pytest`, `pytest-cov`, `mypy`, `ruff`, `black`, `hypothesis`
+
+#### Verifying / repairing the dev toolchain (issue #462)
+
+A worktree `.venv` can end up with runtime dependencies but **without** the dev
+tooling if a sync was interrupted or run without dev deps (the symptom in
+[#462](https://github.com/elevanaltd/octave-mcp/issues/462): missing
+`.venv/bin/ruff`, `.venv/bin/black`, and the coverage HTML toolchain). Verify
+and repair in place:
+
+```bash
+# Verify the dev toolchain is present in THIS venv (not the system one)
+ls .venv/bin/ruff .venv/bin/black .venv/bin/coverage
+
+# Repair: re-run the canonical sync (idempotent, safe to repeat)
+uv sync --all-extras
+```
+
+Always invoke quality gates through `.venv/bin/...` (e.g.
+`.venv/bin/python -m pytest`, `.venv/bin/ruff check src`) so you exercise the
+project venv rather than a system-installed `ruff`/`black`.
 
 ### 3. Verify Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,31 @@ dev = [
     "virtualenv>=20.36.2",  # CVE-2025-68147: TOCTOU vulnerabilities
 ]
 
+# PEP-735 dependency group mirroring the `dev` extra above.
+# Rationale (#462): uv installs the `dev` dependency-group by DEFAULT on a bare
+# `uv sync` (no flags required), whereas `[project.optional-dependencies].dev`
+# is an EXTRA that only installs under `uv sync --all-extras` / `--extra dev` /
+# `pip install -e ".[dev]"`. Declaring the group as well makes the worktree
+# `.venv` robust to a sync invocation that omits `--all-extras`, so dev tooling
+# (ruff/black/pytest-cov/mypy + coverage HTML toolchain) reliably lands in
+# `.venv/bin`. The extra is retained for the pip-fallback install path.
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "pytest-cov>=6.0.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-timeout>=2.3.0",
+    "mypy>=1.14.0",
+    "types-PyYAML>=6.0.12",
+    "ruff>=0.9.0",
+    "black>=26.0.0",
+    "hypothesis>=6.122.0",
+    "pre-commit>=4.1.0",
+    "httpx>=0.28.0",  # For testing HTTP transport
+    "Pygments>=2.20.0",  # CVE-2025-61833: ReDoS vulnerability
+    "virtualenv>=20.36.2",  # CVE-2025-68147: TOCTOU vulnerabilities
+]
+
 [project.scripts]
 octave = "octave_mcp.cli.main:cli"
 octave-mcp-server = "octave_mcp.mcp.server:run"

--- a/uv.lock
+++ b/uv.lock
@@ -644,6 +644,23 @@ http = [
     { name = "uvicorn" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "httpx" },
+    { name = "hypothesis" },
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pygments" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
+    { name = "virtualenv" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=26.0.0" },
@@ -674,6 +691,23 @@ requires-dist = [
     { name = "virtualenv", marker = "extra == 'dev'", specifier = ">=20.36.2" },
 ]
 provides-extras = ["http", "dev"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=26.0.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "hypothesis", specifier = ">=6.122.0" },
+    { name = "mypy", specifier = ">=1.14.0" },
+    { name = "pre-commit", specifier = ">=4.1.0" },
+    { name = "pygments", specifier = ">=2.20.0" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.0" },
+    { name = "ruff", specifier = ">=0.9.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12" },
+    { name = "virtualenv", specifier = ">=20.36.2" },
+]
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
Closes #462.

## Root cause (one-liner)

`pyproject.toml` and `uv.lock` were already correct — `uv sync --all-extras` *does* install ruff/black/pytest-cov/coverage. The #462 symptom is a **partial/transient sync left undetected**: the out-of-repo SessionStart hook swallows sync errors (`uv sync --all-extras --quiet 2>/dev/null`) and sets `VENV_HEALTHY=true` from a compound-`if`, so a `.venv` that received only runtime + `http`-extra packages is treated as fully synced.

## Investigation (reproduced, not guessed)

- **Confirmed dev-deps wiring was unchanged** between PR #458 (where #462 was observed, commit `f54dea4`, 2026-05-27) and current `origin/main` — only the version bumped in the v1.13.1 release commit. So the declaration the IL hit is the same one in `main` today.
- **Reproduced the bug in the wild.** Surveying live worktree `.venv`s, `worktrees/issues-452-453/.venv` (created May 27, the #462 window) was missing `ruff`/`black`/`pytest`/`coverage` while still holding runtime + `http`-extra packages (`mcp`, `httpx`, `uvicorn`, editable `octave_mcp`). Other worktrees were healthy.
- **Confirmed the command itself is correct.** Running the *exact* hook command `uv sync --all-extras` in that broken worktree immediately installed ruff/black/pytest/coverage/mypy. A single canonical re-sync repairs it — proving the gap is the swallowed-error sync path, not the wiring.

## Fix (repo-scoped, defense-in-depth)

Added a **PEP-735 `[dependency-groups]` `dev` group** to `pyproject.toml` mirroring the existing `[project.optional-dependencies]` `dev` extra. uv installs the `dev` dependency-group **by default** on *any* `uv sync` (no flag required), whereas the extra only installs under `--all-extras` / `--extra dev` / `pip install -e ".[dev]"`. This makes the worktree `.venv` robust to a sync invocation that omits `--all-extras`.

- The `dev` **extra is retained** for the hook's `pip install -e ".[dev]"` fallback path, and `uv sync --all-extras` continues to work unchanged (different installer contracts — deliberate, justified duplication, not bloat).
- `uv.lock` regenerated to resolve the new group (`[package.dev-dependencies]`).
- `CONTRIBUTING.md` + `docs/guides/development-setup.md` now document `uv sync --all-extras` as the canonical command and add a **verify/repair recipe** (the repo equivalent of the issue's "CLAUDE.md SessionStart guidance" — the global `CLAUDE.md` is operator-owned and out-of-repo).
- `CHANGELOG.md` `[Unreleased]` updated (`### Fixed` + `### Changed`). The `[Unreleased]` compare-link (`v1.13.1...HEAD`) was already correct.

## Before / after reproduction (I4 receipt)

**BEFORE** (broken `worktrees/issues-452-453/.venv`, created in the #462 window):
```
ruff: MISSING | black: MISSING | coverage: MISSING | pytest: MISSING
.venv/bin only had: octave, octave-mcp-server, httpx, uvicorn, mcp, dotenv, python
```

**AFTER** the fix — bare `uv sync` (no `--all-extras`) into a clean venv:
```
packages installed: 59
ruff: PRESENT | black: PRESENT | pytest: PRESENT | coverage: PRESENT | mypy: PRESENT
coverage htmlfiles: .venv/lib/python3.14/site-packages/coverage/htmlfiles  PRESENT
```

**AFTER** — exact current hook command `uv sync --all-extras` (compatibility preserved):
```
packages installed: 59
ruff: PRESENT | black: PRESENT | uvicorn (http extra): PRESENT
```

**Coverage HTML INTERNALERROR** (issue symptom) — now generates cleanly:
```
$ .venv/bin/python -m pytest tests/unit --cov=octave_mcp --cov-report=html
Coverage HTML written to dir htmlcov   (no INTERNALERROR)
3087 passed, 19 skipped, 3 xfailed
```

## Quality gates (run via `.venv/bin` tooling, proving the fix)

- `ruff check src tests` → All checks passed
- `black --check src tests` → 216 files unchanged
- `mypy src` → Success: no issues found in 57 source files
- Full suite → **3437 passed, 21 skipped, 3 xfailed**
- pre-commit ran on commit (no `--no-verify`)

## Out-of-repo recommendation (operator action — NOT in this PR)

The global SessionStart hook `~/.claude/hooks/session_start/setup-dependencies.sh` masks sync failures. Recommended operator-side hardening (cannot be PR'd from this repo):

1. Stop discarding sync errors: change `uv sync --all-extras --quiet 2>/dev/null` (line ~584) and the venv-creation compound-`if` (line ~532) so a non-zero exit does **not** record `VENV_HEALTHY=true` / `✓ Dependencies synced`.
2. Post-sync verification: assert `.venv/bin/ruff`, `.venv/bin/black`, `.venv/bin/python -m coverage` exist and emit a warning (not silent success) if absent.

With this PR's `[dependency-groups]` change, even the existing hook becomes more robust (the `dev` group installs by default), but fixing the swallowed-error path remains the durable hook-side improvement.

## Scope

Strictly #462. No changes to `write.py` / `write_*.py` / v1.14.0 (#460) territory. Files touched: `pyproject.toml`, `uv.lock`, `CONTRIBUTING.md`, `docs/guides/development-setup.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make dev tooling install reliably on every `uv sync` by adding a `dev` dependency group, so `.venv` always gets `ruff`, `black`, `pytest-cov`/`coverage`, and `mypy`. Fixes the partial `.venv` installs behind #462 and stabilizes coverage HTML and quality gates.

- **Bug Fixes**
  - Added `[dependency-groups].dev` in `pyproject.toml` mirroring the `dev` extra, so `uv sync` installs the dev toolchain by default; retains the `dev` extra for `pip install -e ".[dev]"`.
  - Regenerated `uv.lock` to include the new group; `uv sync --all-extras` continues to work.
  - Updated `CONTRIBUTING.md` and `docs/guides/development-setup.md` to use `uv sync --all-extras` as the canonical command and added a quick verify/repair checklist.

<sup>Written for commit 8f77bbe629aab1018fa8d0774a7d0955db9a2980. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/478?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

