### PR TITLE
fix: resolve MCP structure advisory findings from TMG/CRS/CE review

### DIFF
--- a/src/octave_mcp/mcp/validate.py
+++ b/src/octave_mcp/mcp/validate.py
@@ -26,7 +26,11 @@ from octave_mcp.core.schema_extractor import SchemaDefinition
 from octave_mcp.core.validator import ValidationError, Validator, _count_literal_zones
 from octave_mcp.mcp.base_tool import BaseTool, SchemaBuilder
 from octave_mcp.mcp.compile_grammar import USAGE_HINTS
-from octave_mcp.mcp.write_detection import _detect_snake_case_blob
+from octave_mcp.mcp.write_detection import (
+    _detect_flat_prefix_scalar,
+    _detect_inline_array_root,
+    _detect_snake_case_blob,
+)
 from octave_mcp.schemas.loader import get_builtin_schema, load_schema_by_name
 
 # Gap_6: Regex pattern to extract spec error codes (E001-E007) from error messages
@@ -849,6 +853,16 @@ class ValidateTool(BaseTool):
             # callers see the discipline guidance (I4/I5).
             snake_case_blob_warnings = _detect_snake_case_blob(content)
             result["warnings"].extend(snake_case_blob_warnings)
+
+            # Structural advisory: map-as-inline-array root pattern.
+            # Advisory only — surfaces in warnings[], non-blocking (I4/I5).
+            inline_array_root_warnings = _detect_inline_array_root(content)
+            result["warnings"].extend(inline_array_root_warnings)
+
+            # Structural advisory: flat sibling keys sharing a redundant prefix.
+            # Advisory only — surfaces in warnings[], non-blocking (I4/I5).
+            flat_prefix_warnings = _detect_flat_prefix_scalar(content)
+            result["warnings"].extend(flat_prefix_warnings)
 
         except Exception as e:
             result["status"] = "error"

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1148,15 +1148,19 @@ class WriteTool(BaseTool):
                 errors.append(err)
                 continue
             op_descriptors[key] = (op, payload)
-            # GH#484: Reject MERGE payloads that contain plain nested dict values.
-            # _normalize_value_for_ast wraps any dict as InlineMap unconditionally,
-            # so nested dicts would emit as inline maps (KEY::[K::V]) which fail
-            # strict re-parse with E_NESTED_INLINE_MAP. Strategy S3 (DocumentMutator)
-            # is deferred; the minimum correct fix is rejection at validation time.
+            # GH#484: Reject MERGE payloads that contain non-DELETE-sentinel dict
+            # values. The MERGE handler in _apply_changes only recognises
+            # _is_delete_sentinel as a special sub-operation; every other dict is
+            # passed to _normalize_value_for_ast which wraps it as InlineMap. A
+            # plain nested dict produces nested InlineMap → E_NESTED_INLINE_MAP on
+            # emit. A non-DELETE op-descriptor dict (e.g. $op:APPEND) produces a
+            # flat InlineMap (valid OCTAVE) but with wrong semantics — the caller
+            # almost certainly intended a sub-operation, not a literal map value.
+            # Reject both cases so failures are loud, not silent.
             # I3 (Mirror Constraint): do not silently corrupt the document.
             if op == "MERGE" and isinstance(payload, dict):
                 nested_dict_keys = [
-                    mk for mk, mv in payload.items() if isinstance(mv, dict) and not _is_op_descriptor(mv)
+                    mk for mk, mv in payload.items() if isinstance(mv, dict) and not _is_delete_sentinel(mv)
                 ]
                 if nested_dict_keys:
                     errors.append(

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1156,17 +1156,15 @@ class WriteTool(BaseTool):
             # I3 (Mirror Constraint): do not silently corrupt the document.
             if op == "MERGE" and isinstance(payload, dict):
                 nested_dict_keys = [
-                    mk
-                    for mk, mv in payload.items()
-                    if isinstance(mv, dict) and not _is_op_descriptor(mv) and not _is_delete_sentinel(mv)
+                    mk for mk, mv in payload.items() if isinstance(mv, dict) and not _is_op_descriptor(mv)
                 ]
                 if nested_dict_keys:
                     errors.append(
                         {
-                            "code": "E_NESTED_DICT_IN_CHANGES_MODE",
+                            "code": "E_NESTED_DICT_IN_MERGE_PAYLOAD",
                             "message": (
-                                f"'{key}': nested map values must be written via content_mode + "
-                                f"format_style=preserve (block form). changes-mode dict-merge cannot "
+                                f"'{key}': nested map values must be written via the content parameter "
+                                f"with format_style=preserve (block form). changes-mode MERGE cannot "
                                 f"emit block nesting. Nested dict keys: {nested_dict_keys}."
                             ),
                         }

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1148,6 +1148,30 @@ class WriteTool(BaseTool):
                 errors.append(err)
                 continue
             op_descriptors[key] = (op, payload)
+            # GH#484: Reject MERGE payloads that contain plain nested dict values.
+            # _normalize_value_for_ast wraps any dict as InlineMap unconditionally,
+            # so nested dicts would emit as inline maps (KEY::[K::V]) which fail
+            # strict re-parse with E_NESTED_INLINE_MAP. Strategy S3 (DocumentMutator)
+            # is deferred; the minimum correct fix is rejection at validation time.
+            # I3 (Mirror Constraint): do not silently corrupt the document.
+            if op == "MERGE" and isinstance(payload, dict):
+                nested_dict_keys = [
+                    mk
+                    for mk, mv in payload.items()
+                    if isinstance(mv, dict) and not _is_op_descriptor(mv) and not _is_delete_sentinel(mv)
+                ]
+                if nested_dict_keys:
+                    errors.append(
+                        {
+                            "code": "E_NESTED_DICT_IN_CHANGES_MODE",
+                            "message": (
+                                f"'{key}': nested map values must be written via content_mode + "
+                                f"format_style=preserve (block form). changes-mode dict-merge cannot "
+                                f"emit block nesting. Nested dict keys: {nested_dict_keys}."
+                            ),
+                        }
+                    )
+                    continue
 
         for key in changes:
             # Skip keys that already failed descriptor validation; their target

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -44,6 +44,8 @@ from octave_mcp.mcp.compile_grammar import USAGE_HINTS
 from octave_mcp.mcp.write_detection import (
     _auto_quote_section_refs_in_values,
     _detect_annotation_too_long,
+    _detect_flat_prefix_scalar,
+    _detect_inline_array_root,
     _detect_snake_case_blob,
     _detect_unquoted_section_in_values,
 )
@@ -2837,6 +2839,16 @@ class WriteTool(BaseTool):
             # Refined contract per operator comment 4549996376. v1 ADVISORY only.
             snake_case_blob_warnings = _detect_snake_case_blob(parse_input)
             corrections.extend(snake_case_blob_warnings)
+
+            # Structural advisory: map-as-inline-array root pattern.
+            # Advisory only — non-blocking, routed to corrections.
+            inline_array_root_warnings = _detect_inline_array_root(parse_input)
+            corrections.extend(inline_array_root_warnings)
+
+            # Structural advisory: flat sibling keys sharing a redundant prefix.
+            # Advisory only — non-blocking, routed to corrections.
+            flat_prefix_warnings = _detect_flat_prefix_scalar(parse_input)
+            corrections.extend(flat_prefix_warnings)
 
             # Apply META mutations (if any)
             self._apply_mutations(doc, mutations)

--- a/src/octave_mcp/mcp/write_detection.py
+++ b/src/octave_mcp/mcp/write_detection.py
@@ -944,3 +944,348 @@ def _detect_snake_case_blob(content: str) -> list[dict[str, Any]]:
         i += 1
 
     return warnings
+
+
+# ---------------------------------------------------------------------------
+# GH-structural-advisory: W_INLINE_ARRAY_ROOT
+# ---------------------------------------------------------------------------
+
+# Advisory code for map-as-inline-array structural pattern.
+W_INLINE_ARRAY_ROOT = "W_INLINE_ARRAY_ROOT"
+
+# Threshold: inline array with >= this many K::V elements triggers.
+_W_INLINE_ARRAY_ROOT_ENTRY_THRESHOLD = 3
+
+# Threshold: serialized array length > this triggers regardless of entry count.
+_W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD = 80
+
+# Regex: detects a K::V map-entry element within an inline array — the
+# discriminator between map-as-inline-array and scalar/string lists.
+# A map entry is: optional whitespace, an identifier token, `::`, then a value.
+_W_INLINE_ARRAY_ROOT_ENTRY_RE = re.compile(r"(?:^|,)\s*[A-Za-z_][A-Za-z0-9_]*\s*::")
+
+# Regex: detects an assignment opener with an inline array value on the same
+# line: ``KEY::[...]`` (double-colon form).
+_W_INLINE_ARRAY_ROOT_INLINE_RE = re.compile(r"^[ \t]*[A-Za-z_][A-Za-z0-9_]*\s*::\s*\[")
+
+# Regex: detects a block-opener form ``KEY:[`` (single colon).
+_W_INLINE_ARRAY_ROOT_BLOCK_RE = re.compile(r"^[ \t]*[A-Za-z_][A-Za-z0-9_]*\s*:\s*\[")
+
+
+def _w_inline_array_root_array_is_map(array_content: str) -> bool:
+    """Return True if *array_content* (the text between [ and ]) contains
+    K::V map-entry elements.
+
+    The discriminator: at least one element must contain ``::`` in an
+    identifier-value position (not just a string value).
+    """
+    return bool(_W_INLINE_ARRAY_ROOT_ENTRY_RE.search(array_content))
+
+
+def _w_inline_array_root_entry_count(array_content: str) -> int:
+    """Count the number of top-level comma-separated elements in *array_content*."""
+    # A simple heuristic: count commas at depth 0 plus 1.
+    depth = 0
+    commas = 0
+    in_quote = False
+    for ch in array_content:
+        if ch == '"' and not in_quote:
+            in_quote = True
+        elif ch == '"' and in_quote:
+            in_quote = False
+        elif not in_quote:
+            if ch == "[":
+                depth += 1
+            elif ch == "]":
+                depth -= 1
+            elif ch == "," and depth == 0:
+                commas += 1
+    stripped = array_content.strip()
+    if not stripped:
+        return 0
+    return commas + 1
+
+
+def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
+    """Detect map-as-inline-array structural pattern (W_INLINE_ARRAY_ROOT).
+
+    Fires when a key's value is an inline array ``[...]`` whose elements are
+    themselves K::V map-entries (map-as-inline-array), AND EITHER:
+      * entry count >= 3, OR
+      * serialized length > ``_W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD``
+
+    Does NOT fire on:
+      * Legitimate scalar/string lists: IMMUTABLES::[a, b, c]
+      * Content inside fenced literal zones (Zone 3)
+      * Content inside // comments
+
+    Discriminator: elements contain ``::`` map syntax.
+
+    Severity: ADVISORY only (non-blocking, surfaced in warnings/corrections).
+
+    Args:
+        content: Raw OCTAVE document content string.
+
+    Returns:
+        List of warning dicts with code ``W_INLINE_ARRAY_ROOT``.
+    """
+    warnings_out: list[dict[str, Any]] = []
+
+    literal_zone_lines = _build_literal_zone_line_set(content)
+    lines = content.split("\n")
+
+    # Build cumulative offsets for line-based tracking.
+    line_offsets: list[int] = [0]
+    for ln in lines:
+        line_offsets.append(line_offsets[-1] + len(ln) + 1)
+
+    i = 0
+    while i < len(lines):
+        raw_line = lines[i]
+        line_num = i + 1
+
+        # Skip literal zone lines.
+        if line_num in literal_zone_lines:
+            i += 1
+            continue
+
+        # Skip comment lines.
+        stripped = raw_line.lstrip()
+        if stripped.startswith("//"):
+            i += 1
+            continue
+
+        # --- Case 1: inline form ``KEY::[...]`` on a single line ---
+        m = _W_INLINE_ARRAY_ROOT_INLINE_RE.match(raw_line)
+        # --- Case 2: block-open form ``KEY:[`` possibly spanning lines ---
+        bm = _W_INLINE_ARRAY_ROOT_BLOCK_RE.match(raw_line) if not m else None
+
+        opener_match = m or bm
+        if not opener_match:
+            i += 1
+            continue
+
+        # Locate the opening ``[`` position in the line.
+        bracket_pos = raw_line.index("[", opener_match.start())
+        # Collect the full array content by walking forward until balanced.
+        full_array = ""
+        depth = 0
+        found_close = False
+        scan_line_idx = i
+        while scan_line_idx < len(lines):
+            scan_line = lines[scan_line_idx]
+            # Skip literal zone inside multi-line array collection.
+            if scan_line_idx + 1 in literal_zone_lines and scan_line_idx != i:
+                scan_line_idx += 1
+                continue
+            start_col = bracket_pos if scan_line_idx == i else 0
+            for _col, ch in enumerate(scan_line[start_col:], start=start_col):
+                if ch == "[":
+                    depth += 1
+                    if depth == 1:
+                        continue  # skip the opening bracket itself
+                elif ch == "]":
+                    depth -= 1
+                    if depth == 0:
+                        found_close = True
+                        break
+                if depth > 0:
+                    full_array += ch
+            if found_close:
+                break
+            if depth > 0 and scan_line_idx < len(lines) - 1:
+                full_array += "\n"
+            scan_line_idx += 1
+
+        if not found_close:
+            i += 1
+            continue
+
+        # Discriminate: does the array content contain K::V map entries?
+        if not _w_inline_array_root_array_is_map(full_array):
+            i += 1
+            continue
+
+        entry_count = _w_inline_array_root_entry_count(full_array)
+        array_length = len(full_array)
+
+        if entry_count >= _W_INLINE_ARRAY_ROOT_ENTRY_THRESHOLD or array_length > _W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD:
+            # Extract the key name from the line.
+            key_match = re.match(r"^[ \t]*([A-Za-z_][A-Za-z0-9_]*)", raw_line)
+            key_name = key_match.group(1) if key_match else "<unknown>"
+            warnings_out.append(
+                {
+                    "code": W_INLINE_ARRAY_ROOT,
+                    "tier": "STRUCTURAL_CHECK",
+                    "discipline": "STRUCTURAL_ADVISORY",
+                    "message": (
+                        f"W_INLINE_ARRAY_ROOT at line {line_num}: key '{key_name}' "
+                        f"has {entry_count} map-entry elements authored as an "
+                        f"inline-array root; prefer BLOCK form (KEY: + indented "
+                        f"children). Inline arrays are for scalar lists, not "
+                        f"maps-of-maps."
+                    ),
+                    "line": line_num,
+                    "key": key_name,
+                    "entry_count": entry_count,
+                    "safe": True,
+                    "semantics_changed": False,
+                }
+            )
+
+        i += 1
+
+    return warnings_out
+
+
+# ---------------------------------------------------------------------------
+# GH-structural-advisory: W_FLAT_PREFIX_SCALAR
+# ---------------------------------------------------------------------------
+
+# Advisory code for flat sibling keys that share a redundant prefix.
+W_FLAT_PREFIX_SCALAR = "W_FLAT_PREFIX_SCALAR"
+
+# Minimum number of sibling keys sharing a prefix to trigger the warning.
+_W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD = 3
+
+# Regex matching a top-level (zero-indent or consistent-indent) KEY assignment.
+# Captures the full key name. We restrict to uppercase/underscore keys as those
+# are the primary OCTAVE structural pattern subject to flat-prefix sprawl.
+_W_FLAT_PREFIX_SCALAR_KEY_RE = re.compile(r"^([ \t]*)([A-Z][A-Z0-9_]+)\s*:[:s]")
+
+
+def _w_flat_prefix_scalar_all_prefixes(key: str) -> list[str]:
+    """Return all valid underscore-delimited prefix segments for *key*.
+
+    For ``NODE_RUNTIME_FLOOR`` → [``NODE``, ``NODE_RUNTIME``].
+    For ``DB_HOST`` → [``DB``].
+    For ``FOO`` (no underscore) → [] (single-segment keys have no prefix).
+
+    We generate ALL candidate prefixes (not just "all except last") so that
+    siblings like ``NODE_RUNTIME_FLOOR``, ``NODE_RUNTIME_PIN_SITES``,
+    ``NODE_RUNTIME_WHY`` all map to the shared prefix ``NODE_RUNTIME`` even
+    though their "all except last" prefixes differ (``NODE_RUNTIME`` vs
+    ``NODE_RUNTIME_PIN``).
+    """
+    parts = key.split("_")
+    if len(parts) < 2:
+        return []
+    # All prefixes: from the first segment up to (but not including) the last.
+    return ["_".join(parts[:n]) for n in range(1, len(parts))]
+
+
+def _detect_flat_prefix_scalar(content: str) -> list[dict[str, Any]]:
+    """Detect sibling keys that share a redundant underscore prefix (W_FLAT_PREFIX_SCALAR).
+
+    Heuristic:
+      1. Extract all key assignment lines at the same indentation level
+         (excluding literal zones and comment lines).
+      2. For each candidate prefix (all underscore-delimited prefixes of each
+         key), count how many sibling keys share that prefix.
+      3. For groups with >= 3 members at the same indentation level, emit an
+         advisory warning suggesting nesting under a ``{PREFIX}:`` block parent.
+      4. Report the longest qualifying prefix to give the most actionable advice.
+
+    Severity: ADVISORY only (non-blocking).
+
+    Args:
+        content: Raw OCTAVE document content string.
+
+    Returns:
+        List of warning dicts with code ``W_FLAT_PREFIX_SCALAR``.
+    """
+    warnings_out: list[dict[str, Any]] = []
+    literal_zone_lines = _build_literal_zone_line_set(content)
+
+    lines = content.split("\n")
+
+    # Collect (indent_level, key_name, line_num) tuples.
+    entries: list[tuple[str, str, int]] = []
+
+    for line_idx, raw_line in enumerate(lines):
+        line_num = line_idx + 1
+
+        # Skip literal zone lines.
+        if line_num in literal_zone_lines:
+            continue
+
+        # Skip comment lines.
+        stripped = raw_line.lstrip()
+        if stripped.startswith("//"):
+            continue
+
+        m = _W_FLAT_PREFIX_SCALAR_KEY_RE.match(raw_line)
+        if not m:
+            continue
+
+        indent = m.group(1)
+        key_name = m.group(2)
+        entries.append((indent, key_name, line_num))
+
+    if not entries:
+        return warnings_out
+
+    from collections import defaultdict
+
+    # Build a mapping: (indent, prefix) -> list of (key_name, line_num)
+    # A key contributes to every prefix group it belongs to.
+    prefix_groups: dict[tuple[str, str], list[tuple[str, int]]] = defaultdict(list)
+
+    for indent, key_name, line_num in entries:
+        for prefix in _w_flat_prefix_scalar_all_prefixes(key_name):
+            prefix_groups[(indent, prefix)].append((key_name, line_num))
+
+    # Among qualifying groups (size >= threshold), report the LONGEST prefix
+    # for each key set — this gives the most actionable suggestion.
+    # To avoid double-reporting a set of keys under both "DB" and "DB_HOST"
+    # when the intent is to flag "DB", we deduplicate by the key-set fingerprint
+    # and keep only the longest prefix per unique key set.
+    best_prefix_for_keyset: dict[tuple[str, frozenset[str]], str] = {}
+
+    for (indent, prefix), members in prefix_groups.items():
+        if len(members) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
+            continue
+        key_set = frozenset(k for k, _ in members)
+        group_id = (indent, key_set)
+        existing = best_prefix_for_keyset.get(group_id)
+        if existing is None or len(prefix) > len(existing):
+            best_prefix_for_keyset[group_id] = prefix
+
+    # Emit one warning per unique (indent, key_set) using the best (longest) prefix.
+    for (indent, _key_set), best_prefix in best_prefix_for_keyset.items():
+        # Retrieve the members for this (indent, best_prefix) group.
+        members = prefix_groups[(indent, best_prefix)]
+        # De-duplicate member list (a key may appear multiple times if it
+        # contributes to both shorter and longer prefix groups).
+        seen_keys: set[str] = set()
+        unique_members: list[tuple[str, int]] = []
+        for k, ln in members:
+            if k not in seen_keys:
+                seen_keys.add(k)
+                unique_members.append((k, ln))
+
+        if len(unique_members) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
+            continue
+
+        first_line = unique_members[0][1]
+        key_names = [k for k, _ in unique_members]
+        warnings_out.append(
+            {
+                "code": W_FLAT_PREFIX_SCALAR,
+                "tier": "STRUCTURAL_CHECK",
+                "discipline": "STRUCTURAL_ADVISORY",
+                "message": (
+                    f"W_FLAT_PREFIX_SCALAR at line {first_line}: sibling keys "
+                    f"share prefix '{best_prefix}_'; nest under '{best_prefix}:' "
+                    f"block to drop the redundant prefix (key-token saving + "
+                    f"better attention inheritance). Keys: {', '.join(key_names)}"
+                ),
+                "line": first_line,
+                "prefix": best_prefix,
+                "keys": key_names,
+                "safe": True,
+                "semantics_changed": False,
+            }
+        )
+
+    return warnings_out

--- a/src/octave_mcp/mcp/write_detection.py
+++ b/src/octave_mcp/mcp/write_detection.py
@@ -972,38 +972,138 @@ _W_INLINE_ARRAY_ROOT_INLINE_RE = re.compile(r"^[ \t]*[A-Za-z_][A-Za-z0-9_]*\s*::
 _W_INLINE_ARRAY_ROOT_BLOCK_RE = re.compile(r"^[ \t]*[A-Za-z_][A-Za-z0-9_]*\s*:\s*\[")
 
 
-def _w_inline_array_root_array_is_map(array_content: str) -> bool:
-    """Return True if *array_content* (the text between [ and ]) contains
-    K::V map-entry elements.
+def _w_inline_array_root_collect_array(
+    lines: list[str],
+    start_line_idx: int,
+    bracket_col: int,
+    literal_zone_lines: set[int],
+) -> tuple[str, int]:
+    """Collect the full text between the opening ``[`` and its matching ``]``.
 
-    The discriminator: at least one element must contain ``::`` in an
-    identifier-value position (not just a string value).
+    Tracks bracket depth while respecting quoted strings and ``//`` comments so
+    that brackets inside those protected zones are treated as text, not syntax
+    (CRS finding 2: unprotected bracket scan).
+
+    Args:
+        lines: All lines of the document.
+        start_line_idx: Zero-based index of the line containing the opening ``[``.
+        bracket_col: Column index of the opening ``[`` in that line.
+        literal_zone_lines: 1-based line numbers inside literal zones (skipped).
+
+    Returns:
+        Tuple of (array_content_str, last_scan_line_idx).  ``array_content_str``
+        is the raw text between ``[`` and ``]``; ``last_scan_line_idx`` is the
+        zero-based index of the line on which the closing ``]`` was found (or
+        ``start_line_idx`` if not found).
     """
-    return bool(_W_INLINE_ARRAY_ROOT_ENTRY_RE.search(array_content))
-
-
-def _w_inline_array_root_entry_count(array_content: str) -> int:
-    """Count the number of top-level comma-separated elements in *array_content*."""
-    # A simple heuristic: count commas at depth 0 plus 1.
+    chunks: list[str] = []
     depth = 0
-    commas = 0
     in_quote = False
-    for ch in array_content:
-        if ch == '"' and not in_quote:
-            in_quote = True
-        elif ch == '"' and in_quote:
-            in_quote = False
-        elif not in_quote:
+    found_close = False
+    scan_idx = start_line_idx
+
+    while scan_idx < len(lines):
+        scan_line = lines[scan_idx]
+        line_num = scan_idx + 1
+        # Skip literal zone lines mid-array (except the opener line itself,
+        # which was already checked before calling this function).
+        if scan_idx != start_line_idx and line_num in literal_zone_lines:
+            scan_idx += 1
+            continue
+
+        col_start = bracket_col if scan_idx == start_line_idx else 0
+        line_text = scan_line[col_start:]
+        i = 0
+        while i < len(line_text):
+            ch = line_text[i]
+            if in_quote:
+                if ch == '"':
+                    in_quote = False
+                chunks.append(ch)
+                i += 1
+                continue
+            if ch == '"':
+                in_quote = True
+                chunks.append(ch)
+                i += 1
+                continue
+            if ch == "/" and i + 1 < len(line_text) and line_text[i + 1] == "/" and depth <= 1:
+                # OCTAVE line comment at the outermost array level; skip rest of line.
+                break
             if ch == "[":
                 depth += 1
+                if depth == 1:
+                    # Opening bracket — skip it, don't include in content.
+                    i += 1
+                    continue
             elif ch == "]":
                 depth -= 1
-            elif ch == "," and depth == 0:
-                commas += 1
-    stripped = array_content.strip()
-    if not stripped:
-        return 0
-    return commas + 1
+                if depth == 0:
+                    found_close = True
+                    break
+            if depth > 0:
+                chunks.append(ch)
+            i += 1
+
+        if found_close:
+            break
+        if depth > 0 and scan_idx < len(lines) - 1:
+            chunks.append("\n")
+        scan_idx += 1
+
+    return "".join(chunks), scan_idx if found_close else start_line_idx
+
+
+def _w_inline_array_root_count_map_entries(array_content: str) -> int:
+    """Count top-level elements that are K::V map entries (not bare scalars).
+
+    Only top-level (depth-0) comma-separated tokens whose stripped form starts
+    with an identifier followed by ``::`` are counted as map entries. Plain
+    scalars and quoted strings are excluded (CRS finding 3: should count only
+    map-entry elements, not total elements).
+
+    Args:
+        array_content: Raw text between ``[`` and ``]`` of the inline array.
+
+    Returns:
+        Number of top-level map-entry elements.
+    """
+    # Split into top-level comma-separated segments respecting depth and quotes.
+    segments: list[str] = []
+    current: list[str] = []
+    depth = 0
+    in_quote = False
+    for ch in array_content:
+        if in_quote:
+            if ch == '"':
+                in_quote = False
+            current.append(ch)
+        elif ch == '"':
+            in_quote = True
+            current.append(ch)
+        elif ch == "[":
+            depth += 1
+            current.append(ch)
+        elif ch == "]":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            segments.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    if current or array_content.strip():
+        segments.append("".join(current))
+
+    map_entry_count = 0
+    for seg in segments:
+        stripped = seg.strip()
+        if not stripped:
+            continue
+        # A map entry starts with an unquoted identifier followed by ``::``
+        if _W_INLINE_ARRAY_ROOT_ENTRY_RE.match("," + stripped):
+            map_entry_count += 1
+    return map_entry_count
 
 
 def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
@@ -1011,15 +1111,17 @@ def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
 
     Fires when a key's value is an inline array ``[...]`` whose elements are
     themselves K::V map-entries (map-as-inline-array), AND EITHER:
-      * entry count >= 3, OR
-      * serialized length > ``_W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD``
+      * map-entry element count >= 3, OR
+      * serialized array length > ``_W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD``
+        (with at least one map-entry element present)
 
     Does NOT fire on:
       * Legitimate scalar/string lists: IMMUTABLES::[a, b, c]
       * Content inside fenced literal zones (Zone 3)
       * Content inside // comments
+      * Arrays where ``::`` appears only inside quoted strings
 
-    Discriminator: elements contain ``::`` map syntax.
+    Discriminator: top-level (unquoted) elements contain ``::`` map syntax.
 
     Severity: ADVISORY only (non-blocking, surfaced in warnings/corrections).
 
@@ -1033,11 +1135,6 @@ def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
 
     literal_zone_lines = _build_literal_zone_line_set(content)
     lines = content.split("\n")
-
-    # Build cumulative offsets for line-based tracking.
-    line_offsets: list[int] = [0]
-    for ln in lines:
-        line_offsets.append(line_offsets[-1] + len(ln) + 1)
 
     i = 0
     while i < len(lines):
@@ -1067,50 +1164,22 @@ def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
 
         # Locate the opening ``[`` position in the line.
         bracket_pos = raw_line.index("[", opener_match.start())
-        # Collect the full array content by walking forward until balanced.
-        full_array = ""
-        depth = 0
-        found_close = False
-        scan_line_idx = i
-        while scan_line_idx < len(lines):
-            scan_line = lines[scan_line_idx]
-            # Skip literal zone inside multi-line array collection.
-            if scan_line_idx + 1 in literal_zone_lines and scan_line_idx != i:
-                scan_line_idx += 1
-                continue
-            start_col = bracket_pos if scan_line_idx == i else 0
-            for _col, ch in enumerate(scan_line[start_col:], start=start_col):
-                if ch == "[":
-                    depth += 1
-                    if depth == 1:
-                        continue  # skip the opening bracket itself
-                elif ch == "]":
-                    depth -= 1
-                    if depth == 0:
-                        found_close = True
-                        break
-                if depth > 0:
-                    full_array += ch
-            if found_close:
-                break
-            if depth > 0 and scan_line_idx < len(lines) - 1:
-                full_array += "\n"
-            scan_line_idx += 1
 
-        if not found_close:
-            i += 1
+        # Collect the full array content with quote/comment-aware scanning.
+        full_array, last_scan_idx = _w_inline_array_root_collect_array(lines, i, bracket_pos, literal_zone_lines)
+
+        if not full_array and not full_array.strip():
+            # Empty or unclosed array — skip.
+            i = last_scan_idx + 1
             continue
 
-        # Discriminate: does the array content contain K::V map entries?
-        if not _w_inline_array_root_array_is_map(full_array):
-            i += 1
-            continue
-
-        entry_count = _w_inline_array_root_entry_count(full_array)
+        # Discriminate: count only unquoted K::V map-entry elements.
+        map_entry_count = _w_inline_array_root_count_map_entries(full_array)
         array_length = len(full_array)
 
-        if entry_count >= _W_INLINE_ARRAY_ROOT_ENTRY_THRESHOLD or array_length > _W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD:
-            # Extract the key name from the line.
+        if map_entry_count >= _W_INLINE_ARRAY_ROOT_ENTRY_THRESHOLD or (
+            map_entry_count >= 1 and array_length > _W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD
+        ):
             key_match = re.match(r"^[ \t]*([A-Za-z_][A-Za-z0-9_]*)", raw_line)
             key_name = key_match.group(1) if key_match else "<unknown>"
             warnings_out.append(
@@ -1120,20 +1189,21 @@ def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
                     "discipline": "STRUCTURAL_ADVISORY",
                     "message": (
                         f"W_INLINE_ARRAY_ROOT at line {line_num}: key '{key_name}' "
-                        f"has {entry_count} map-entry elements authored as an "
+                        f"has {map_entry_count} map-entry elements authored as an "
                         f"inline-array root; prefer BLOCK form (KEY: + indented "
                         f"children). Inline arrays are for scalar lists, not "
                         f"maps-of-maps."
                     ),
                     "line": line_num,
                     "key": key_name,
-                    "entry_count": entry_count,
+                    "entry_count": map_entry_count,
                     "safe": True,
                     "semantics_changed": False,
                 }
             )
 
-        i += 1
+        # Advance past the scanned lines (efficiency fix: don't re-scan).
+        i = last_scan_idx + 1
 
     return warnings_out
 
@@ -1181,13 +1251,23 @@ def _detect_flat_prefix_scalar(content: str) -> list[dict[str, Any]]:
     """Detect sibling keys that share a redundant underscore prefix (W_FLAT_PREFIX_SCALAR).
 
     Heuristic:
-      1. Extract all key assignment lines at the same indentation level
-         (excluding literal zones and comment lines).
-      2. For each candidate prefix (all underscore-delimited prefixes of each
-         key), count how many sibling keys share that prefix.
-      3. For groups with >= 3 members at the same indentation level, emit an
-         advisory warning suggesting nesting under a ``{PREFIX}:`` block parent.
+      1. Walk all lines, collecting key assignment lines while tracking the
+         current parent block context.  A line at a *shallower* indentation than
+         the current context (other than blank lines and comment lines) resets
+         the sibling group — keys at different indentation levels are not siblings
+         even if they share the same indent string (CRS finding 1: parent-block
+         context must be tracked to avoid false grouping).
+      2. Within each contiguous sibling group, for each candidate prefix (all
+         underscore-delimited prefixes of each key), count how many keys share
+         that prefix.
+      3. For groups with >= 3 members, emit an advisory warning suggesting
+         nesting under a ``{PREFIX}:`` block parent.
       4. Report the longest qualifying prefix to give the most actionable advice.
+
+    v1 scope note: detection operates on lines collected within the same
+    parent-block context (same indentation run).  Keys scattered across
+    different parent blocks at the same indent level are NOT grouped — this
+    prevents false positives when the same prefix appears in unrelated sections.
 
     Severity: ADVISORY only (non-blocking).
 
@@ -1199,11 +1279,68 @@ def _detect_flat_prefix_scalar(content: str) -> list[dict[str, Any]]:
     """
     warnings_out: list[dict[str, Any]] = []
     literal_zone_lines = _build_literal_zone_line_set(content)
-
     lines = content.split("\n")
 
-    # Collect (indent_level, key_name, line_num) tuples.
-    entries: list[tuple[str, str, int]] = []
+    from collections import defaultdict
+
+    def _process_sibling_group(group: list[tuple[str, int]]) -> None:
+        """Analyse one contiguous sibling group and emit warnings as appropriate."""
+        if len(group) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
+            return
+
+        prefix_groups_local: dict[str, list[tuple[str, int]]] = defaultdict(list)
+        for key_name, line_num in group:
+            for prefix in _w_flat_prefix_scalar_all_prefixes(key_name):
+                prefix_groups_local[prefix].append((key_name, line_num))
+
+        # Deduplicate: for each unique key-set, keep only the longest prefix.
+        best_prefix_for_keyset: dict[frozenset[str], str] = {}
+        for prefix, members in prefix_groups_local.items():
+            if len(members) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
+                continue
+            key_set = frozenset(k for k, _ in members)
+            existing = best_prefix_for_keyset.get(key_set)
+            if existing is None or len(prefix) > len(existing):
+                best_prefix_for_keyset[key_set] = prefix
+
+        for _key_set, best_prefix in best_prefix_for_keyset.items():
+            members = prefix_groups_local[best_prefix]
+            seen: set[str] = set()
+            unique: list[tuple[str, int]] = []
+            for k, ln in members:
+                if k not in seen:
+                    seen.add(k)
+                    unique.append((k, ln))
+            if len(unique) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
+                continue
+            first_line = unique[0][1]
+            key_names = [k for k, _ in unique]
+            warnings_out.append(
+                {
+                    "code": W_FLAT_PREFIX_SCALAR,
+                    "tier": "STRUCTURAL_CHECK",
+                    "discipline": "STRUCTURAL_ADVISORY",
+                    "message": (
+                        f"W_FLAT_PREFIX_SCALAR at line {first_line}: sibling keys "
+                        f"share prefix '{best_prefix}_'; nest under '{best_prefix}:' "
+                        f"block to drop the redundant prefix (key-token saving + "
+                        f"better attention inheritance). Keys: {', '.join(key_names)}"
+                    ),
+                    "line": first_line,
+                    "prefix": best_prefix,
+                    "keys": key_names,
+                    "safe": True,
+                    "semantics_changed": False,
+                }
+            )
+
+    # Walk lines, tracking the current sibling group by a (indent, group_id)
+    # context.  A new parent block (a line at shallower or equal indentation
+    # that is not a key-assignment itself) closes the current sibling group.
+    # We use a simple monotonic group counter — each non-blank, non-comment
+    # line at a shallower indent than the active siblings starts a new group.
+    current_indent: str | None = None
+    current_group: list[tuple[str, int]] = []
 
     for line_idx, raw_line in enumerate(lines):
         line_num = line_idx + 1
@@ -1212,83 +1349,44 @@ def _detect_flat_prefix_scalar(content: str) -> list[dict[str, Any]]:
         if line_num in literal_zone_lines:
             continue
 
-        # Skip comment lines.
         stripped = raw_line.lstrip()
+
+        # Skip blank lines.
+        if not stripped:
+            continue
+
+        # Skip comment lines.
         if stripped.startswith("//"):
             continue
 
         m = _W_FLAT_PREFIX_SCALAR_KEY_RE.match(raw_line)
-        if not m:
-            continue
 
-        indent = m.group(1)
-        key_name = m.group(2)
-        entries.append((indent, key_name, line_num))
+        if m:
+            indent = m.group(1)
+            key_name = m.group(2)
 
-    if not entries:
-        return warnings_out
+            if current_indent is None:
+                # First key — start a new group.
+                current_indent = indent
+                current_group = [(key_name, line_num)]
+            elif indent == current_indent:
+                # Same indentation — same sibling group.
+                current_group.append((key_name, line_num))
+            else:
+                # Different indentation — close the current group and start fresh.
+                _process_sibling_group(current_group)
+                current_indent = indent
+                current_group = [(key_name, line_num)]
+        else:
+            # Non-key line at any indentation — if it is shallower than or equal
+            # to the current group's indent, it closes the sibling context.
+            this_indent = raw_line[: len(raw_line) - len(stripped)]
+            if current_indent is not None and len(this_indent) <= len(current_indent):
+                _process_sibling_group(current_group)
+                current_indent = None
+                current_group = []
 
-    from collections import defaultdict
-
-    # Build a mapping: (indent, prefix) -> list of (key_name, line_num)
-    # A key contributes to every prefix group it belongs to.
-    prefix_groups: dict[tuple[str, str], list[tuple[str, int]]] = defaultdict(list)
-
-    for indent, key_name, line_num in entries:
-        for prefix in _w_flat_prefix_scalar_all_prefixes(key_name):
-            prefix_groups[(indent, prefix)].append((key_name, line_num))
-
-    # Among qualifying groups (size >= threshold), report the LONGEST prefix
-    # for each key set — this gives the most actionable suggestion.
-    # To avoid double-reporting a set of keys under both "DB" and "DB_HOST"
-    # when the intent is to flag "DB", we deduplicate by the key-set fingerprint
-    # and keep only the longest prefix per unique key set.
-    best_prefix_for_keyset: dict[tuple[str, frozenset[str]], str] = {}
-
-    for (indent, prefix), members in prefix_groups.items():
-        if len(members) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
-            continue
-        key_set = frozenset(k for k, _ in members)
-        group_id = (indent, key_set)
-        existing = best_prefix_for_keyset.get(group_id)
-        if existing is None or len(prefix) > len(existing):
-            best_prefix_for_keyset[group_id] = prefix
-
-    # Emit one warning per unique (indent, key_set) using the best (longest) prefix.
-    for (indent, _key_set), best_prefix in best_prefix_for_keyset.items():
-        # Retrieve the members for this (indent, best_prefix) group.
-        members = prefix_groups[(indent, best_prefix)]
-        # De-duplicate member list (a key may appear multiple times if it
-        # contributes to both shorter and longer prefix groups).
-        seen_keys: set[str] = set()
-        unique_members: list[tuple[str, int]] = []
-        for k, ln in members:
-            if k not in seen_keys:
-                seen_keys.add(k)
-                unique_members.append((k, ln))
-
-        if len(unique_members) < _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD:
-            continue
-
-        first_line = unique_members[0][1]
-        key_names = [k for k, _ in unique_members]
-        warnings_out.append(
-            {
-                "code": W_FLAT_PREFIX_SCALAR,
-                "tier": "STRUCTURAL_CHECK",
-                "discipline": "STRUCTURAL_ADVISORY",
-                "message": (
-                    f"W_FLAT_PREFIX_SCALAR at line {first_line}: sibling keys "
-                    f"share prefix '{best_prefix}_'; nest under '{best_prefix}:' "
-                    f"block to drop the redundant prefix (key-token saving + "
-                    f"better attention inheritance). Keys: {', '.join(key_names)}"
-                ),
-                "line": first_line,
-                "prefix": best_prefix,
-                "keys": key_names,
-                "safe": True,
-                "semantics_changed": False,
-            }
-        )
+    # Flush the last group.
+    _process_sibling_group(current_group)
 
     return warnings_out

--- a/src/octave_mcp/mcp/write_detection.py
+++ b/src/octave_mcp/mcp/write_detection.py
@@ -1151,7 +1151,10 @@ _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD = 3
 # Regex matching a top-level (zero-indent or consistent-indent) KEY assignment.
 # Captures the full key name. We restrict to uppercase/underscore keys as those
 # are the primary OCTAVE structural pattern subject to flat-prefix sprawl.
-_W_FLAT_PREFIX_SCALAR_KEY_RE = re.compile(r"^([ \t]*)([A-Z][A-Z0-9_]+)\s*:[:s]")
+# The value-start pattern `:[:\s]` matches either a second `:` (double-colon
+# assignment form `KEY::value`) or whitespace (block-open form `KEY: child`),
+# allowing detection of both sibling-assignment and sibling-block patterns.
+_W_FLAT_PREFIX_SCALAR_KEY_RE = re.compile(r"^([ \t]*)([A-Z][A-Z0-9_]+)\s*:[:\s]")
 
 
 def _w_flat_prefix_scalar_all_prefixes(key: str) -> list[str]:

--- a/src/octave_mcp/mcp/write_detection.py
+++ b/src/octave_mcp/mcp/write_detection.py
@@ -1082,7 +1082,7 @@ def _w_inline_array_root_collect_array(
             chunks.append("\n")
         scan_idx += 1
 
-    return "".join(chunks), scan_idx if found_close else start_line_idx
+    return ("".join(chunks), scan_idx) if found_close else ("", start_line_idx)
 
 
 def _w_inline_array_root_count_map_entries(array_content: str) -> int:
@@ -1254,7 +1254,7 @@ _W_FLAT_PREFIX_SCALAR_GROUP_THRESHOLD = 3
 # The value-start pattern `:[:\s]` matches either a second `:` (double-colon
 # assignment form `KEY::value`) or whitespace (block-open form `KEY: child`),
 # allowing detection of both sibling-assignment and sibling-block patterns.
-_W_FLAT_PREFIX_SCALAR_KEY_RE = re.compile(r"^([ \t]*)([A-Z][A-Z0-9_]+)\s*:[:\s]")
+_W_FLAT_PREFIX_SCALAR_KEY_RE = re.compile(r"^([ \t]*)([A-Z][A-Z0-9_]+)\s*:(?::|\s|$)")
 
 
 def _w_flat_prefix_scalar_all_prefixes(key: str) -> list[str]:

--- a/src/octave_mcp/mcp/write_detection.py
+++ b/src/octave_mcp/mcp/write_detection.py
@@ -950,6 +950,9 @@ def _detect_snake_case_blob(content: str) -> list[dict[str, Any]]:
 # GH-structural-advisory: W_INLINE_ARRAY_ROOT
 # ---------------------------------------------------------------------------
 
+# Critical-Engineer: consulted for Validator detector architecture
+# (advisory routing, quote-scan robustness, drift surface) — CE gate 2026-05-29.
+
 # Advisory code for map-as-inline-array structural pattern.
 W_INLINE_ARRAY_ROOT = "W_INLINE_ARRAY_ROOT"
 
@@ -963,6 +966,35 @@ _W_INLINE_ARRAY_ROOT_LENGTH_THRESHOLD = 80
 # discriminator between map-as-inline-array and scalar/string lists.
 # A map entry is: optional whitespace, an identifier token, `::`, then a value.
 _W_INLINE_ARRAY_ROOT_ENTRY_RE = re.compile(r"(?:^|,)\s*[A-Za-z_][A-Za-z0-9_]*\s*::")
+
+
+def _w_quote_is_unescaped(text: str, pos: int) -> bool:
+    """Return True iff the ``"`` at *pos* in *text* is NOT escaped.
+
+    Implements the backslash-run-parity convention already used in
+    ``_all_section_marks_quoted`` and ``_build_holographic_line_set``
+    (cubic-dev-ai P1 fix, PR #431): count consecutive backslashes
+    immediately before the quote; an **even** count (including zero)
+    means the quote is unescaped; an **odd** count means it is escaped.
+
+    CE gate 2026-05-29: extracted as a shared helper so all four scanners
+    that track in-quote state use the same parity logic and cannot drift
+    independently.
+
+    Args:
+        text: The string being scanned.
+        pos: Index of the ``"`` character to test.
+
+    Returns:
+        True if the quote at *pos* is unescaped (should toggle in-quote state).
+    """
+    backslash_count = 0
+    j = pos - 1
+    while j >= 0 and text[j] == "\\":
+        backslash_count += 1
+        j -= 1
+    return backslash_count % 2 == 0
+
 
 # Regex: detects an assignment opener with an inline array value on the same
 # line: ``KEY::[...]`` (double-colon form).
@@ -1016,14 +1048,13 @@ def _w_inline_array_root_collect_array(
         i = 0
         while i < len(line_text):
             ch = line_text[i]
-            if in_quote:
-                if ch == '"':
-                    in_quote = False
+            # Backslash-parity quote toggle (CE gate 2026-05-29 / cubic P1 convention).
+            if ch == '"' and _w_quote_is_unescaped(line_text, i):
+                in_quote = not in_quote
                 chunks.append(ch)
                 i += 1
                 continue
-            if ch == '"':
-                in_quote = True
+            if in_quote:
                 chunks.append(ch)
                 i += 1
                 continue
@@ -1069,17 +1100,16 @@ def _w_inline_array_root_count_map_entries(array_content: str) -> int:
         Number of top-level map-entry elements.
     """
     # Split into top-level comma-separated segments respecting depth and quotes.
+    # Uses backslash-parity quote toggle (CE gate 2026-05-29 / cubic P1 convention).
     segments: list[str] = []
     current: list[str] = []
     depth = 0
     in_quote = False
-    for ch in array_content:
-        if in_quote:
-            if ch == '"':
-                in_quote = False
+    for idx, ch in enumerate(array_content):
+        if ch == '"' and _w_quote_is_unescaped(array_content, idx):
+            in_quote = not in_quote
             current.append(ch)
-        elif ch == '"':
-            in_quote = True
+        elif in_quote:
             current.append(ch)
         elif ch == "[":
             depth += 1
@@ -1168,7 +1198,7 @@ def _detect_inline_array_root(content: str) -> list[dict[str, Any]]:
         # Collect the full array content with quote/comment-aware scanning.
         full_array, last_scan_idx = _w_inline_array_root_collect_array(lines, i, bracket_pos, literal_zone_lines)
 
-        if not full_array and not full_array.strip():
+        if not full_array.strip():
             # Empty or unclosed array — skip.
             i = last_scan_idx + 1
             continue

--- a/tests/unit/test_gh484_nested_dict_in_changes_mode.py
+++ b/tests/unit/test_gh484_nested_dict_in_changes_mode.py
@@ -8,9 +8,12 @@ Root cause: ``_normalize_value_for_ast`` in write_mutation.py wraps any ``dict``
 
 STRATEGY_S3 (DocumentMutator) is deferred.  The minimum correct fix is a REJECTION guard
 at input validation time: ``_validate_change_paths`` must append an
-``E_NESTED_DICT_IN_MERGE_PAYLOAD`` error when a MERGE payload contains plain nested dict
-values (ones that are not op-descriptors — ``_is_op_descriptor`` subsumes delete
-sentinels since both carry a ``$op`` key).
+``E_NESTED_DICT_IN_MERGE_PAYLOAD`` error when a MERGE payload contains any dict sub-value
+that is not a delete sentinel (``{"$op": "DELETE"}``).  The MERGE handler in
+``_apply_changes`` only recognises delete sentinels as special sub-operations; every
+other dict — including non-DELETE op-descriptors such as ``{"$op": "APPEND", ...}`` —
+is normalised as a literal InlineMap, which is either structurally invalid (nested
+InlineMap → ``E_NESTED_INLINE_MAP``) or semantically wrong (wrong caller intent).
 
 TDD protocol (T2 tier): these tests were authored RED (failing before the guard lands)
 and gate GREEN (guard implemented in ``_validate_change_paths``).
@@ -64,9 +67,9 @@ async def test_merge_with_nested_dict_returns_error() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" in error_codes, (
-        f"Expected E_NESTED_DICT_IN_MERGE_PAYLOAD in errors but got: {errors}"
-    )
+    assert (
+        "E_NESTED_DICT_IN_MERGE_PAYLOAD" in error_codes
+    ), f"Expected E_NESTED_DICT_IN_MERGE_PAYLOAD in errors but got: {errors}"
 
 
 @pytest.mark.asyncio
@@ -80,12 +83,10 @@ async def test_merge_with_nested_dict_error_message_is_actionable() -> None:
     e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_MERGE_PAYLOAD"), None)
     assert e is not None, f"No E_NESTED_DICT_IN_MERGE_PAYLOAD error found in: {errors}"
     msg = e.get("message", "")
-    assert "content" in msg, (
-        f"Error message should mention the 'content' parameter. Got: {msg!r}"
-    )
-    assert "format_style" in msg or "preserve" in msg, (
-        f"Error message should mention 'format_style=preserve'. Got: {msg!r}"
-    )
+    assert "content" in msg, f"Error message should mention the 'content' parameter. Got: {msg!r}"
+    assert (
+        "format_style" in msg or "preserve" in msg
+    ), f"Error message should mention 'format_style=preserve'. Got: {msg!r}"
     # Should mention which nested key(s) triggered the rejection
     assert "NESTED" in msg, f"Error message should cite the nested key 'NESTED'. Got: {msg!r}"
 
@@ -123,18 +124,18 @@ async def test_merge_with_scalar_values_passes() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for scalar MERGE: {errors}"
-    )
+    assert (
+        "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes
+    ), f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for scalar MERGE: {errors}"
 
 
 @pytest.mark.asyncio
-async def test_merge_with_op_descriptor_value_passes() -> None:
-    """A MERGE payload whose sub-value is itself an op-descriptor must pass through.
+async def test_merge_with_delete_sentinel_passes() -> None:
+    """A MERGE payload whose sub-value is a DELETE sentinel must pass through.
 
-    Op-descriptors (any dict with a ``$op`` key, including delete sentinels) are
-    legitimate sub-operations and must not be misidentified as plain nested dicts.
-    The guard uses ``_is_op_descriptor`` which covers all ``$op``-keyed dicts.
+    Delete sentinels (``{"$op": "DELETE"}``) are the only dict sub-values the
+    MERGE handler treats as a special sub-operation (child deletion). The guard
+    uses ``_is_delete_sentinel`` to exempt exactly this case.
     """
     result = await _write(
         _BASE_DOC,
@@ -142,9 +143,30 @@ async def test_merge_with_op_descriptor_value_passes() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for op-descriptor sub-value: {errors}"
+    assert (
+        "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes
+    ), f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for delete-sentinel sub-value: {errors}"
+
+
+@pytest.mark.asyncio
+async def test_merge_with_non_delete_op_descriptor_is_rejected() -> None:
+    """A MERGE payload whose sub-value is a non-DELETE op-descriptor must be rejected.
+
+    The MERGE handler in _apply_changes only recognises delete sentinels as
+    special sub-operations; every other dict (including op-descriptors like
+    ``{"$op": "APPEND", ...}``) is normalised as a literal InlineMap value.
+    A non-DELETE op-descriptor is almost certainly a caller mistake (intending
+    a recursive sub-operation), so the guard rejects it explicitly.
+    """
+    result = await _write(
+        _BASE_DOC,
+        changes={"KEY": {"$op": "MERGE", "value": {"SUB": {"$op": "APPEND", "value": "x"}}}},
     )
+    errors = result.get("errors", [])
+    error_codes = [e.get("code") for e in errors]
+    assert (
+        "E_NESTED_DICT_IN_MERGE_PAYLOAD" in error_codes
+    ), f"Expected E_NESTED_DICT_IN_MERGE_PAYLOAD for non-DELETE op-descriptor sub-value: {errors}"
 
 
 @pytest.mark.asyncio
@@ -157,9 +179,9 @@ async def test_non_merge_op_with_dict_value_not_affected() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for non-MERGE change: {errors}"
-    )
+    assert (
+        "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes
+    ), f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for non-MERGE change: {errors}"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_gh484_nested_dict_in_changes_mode.py
+++ b/tests/unit/test_gh484_nested_dict_in_changes_mode.py
@@ -1,4 +1,4 @@
-"""GH#484 — E_NESTED_DICT_IN_CHANGES_MODE rejection guard for ``octave_write`` changes-mode.
+"""GH#484 — E_NESTED_DICT_IN_MERGE_PAYLOAD rejection guard for ``octave_write`` changes-mode.
 
 Root cause: ``_normalize_value_for_ast`` in write_mutation.py wraps any ``dict`` as
 ``InlineMap`` unconditionally.  When a MERGE payload contains a nested plain Python dict
@@ -8,8 +8,9 @@ Root cause: ``_normalize_value_for_ast`` in write_mutation.py wraps any ``dict``
 
 STRATEGY_S3 (DocumentMutator) is deferred.  The minimum correct fix is a REJECTION guard
 at input validation time: ``_validate_change_paths`` must append an
-``E_NESTED_DICT_IN_CHANGES_MODE`` error when a MERGE payload contains plain nested dict
-values (ones that are neither op-descriptors nor delete sentinels).
+``E_NESTED_DICT_IN_MERGE_PAYLOAD`` error when a MERGE payload contains plain nested dict
+values (ones that are not op-descriptors — ``_is_op_descriptor`` subsumes delete
+sentinels since both carry a ``$op`` key).
 
 TDD protocol (T2 tier): these tests were authored RED (failing before the guard lands)
 and gate GREEN (guard implemented in ``_validate_change_paths``).
@@ -45,7 +46,7 @@ async def _write(doc: str, changes: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# E_NESTED_DICT_IN_CHANGES_MODE — rejection guard
+# E_NESTED_DICT_IN_MERGE_PAYLOAD — rejection guard
 # ---------------------------------------------------------------------------
 
 
@@ -55,7 +56,7 @@ async def test_merge_with_nested_dict_returns_error() -> None:
 
     Acceptance criterion from GH#484: calling octave_write with
     ``changes={"SOME_KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}}``
-    must produce E_NESTED_DICT_IN_CHANGES_MODE in the errors list.
+    must produce E_NESTED_DICT_IN_MERGE_PAYLOAD in the errors list.
     """
     result = await _write(
         _BASE_DOC,
@@ -63,24 +64,24 @@ async def test_merge_with_nested_dict_returns_error() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_CHANGES_MODE" in error_codes, (
-        f"Expected E_NESTED_DICT_IN_CHANGES_MODE in errors but got: {errors}"
+    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" in error_codes, (
+        f"Expected E_NESTED_DICT_IN_MERGE_PAYLOAD in errors but got: {errors}"
     )
 
 
 @pytest.mark.asyncio
 async def test_merge_with_nested_dict_error_message_is_actionable() -> None:
-    """The error message must direct the caller to content_mode + format_style=preserve."""
+    """The error message must direct the caller to the content parameter + format_style=preserve."""
     result = await _write(
         _BASE_DOC,
         changes={"KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}},
     )
     errors = result.get("errors", [])
-    e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_CHANGES_MODE"), None)
-    assert e is not None, f"No E_NESTED_DICT_IN_CHANGES_MODE error found in: {errors}"
+    e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_MERGE_PAYLOAD"), None)
+    assert e is not None, f"No E_NESTED_DICT_IN_MERGE_PAYLOAD error found in: {errors}"
     msg = e.get("message", "")
-    assert "content_mode" in msg or "content" in msg, (
-        f"Error message should mention 'content' (content_mode parameter). Got: {msg!r}"
+    assert "content" in msg, (
+        f"Error message should mention the 'content' parameter. Got: {msg!r}"
     )
     assert "format_style" in msg or "preserve" in msg, (
         f"Error message should mention 'format_style=preserve'. Got: {msg!r}"
@@ -106,7 +107,7 @@ async def test_merge_with_multiple_nested_dicts_lists_all_keys() -> None:
         },
     )
     errors = result.get("errors", [])
-    e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_CHANGES_MODE"), None)
+    e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_MERGE_PAYLOAD"), None)
     assert e is not None
     msg = e.get("message", "")
     assert "FIRST" in msg, f"Expected 'FIRST' in message. Got: {msg!r}"
@@ -122,8 +123,8 @@ async def test_merge_with_scalar_values_passes() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for scalar MERGE: {errors}"
+    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for scalar MERGE: {errors}"
     )
 
 
@@ -131,8 +132,9 @@ async def test_merge_with_scalar_values_passes() -> None:
 async def test_merge_with_op_descriptor_value_passes() -> None:
     """A MERGE payload whose sub-value is itself an op-descriptor must pass through.
 
-    Op-descriptors (e.g., ``{"$op": "DELETE"}``) are legitimate sub-operations and
-    must not be misidentified as plain nested dicts.
+    Op-descriptors (any dict with a ``$op`` key, including delete sentinels) are
+    legitimate sub-operations and must not be misidentified as plain nested dicts.
+    The guard uses ``_is_op_descriptor`` which covers all ``$op``-keyed dicts.
     """
     result = await _write(
         _BASE_DOC,
@@ -140,26 +142,8 @@ async def test_merge_with_op_descriptor_value_passes() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for op-descriptor sub-value: {errors}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_merge_with_delete_sentinel_value_passes() -> None:
-    """A MERGE payload whose sub-value is a delete sentinel must pass through.
-
-    Delete sentinels (``{"$op": "DELETE"}``) are op-descriptors and must not
-    be misidentified as plain nested dicts.
-    """
-    result = await _write(
-        _BASE_DOC,
-        changes={"META": {"$op": "MERGE", "value": {"TYPE": {"$op": "DELETE"}}}},
-    )
-    errors = result.get("errors", [])
-    error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for delete-sentinel sub-value: {errors}"
+    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for op-descriptor sub-value: {errors}"
     )
 
 
@@ -173,20 +157,20 @@ async def test_non_merge_op_with_dict_value_not_affected() -> None:
     )
     errors = result.get("errors", [])
     error_codes = [e.get("code") for e in errors]
-    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
-        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for non-MERGE change: {errors}"
+    assert "E_NESTED_DICT_IN_MERGE_PAYLOAD" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_MERGE_PAYLOAD for non-MERGE change: {errors}"
     )
 
 
 @pytest.mark.asyncio
-async def test_merge_nested_dict_status_is_error_not_success() -> None:
-    """When E_NESTED_DICT_IN_CHANGES_MODE fires, status must not be 'success'."""
+async def test_merge_with_nested_dict_does_not_return_success_status() -> None:
+    """When E_NESTED_DICT_IN_MERGE_PAYLOAD fires, status must not be 'success'."""
     result = await _write(
         _BASE_DOC,
         changes={"KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}},
     )
     errors = result.get("errors", [])
-    has_error = any(e.get("code") == "E_NESTED_DICT_IN_CHANGES_MODE" for e in errors)
+    has_error = any(e.get("code") == "E_NESTED_DICT_IN_MERGE_PAYLOAD" for e in errors)
     assert has_error
     # Status must not indicate success when a blocking error was raised
     status = result.get("status", "")

--- a/tests/unit/test_gh484_nested_dict_in_changes_mode.py
+++ b/tests/unit/test_gh484_nested_dict_in_changes_mode.py
@@ -1,0 +1,193 @@
+"""GH#484 — E_NESTED_DICT_IN_CHANGES_MODE rejection guard for ``octave_write`` changes-mode.
+
+Root cause: ``_normalize_value_for_ast`` in write_mutation.py wraps any ``dict`` as
+``InlineMap`` unconditionally.  When a MERGE payload contains a nested plain Python dict
+(e.g., ``{"NESTED": {"deep": "dict"}}``), the serialization emits an inline map
+(``KEY::[NESTED::[deep::dict]]``) which fails strict re-parse with
+``E_NESTED_INLINE_MAP``.
+
+STRATEGY_S3 (DocumentMutator) is deferred.  The minimum correct fix is a REJECTION guard
+at input validation time: ``_validate_change_paths`` must append an
+``E_NESTED_DICT_IN_CHANGES_MODE`` error when a MERGE payload contains plain nested dict
+values (ones that are neither op-descriptors nor delete sentinels).
+
+TDD protocol (T2 tier): these tests were authored RED (failing before the guard lands)
+and gate GREEN (guard implemented in ``_validate_change_paths``).
+"""
+
+import os
+import tempfile
+
+import pytest
+
+from octave_mcp.mcp.write import WriteTool
+
+_TOOL = WriteTool()
+
+_BASE_DOC = """===EXAMPLE===
+META:
+  TYPE::TEST
+KEY::top_level_value
+===END===
+"""
+
+
+async def _write(doc: str, changes: dict) -> dict:
+    """Seed ``doc`` to a temp file, apply ``changes``, return the result dict."""
+    fd, path = tempfile.mkstemp(suffix=".oct.md")
+    os.close(fd)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(doc)
+        return await _TOOL.execute(target_path=path, changes=changes, format_style="preserve")
+    finally:
+        os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# E_NESTED_DICT_IN_CHANGES_MODE — rejection guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_merge_with_nested_dict_returns_error() -> None:
+    """MERGE payload containing a plain nested dict must be rejected.
+
+    Acceptance criterion from GH#484: calling octave_write with
+    ``changes={"SOME_KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}}``
+    must produce E_NESTED_DICT_IN_CHANGES_MODE in the errors list.
+    """
+    result = await _write(
+        _BASE_DOC,
+        changes={"KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}},
+    )
+    errors = result.get("errors", [])
+    error_codes = [e.get("code") for e in errors]
+    assert "E_NESTED_DICT_IN_CHANGES_MODE" in error_codes, (
+        f"Expected E_NESTED_DICT_IN_CHANGES_MODE in errors but got: {errors}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_with_nested_dict_error_message_is_actionable() -> None:
+    """The error message must direct the caller to content_mode + format_style=preserve."""
+    result = await _write(
+        _BASE_DOC,
+        changes={"KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}},
+    )
+    errors = result.get("errors", [])
+    e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_CHANGES_MODE"), None)
+    assert e is not None, f"No E_NESTED_DICT_IN_CHANGES_MODE error found in: {errors}"
+    msg = e.get("message", "")
+    assert "content_mode" in msg or "content" in msg, (
+        f"Error message should mention 'content' (content_mode parameter). Got: {msg!r}"
+    )
+    assert "format_style" in msg or "preserve" in msg, (
+        f"Error message should mention 'format_style=preserve'. Got: {msg!r}"
+    )
+    # Should mention which nested key(s) triggered the rejection
+    assert "NESTED" in msg, f"Error message should cite the nested key 'NESTED'. Got: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_merge_with_multiple_nested_dicts_lists_all_keys() -> None:
+    """All nested dict keys must appear in the error message."""
+    result = await _write(
+        _BASE_DOC,
+        changes={
+            "KEY": {
+                "$op": "MERGE",
+                "value": {
+                    "FIRST": {"a": "1"},
+                    "SECOND": {"b": "2"},
+                    "SCALAR": "fine",
+                },
+            }
+        },
+    )
+    errors = result.get("errors", [])
+    e = next((e for e in errors if e.get("code") == "E_NESTED_DICT_IN_CHANGES_MODE"), None)
+    assert e is not None
+    msg = e.get("message", "")
+    assert "FIRST" in msg, f"Expected 'FIRST' in message. Got: {msg!r}"
+    assert "SECOND" in msg, f"Expected 'SECOND' in message. Got: {msg!r}"
+
+
+@pytest.mark.asyncio
+async def test_merge_with_scalar_values_passes() -> None:
+    """MERGE payload with only scalar values must NOT trigger the guard."""
+    result = await _write(
+        _BASE_DOC,
+        changes={"META": {"$op": "MERGE", "value": {"TYPE": "UPDATED", "STATUS": "OK"}}},
+    )
+    errors = result.get("errors", [])
+    error_codes = [e.get("code") for e in errors]
+    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for scalar MERGE: {errors}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_with_op_descriptor_value_passes() -> None:
+    """A MERGE payload whose sub-value is itself an op-descriptor must pass through.
+
+    Op-descriptors (e.g., ``{"$op": "DELETE"}``) are legitimate sub-operations and
+    must not be misidentified as plain nested dicts.
+    """
+    result = await _write(
+        _BASE_DOC,
+        changes={"META": {"$op": "MERGE", "value": {"TYPE": {"$op": "DELETE"}}}},
+    )
+    errors = result.get("errors", [])
+    error_codes = [e.get("code") for e in errors]
+    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for op-descriptor sub-value: {errors}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_with_delete_sentinel_value_passes() -> None:
+    """A MERGE payload whose sub-value is a delete sentinel must pass through.
+
+    Delete sentinels (``{"$op": "DELETE"}``) are op-descriptors and must not
+    be misidentified as plain nested dicts.
+    """
+    result = await _write(
+        _BASE_DOC,
+        changes={"META": {"$op": "MERGE", "value": {"TYPE": {"$op": "DELETE"}}}},
+    )
+    errors = result.get("errors", [])
+    error_codes = [e.get("code") for e in errors]
+    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for delete-sentinel sub-value: {errors}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_merge_op_with_dict_value_not_affected() -> None:
+    """Non-MERGE ops (e.g., bare dict assignment) are unaffected by the guard."""
+    result = await _write(
+        _BASE_DOC,
+        # Bare dict (no $op) is processed differently — guard is MERGE-specific
+        changes={"META": {"TYPE": "UPDATED"}},
+    )
+    errors = result.get("errors", [])
+    error_codes = [e.get("code") for e in errors]
+    assert "E_NESTED_DICT_IN_CHANGES_MODE" not in error_codes, (
+        f"Unexpected E_NESTED_DICT_IN_CHANGES_MODE for non-MERGE change: {errors}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_nested_dict_status_is_error_not_success() -> None:
+    """When E_NESTED_DICT_IN_CHANGES_MODE fires, status must not be 'success'."""
+    result = await _write(
+        _BASE_DOC,
+        changes={"KEY": {"$op": "MERGE", "value": {"NESTED": {"deep": "dict"}}}},
+    )
+    errors = result.get("errors", [])
+    has_error = any(e.get("code") == "E_NESTED_DICT_IN_CHANGES_MODE" for e in errors)
+    assert has_error
+    # Status must not indicate success when a blocking error was raised
+    status = result.get("status", "")
+    assert status != "success", f"Expected non-success status when errors present, got: {status!r}"

--- a/tests/unit/test_structural_advisory_warnings.py
+++ b/tests/unit/test_structural_advisory_warnings.py
@@ -35,10 +35,9 @@ import pytest
 from octave_mcp.mcp.validate import ValidateTool
 from octave_mcp.mcp.write import WriteTool
 from octave_mcp.mcp.write_detection import (
-    _detect_inline_array_root,
     _detect_flat_prefix_scalar,
+    _detect_inline_array_root,
 )
-
 
 # ---------------------------------------------------------------------------
 # W_INLINE_ARRAY_ROOT — unit tests

--- a/tests/unit/test_structural_advisory_warnings.py
+++ b/tests/unit/test_structural_advisory_warnings.py
@@ -1,0 +1,451 @@
+"""Tests for structural advisory warnings W_INLINE_ARRAY_ROOT and W_FLAT_PREFIX_SCALAR.
+
+Advisory note 2026-05-29 (Ask 1): two new structural advisory warnings for the
+OCTAVE-MCP validator, following the same pattern as W_SNAKE_CASE_BLOB (GH#452/PR#456).
+
+Detection contracts:
+
+W_INLINE_ARRAY_ROOT
+    TRIGGER   :: key's value is an inline array [...] whose elements are K::V
+                 map-entries (map-as-inline-array), AND entry count >= 3 OR
+                 serialized length > reasonable threshold.
+    EXCLUSION :: elements are plain scalars/strings (no '::' map syntax).
+    SEVERITY  :: advisory (warnings channel, non-blocking)
+    MESSAGE   :: "multi-field token authored as inline-array root; prefer BLOCK
+                  form (KEY: + indented children). Inline arrays are for scalar
+                  lists, not maps-of-maps."
+
+W_FLAT_PREFIX_SCALAR
+    TRIGGER   :: >= 3 sibling keys share a longest common underscore-delimited
+                 prefix; flagging them suggests nesting under a block parent to
+                 remove the redundant prefix.
+    HEURISTIC :: group sibling keys by longest-common-prefix-up-to-_; flag
+                 groups of size >= 3.
+    SEVERITY  :: advisory (warnings channel, non-blocking)
+    MESSAGE   :: "sibling keys share prefix '{PREFIX}_'; nest under '{PREFIX}:'
+                  block to drop the redundant prefix (key-token saving + better
+                  attention inheritance)."
+
+TDD RED phase: these tests FAIL before the implementation lands in
+``src/octave_mcp/mcp/write_detection.py``.
+"""
+
+import pytest
+
+from octave_mcp.mcp.validate import ValidateTool
+from octave_mcp.mcp.write import WriteTool
+from octave_mcp.mcp.write_detection import (
+    _detect_inline_array_root,
+    _detect_flat_prefix_scalar,
+)
+
+
+# ---------------------------------------------------------------------------
+# W_INLINE_ARRAY_ROOT — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestInlineArrayRootDetector:
+    """Direct calls to _detect_inline_array_root."""
+
+    # --- Positive cases: must fire ---
+
+    def test_fires_on_map_as_inline_array_three_entries(self):
+        """Three K::V elements in inline array must trigger."""
+        content = "ITEMS::[KEY_A::val_a, KEY_B::val_b, KEY_C::val_c]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" in codes
+
+    def test_fires_on_map_as_inline_array_four_entries(self):
+        """Four K::V elements in inline array must trigger."""
+        content = "META_ITEMS::[A::1, B::2, C::3, D::4]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" in codes
+
+    def test_fires_on_long_serialized_inline_map_array(self):
+        """Long inline map-array (even 2 entries, long serialized form) triggers on length."""
+        # > reasonable threshold via length even if count is only 2
+        long_key_a = "A" * 40
+        long_key_b = "B" * 40
+        content = f"SECTION::[{long_key_a}::value_one, {long_key_b}::value_two]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" in codes
+
+    def test_fires_on_block_form_assignment_inline_array_with_map_elements(self):
+        """KEY: [...] block-form opening with map elements must also trigger."""
+        content = "SECTION:[\n  A::1,\n  B::2,\n  C::3\n]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" in codes
+
+    # --- Negative cases: must NOT fire ---
+
+    def test_no_fire_on_scalar_list(self):
+        """Plain scalar list must NOT trigger — this is legitimate OCTAVE."""
+        content = "IMMUTABLES::[a, b, c]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_fire_on_authority_scalar_list(self):
+        """AUTHORITY::[a, b] — scalar list, no :: in elements."""
+        content = "AUTHORITY::[admin, user]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_fire_on_consolidates_scalar_list(self):
+        """CONSOLIDATES::[...] with scalar entries must NOT trigger."""
+        content = "CONSOLIDATES::[GH_123, GH_456, GH_789]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_fire_on_two_map_entries_short(self):
+        """Two short K::V elements is not a strong enough signal without length pressure."""
+        content = "SMALL::[A::1, B::2]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_fire_in_literal_zone(self):
+        """Map-as-inline-array inside a fenced literal zone must NOT trigger."""
+        content = "```\nSECTION::[A::1, B::2, C::3]\n```\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_fire_in_comment(self):
+        """Map-as-inline-array inside a // comment must NOT trigger."""
+        content = "// SECTION::[A::1, B::2, C::3]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    # --- Warning shape ---
+
+    def test_warning_has_stable_code_and_provenance(self):
+        """Warning carries stable code, line number, and key (I4)."""
+        content = "FILLER::ok\n\nSECTION::[A::1, B::2, C::3]\n"
+        warnings = _detect_inline_array_root(content)
+        hits = [w for w in warnings if w["code"] == "W_INLINE_ARRAY_ROOT"]
+        assert len(hits) >= 1
+        w = hits[0]
+        assert w["code"] == "W_INLINE_ARRAY_ROOT"
+        assert w["line"] == 3
+        assert w["safe"] is True
+        assert w["semantics_changed"] is False
+
+    def test_warning_message_references_block_form(self):
+        """Warning message mentions BLOCK form preference."""
+        content = "SECTION::[A::1, B::2, C::3]\n"
+        warnings = _detect_inline_array_root(content)
+        hits = [w for w in warnings if w["code"] == "W_INLINE_ARRAY_ROOT"]
+        assert any("BLOCK" in w["message"] or "block" in w["message"] for w in hits)
+
+    def test_advisory_severity_only(self):
+        """W_INLINE_ARRAY_ROOT must carry safe=True, semantics_changed=False."""
+        content = "SECTION::[A::1, B::2, C::3]\n"
+        warnings = _detect_inline_array_root(content)
+        for w in warnings:
+            if w["code"] == "W_INLINE_ARRAY_ROOT":
+                assert w["safe"] is True
+                assert w["semantics_changed"] is False
+
+
+# ---------------------------------------------------------------------------
+# W_FLAT_PREFIX_SCALAR — unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlatPrefixScalarDetector:
+    """Direct calls to _detect_flat_prefix_scalar."""
+
+    # --- Positive cases: must fire ---
+
+    def test_fires_on_three_siblings_with_shared_prefix(self):
+        """NODE_RUNTIME_FLOOR, NODE_RUNTIME_PIN_SITES, NODE_RUNTIME_WHY → fires."""
+        content = (
+            "===DOC===\n"
+            "META::\n"
+            "  TYPE::TEST\n"
+            "NODE_RUNTIME_FLOOR::3.12\n"
+            "NODE_RUNTIME_PIN_SITES::[a, b]\n"
+            "NODE_RUNTIME_WHY::performance\n"
+            "===END===\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" in codes
+
+    def test_fires_on_four_siblings_with_shared_prefix(self):
+        """Four sibling keys with shared prefix must trigger."""
+        content = (
+            "DB_HOST::localhost\n"
+            "DB_PORT::5432\n"
+            "DB_NAME::mydb\n"
+            "DB_USER::admin\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" in codes
+
+    def test_warning_message_names_the_prefix(self):
+        """Warning message must name the shared prefix."""
+        content = (
+            "NODE_RUNTIME_FLOOR::3.12\n"
+            "NODE_RUNTIME_PIN_SITES::[a, b]\n"
+            "NODE_RUNTIME_WHY::performance\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        assert hits, "Expected W_FLAT_PREFIX_SCALAR warning"
+        # Message should mention the prefix
+        assert any("NODE_RUNTIME" in w["message"] for w in hits)
+
+    def test_fires_with_mixed_depth_prefix(self):
+        """CACHE_READ, CACHE_WRITE, CACHE_EXPIRE at document root must fire."""
+        content = (
+            "CACHE_READ::fast\n"
+            "CACHE_WRITE::slow\n"
+            "CACHE_EXPIRE::300\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" in codes
+
+    # --- Negative cases: must NOT fire ---
+
+    def test_no_fire_on_two_siblings_with_shared_prefix(self):
+        """Only 2 siblings with shared prefix is below threshold — must NOT trigger."""
+        content = (
+            "NODE_RUNTIME_FLOOR::3.12\n"
+            "NODE_RUNTIME_WHY::performance\n"
+            "OTHER_KEY::value\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" not in codes
+
+    def test_no_fire_on_keys_without_shared_prefix(self):
+        """Keys that don't share a prefix must NOT trigger."""
+        content = (
+            "ALPHA_ONE::1\n"
+            "BETA_TWO::2\n"
+            "GAMMA_THREE::3\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" not in codes
+
+    def test_no_fire_on_single_underscore_segment_keys(self):
+        """Keys with no shared multi-segment prefix must NOT trigger.
+
+        E.g. FOO, BAR, BAZ all have no common prefix.
+        """
+        content = (
+            "FOO::1\n"
+            "BAR::2\n"
+            "BAZ::3\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" not in codes
+
+    def test_no_fire_in_literal_zone(self):
+        """Flat prefix pattern inside a literal zone must NOT trigger."""
+        content = "```\nDB_HOST::localhost\nDB_PORT::5432\nDB_NAME::mydb\n```\n"
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" not in codes
+
+    def test_no_fire_in_comment_lines(self):
+        """Keys that appear only in comment lines must NOT trigger."""
+        content = (
+            "// DB_HOST::localhost\n"
+            "// DB_PORT::5432\n"
+            "// DB_NAME::mydb\n"
+            "REAL_KEY::value\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" not in codes
+
+    # --- Warning shape ---
+
+    def test_warning_has_stable_code_line_and_provenance(self):
+        """Warning carries stable code, line number, safe=True, semantics_changed=False (I4)."""
+        content = (
+            "DB_HOST::localhost\n"
+            "DB_PORT::5432\n"
+            "DB_NAME::mydb\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        assert len(hits) >= 1
+        w = hits[0]
+        assert w["code"] == "W_FLAT_PREFIX_SCALAR"
+        assert "line" in w
+        assert w["safe"] is True
+        assert w["semantics_changed"] is False
+
+    def test_advisory_severity_only(self):
+        """W_FLAT_PREFIX_SCALAR must carry safe=True, semantics_changed=False."""
+        content = (
+            "CACHE_READ::fast\n"
+            "CACHE_WRITE::slow\n"
+            "CACHE_EXPIRE::300\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        for w in warnings:
+            if w["code"] == "W_FLAT_PREFIX_SCALAR":
+                assert w["safe"] is True
+                assert w["semantics_changed"] is False
+
+    def test_warning_message_references_nesting_suggestion(self):
+        """Warning message mentions nesting under a block parent."""
+        content = (
+            "CACHE_READ::fast\n"
+            "CACHE_WRITE::slow\n"
+            "CACHE_EXPIRE::300\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        assert hits
+        # Must mention nesting or the prefix block pattern
+        assert any("nest" in w["message"].lower() or "CACHE" in w["message"] for w in hits)
+
+
+# ---------------------------------------------------------------------------
+# ValidateTool integration — both warnings surface in warnings[]
+# ---------------------------------------------------------------------------
+
+
+class TestValidateToolInlineArrayRoot:
+    """W_INLINE_ARRAY_ROOT must surface in octave_validate warnings[]."""
+
+    FIXTURE = """\
+===VALIDATE_TEST===
+META:
+  TYPE::TEST
+SECTION::[A::1, B::2, C::3]
+===END===
+"""
+
+    @pytest.mark.asyncio
+    async def test_validate_tool_emits_inline_array_root_in_warnings(self):
+        tool = ValidateTool()
+        result = await tool.execute(content=self.FIXTURE, schema="META")
+        warnings = result.get("warnings", [])
+        codes = [w.get("code") for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" in codes
+
+    @pytest.mark.asyncio
+    async def test_validate_tool_does_not_block_on_inline_array_root(self):
+        """Advisory only — must NOT produce an error for W_INLINE_ARRAY_ROOT."""
+        tool = ValidateTool()
+        result = await tool.execute(content=self.FIXTURE, schema="META")
+        errors = result.get("errors", [])
+        assert not any(e.get("code") == "W_INLINE_ARRAY_ROOT" for e in errors)
+
+
+class TestValidateToolFlatPrefixScalar:
+    """W_FLAT_PREFIX_SCALAR must surface in octave_validate warnings[]."""
+
+    FIXTURE = """\
+===VALIDATE_TEST===
+META:
+  TYPE::TEST
+DB_HOST::localhost
+DB_PORT::5432
+DB_NAME::mydb
+===END===
+"""
+
+    @pytest.mark.asyncio
+    async def test_validate_tool_emits_flat_prefix_scalar_in_warnings(self):
+        tool = ValidateTool()
+        result = await tool.execute(content=self.FIXTURE, schema="META")
+        warnings = result.get("warnings", [])
+        codes = [w.get("code") for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" in codes
+
+    @pytest.mark.asyncio
+    async def test_validate_tool_does_not_block_on_flat_prefix_scalar(self):
+        """Advisory only — must NOT produce an error for W_FLAT_PREFIX_SCALAR."""
+        tool = ValidateTool()
+        result = await tool.execute(content=self.FIXTURE, schema="META")
+        errors = result.get("errors", [])
+        assert not any(e.get("code") == "W_FLAT_PREFIX_SCALAR" for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# WriteTool integration — both warnings surface in corrections[]
+# ---------------------------------------------------------------------------
+
+
+class TestWriteToolInlineArrayRoot:
+    """W_INLINE_ARRAY_ROOT must surface in WriteTool corrections[]."""
+
+    FIXTURE = """\
+===WRITE_TEST===
+META:
+  TYPE::TEST
+SECTION::[A::1, B::2, C::3]
+===END===
+"""
+
+    @pytest.mark.asyncio
+    async def test_write_tool_emits_inline_array_root_in_corrections(self, tmp_path):
+        tool = WriteTool()
+        target = str(tmp_path / "test.oct.md")
+        result = await tool.execute(target_path=target, content=self.FIXTURE)
+        corrections = result.get("corrections", [])
+        codes = [c["code"] for c in corrections]
+        assert "W_INLINE_ARRAY_ROOT" in codes
+
+    @pytest.mark.asyncio
+    async def test_write_tool_does_not_error_on_inline_array_root(self, tmp_path):
+        """Advisory only — must NOT block the write."""
+        tool = WriteTool()
+        target = str(tmp_path / "test.oct.md")
+        result = await tool.execute(target_path=target, content=self.FIXTURE)
+        assert result.get("status") != "error"
+        errors = result.get("errors", [])
+        assert not any(e.get("code") == "W_INLINE_ARRAY_ROOT" for e in errors)
+
+
+class TestWriteToolFlatPrefixScalar:
+    """W_FLAT_PREFIX_SCALAR must surface in WriteTool corrections[]."""
+
+    FIXTURE = """\
+===WRITE_TEST===
+META:
+  TYPE::TEST
+DB_HOST::localhost
+DB_PORT::5432
+DB_NAME::mydb
+===END===
+"""
+
+    @pytest.mark.asyncio
+    async def test_write_tool_emits_flat_prefix_scalar_in_corrections(self, tmp_path):
+        tool = WriteTool()
+        target = str(tmp_path / "test.oct.md")
+        result = await tool.execute(target_path=target, content=self.FIXTURE)
+        corrections = result.get("corrections", [])
+        codes = [c["code"] for c in corrections]
+        assert "W_FLAT_PREFIX_SCALAR" in codes
+
+    @pytest.mark.asyncio
+    async def test_write_tool_does_not_error_on_flat_prefix_scalar(self, tmp_path):
+        """Advisory only — must NOT block the write."""
+        tool = WriteTool()
+        target = str(tmp_path / "test.oct.md")
+        result = await tool.execute(target_path=target, content=self.FIXTURE)
+        assert result.get("status") != "error"
+        errors = result.get("errors", [])
+        assert not any(e.get("code") == "W_FLAT_PREFIX_SCALAR" for e in errors)

--- a/tests/unit/test_structural_advisory_warnings.py
+++ b/tests/unit/test_structural_advisory_warnings.py
@@ -449,3 +449,112 @@ DB_NAME::mydb
         assert result.get("status") != "error"
         errors = result.get("errors", [])
         assert not any(e.get("code") == "W_FLAT_PREFIX_SCALAR" for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# TMG advisory follow-ups (A1–A5 from TMG review)
+# ---------------------------------------------------------------------------
+
+
+class TestInlineArrayRootTMGAdvisory:
+    """TMG A1: tier assertion; TMG A5: long scalar list must NOT fire."""
+
+    def test_warning_tier_is_structural_check(self):
+        """A1: tier field must be STRUCTURAL_CHECK (not silently absent or wrong)."""
+        content = "SECTION::[A::1, B::2, C::3]\n"
+        warnings = _detect_inline_array_root(content)
+        hits = [w for w in warnings if w["code"] == "W_INLINE_ARRAY_ROOT"]
+        assert hits, "Expected W_INLINE_ARRAY_ROOT warning"
+        assert all(w["tier"] == "STRUCTURAL_CHECK" for w in hits)
+
+    def test_long_scalar_list_does_not_fire(self):
+        """A5: a >80-char scalar list (no '::') must NOT trigger — map discriminator guards this."""
+        # Scalars, no K::V syntax. Length > 80 chars.
+        long_scalars = ", ".join([f"item_{i:03d}" for i in range(15)])
+        content = f"LONG_ITEMS::[{long_scalars}]\n"
+        assert len(long_scalars) > 80, "Fixture must be > 80 chars to exercise length branch"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+
+class TestFlatPrefixScalarTMGAdvisory:
+    """TMG A1/A2/A3/A4 follow-ups for W_FLAT_PREFIX_SCALAR."""
+
+    def test_warning_tier_is_structural_check(self):
+        """A1: tier field must be STRUCTURAL_CHECK."""
+        content = (
+            "DB_HOST::localhost\n"
+            "DB_PORT::5432\n"
+            "DB_NAME::mydb\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        assert hits, "Expected W_FLAT_PREFIX_SCALAR warning"
+        assert all(w["tier"] == "STRUCTURAL_CHECK" for w in hits)
+
+    def test_dedup_emits_exactly_one_warning_per_group(self):
+        """A2: deduplication logic — NODE_RUNTIME_* group must emit exactly one warning.
+
+        Without dedup, the multi-prefix algorithm could emit both under
+        prefix 'NODE' and prefix 'NODE_RUNTIME' for the same key set.
+        """
+        content = (
+            "NODE_RUNTIME_FLOOR::3.12\n"
+            "NODE_RUNTIME_PIN_SITES::[a, b]\n"
+            "NODE_RUNTIME_WHY::performance\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        assert len(hits) == 1, (
+            f"Expected exactly 1 W_FLAT_PREFIX_SCALAR warning for NODE_RUNTIME_* group, "
+            f"got {len(hits)}: {[w['prefix'] for w in hits]}"
+        )
+
+    def test_mixed_indent_keys_not_grouped_across_indents(self):
+        """A3: sibling-by-indentation — same prefix at different indent levels must NOT be grouped.
+
+        DB_HOST at indent 0 and indented DB_HOST::... at indent 2 are not siblings.
+        """
+        content = (
+            "DB_HOST::localhost\n"
+            "DB_PORT::5432\n"
+            "SECTION:\n"
+            "  DB_NAME::inner\n"
+            "  DB_USER::inner_user\n"
+            "  DB_PASS::inner_pass\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        # Top-level DB_HOST + DB_PORT = 2 only (below threshold).
+        # Indented DB_NAME + DB_USER + DB_PASS = 3 (triggers for indented group).
+        # They must NOT be merged into one cross-indent group of 5.
+        for hit in hits:
+            key_list = hit["keys"]
+            # No warning should contain keys from BOTH indent levels.
+            has_top_level = any(k in ("DB_HOST", "DB_PORT") for k in key_list)
+            has_indented = any(k in ("DB_NAME", "DB_USER", "DB_PASS") for k in key_list)
+            assert not (has_top_level and has_indented), (
+                f"Cross-indent grouping detected: {key_list}"
+            )
+
+    def test_block_form_siblings_detected(self):
+        """A4: block-form siblings (KEY: child) should also trigger after regex fix.
+
+        After fixing the [:s] typo to [:\\s], a 'KEY: ' (block-open with space)
+        form is also matched. Three such siblings at the same level should trigger.
+        """
+        # Block-open form: DB_HOST: followed by value on next line would be
+        # `DB_HOST:\n  value`, but at the key-scan level we match the opener line.
+        # The simplest form that exercises the \\s branch: `KEY: value` (space after colon).
+        content = (
+            "DB_HOST: localhost\n"
+            "DB_PORT: 5432\n"
+            "DB_NAME: mydb\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_FLAT_PREFIX_SCALAR" in codes, (
+            "Block-form (KEY: value with space) siblings must also trigger "
+            "W_FLAT_PREFIX_SCALAR after regex fix."
+        )

--- a/tests/unit/test_structural_advisory_warnings.py
+++ b/tests/unit/test_structural_advisory_warnings.py
@@ -182,23 +182,14 @@ class TestFlatPrefixScalarDetector:
 
     def test_fires_on_four_siblings_with_shared_prefix(self):
         """Four sibling keys with shared prefix must trigger."""
-        content = (
-            "DB_HOST::localhost\n"
-            "DB_PORT::5432\n"
-            "DB_NAME::mydb\n"
-            "DB_USER::admin\n"
-        )
+        content = "DB_HOST::localhost\n" "DB_PORT::5432\n" "DB_NAME::mydb\n" "DB_USER::admin\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" in codes
 
     def test_warning_message_names_the_prefix(self):
         """Warning message must name the shared prefix."""
-        content = (
-            "NODE_RUNTIME_FLOOR::3.12\n"
-            "NODE_RUNTIME_PIN_SITES::[a, b]\n"
-            "NODE_RUNTIME_WHY::performance\n"
-        )
+        content = "NODE_RUNTIME_FLOOR::3.12\n" "NODE_RUNTIME_PIN_SITES::[a, b]\n" "NODE_RUNTIME_WHY::performance\n"
         warnings = _detect_flat_prefix_scalar(content)
         hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
         assert hits, "Expected W_FLAT_PREFIX_SCALAR warning"
@@ -207,11 +198,7 @@ class TestFlatPrefixScalarDetector:
 
     def test_fires_with_mixed_depth_prefix(self):
         """CACHE_READ, CACHE_WRITE, CACHE_EXPIRE at document root must fire."""
-        content = (
-            "CACHE_READ::fast\n"
-            "CACHE_WRITE::slow\n"
-            "CACHE_EXPIRE::300\n"
-        )
+        content = "CACHE_READ::fast\n" "CACHE_WRITE::slow\n" "CACHE_EXPIRE::300\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" in codes
@@ -220,22 +207,14 @@ class TestFlatPrefixScalarDetector:
 
     def test_no_fire_on_two_siblings_with_shared_prefix(self):
         """Only 2 siblings with shared prefix is below threshold — must NOT trigger."""
-        content = (
-            "NODE_RUNTIME_FLOOR::3.12\n"
-            "NODE_RUNTIME_WHY::performance\n"
-            "OTHER_KEY::value\n"
-        )
+        content = "NODE_RUNTIME_FLOOR::3.12\n" "NODE_RUNTIME_WHY::performance\n" "OTHER_KEY::value\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" not in codes
 
     def test_no_fire_on_keys_without_shared_prefix(self):
         """Keys that don't share a prefix must NOT trigger."""
-        content = (
-            "ALPHA_ONE::1\n"
-            "BETA_TWO::2\n"
-            "GAMMA_THREE::3\n"
-        )
+        content = "ALPHA_ONE::1\n" "BETA_TWO::2\n" "GAMMA_THREE::3\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" not in codes
@@ -245,11 +224,7 @@ class TestFlatPrefixScalarDetector:
 
         E.g. FOO, BAR, BAZ all have no common prefix.
         """
-        content = (
-            "FOO::1\n"
-            "BAR::2\n"
-            "BAZ::3\n"
-        )
+        content = "FOO::1\n" "BAR::2\n" "BAZ::3\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" not in codes
@@ -263,12 +238,7 @@ class TestFlatPrefixScalarDetector:
 
     def test_no_fire_in_comment_lines(self):
         """Keys that appear only in comment lines must NOT trigger."""
-        content = (
-            "// DB_HOST::localhost\n"
-            "// DB_PORT::5432\n"
-            "// DB_NAME::mydb\n"
-            "REAL_KEY::value\n"
-        )
+        content = "// DB_HOST::localhost\n" "// DB_PORT::5432\n" "// DB_NAME::mydb\n" "REAL_KEY::value\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" not in codes
@@ -277,11 +247,7 @@ class TestFlatPrefixScalarDetector:
 
     def test_warning_has_stable_code_line_and_provenance(self):
         """Warning carries stable code, line number, safe=True, semantics_changed=False (I4)."""
-        content = (
-            "DB_HOST::localhost\n"
-            "DB_PORT::5432\n"
-            "DB_NAME::mydb\n"
-        )
+        content = "DB_HOST::localhost\n" "DB_PORT::5432\n" "DB_NAME::mydb\n"
         warnings = _detect_flat_prefix_scalar(content)
         hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
         assert len(hits) >= 1
@@ -293,11 +259,7 @@ class TestFlatPrefixScalarDetector:
 
     def test_advisory_severity_only(self):
         """W_FLAT_PREFIX_SCALAR must carry safe=True, semantics_changed=False."""
-        content = (
-            "CACHE_READ::fast\n"
-            "CACHE_WRITE::slow\n"
-            "CACHE_EXPIRE::300\n"
-        )
+        content = "CACHE_READ::fast\n" "CACHE_WRITE::slow\n" "CACHE_EXPIRE::300\n"
         warnings = _detect_flat_prefix_scalar(content)
         for w in warnings:
             if w["code"] == "W_FLAT_PREFIX_SCALAR":
@@ -306,11 +268,7 @@ class TestFlatPrefixScalarDetector:
 
     def test_warning_message_references_nesting_suggestion(self):
         """Warning message mentions nesting under a block parent."""
-        content = (
-            "CACHE_READ::fast\n"
-            "CACHE_WRITE::slow\n"
-            "CACHE_EXPIRE::300\n"
-        )
+        content = "CACHE_READ::fast\n" "CACHE_WRITE::slow\n" "CACHE_EXPIRE::300\n"
         warnings = _detect_flat_prefix_scalar(content)
         hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
         assert hits
@@ -482,11 +440,7 @@ class TestFlatPrefixScalarTMGAdvisory:
 
     def test_warning_tier_is_structural_check(self):
         """A1: tier field must be STRUCTURAL_CHECK."""
-        content = (
-            "DB_HOST::localhost\n"
-            "DB_PORT::5432\n"
-            "DB_NAME::mydb\n"
-        )
+        content = "DB_HOST::localhost\n" "DB_PORT::5432\n" "DB_NAME::mydb\n"
         warnings = _detect_flat_prefix_scalar(content)
         hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
         assert hits, "Expected W_FLAT_PREFIX_SCALAR warning"
@@ -498,11 +452,7 @@ class TestFlatPrefixScalarTMGAdvisory:
         Without dedup, the multi-prefix algorithm could emit both under
         prefix 'NODE' and prefix 'NODE_RUNTIME' for the same key set.
         """
-        content = (
-            "NODE_RUNTIME_FLOOR::3.12\n"
-            "NODE_RUNTIME_PIN_SITES::[a, b]\n"
-            "NODE_RUNTIME_WHY::performance\n"
-        )
+        content = "NODE_RUNTIME_FLOOR::3.12\n" "NODE_RUNTIME_PIN_SITES::[a, b]\n" "NODE_RUNTIME_WHY::performance\n"
         warnings = _detect_flat_prefix_scalar(content)
         hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
         assert len(hits) == 1, (
@@ -533,9 +483,7 @@ class TestFlatPrefixScalarTMGAdvisory:
             # No warning should contain keys from BOTH indent levels.
             has_top_level = any(k in ("DB_HOST", "DB_PORT") for k in key_list)
             has_indented = any(k in ("DB_NAME", "DB_USER", "DB_PASS") for k in key_list)
-            assert not (has_top_level and has_indented), (
-                f"Cross-indent grouping detected: {key_list}"
-            )
+            assert not (has_top_level and has_indented), f"Cross-indent grouping detected: {key_list}"
 
     def test_block_form_siblings_detected(self):
         """A4: block-form siblings (KEY: child) should also trigger after regex fix.
@@ -546,16 +494,11 @@ class TestFlatPrefixScalarTMGAdvisory:
         # Block-open form: DB_HOST: followed by value on next line would be
         # `DB_HOST:\n  value`, but at the key-scan level we match the opener line.
         # The simplest form that exercises the \\s branch: `KEY: value` (space after colon).
-        content = (
-            "DB_HOST: localhost\n"
-            "DB_PORT: 5432\n"
-            "DB_NAME: mydb\n"
-        )
+        content = "DB_HOST: localhost\n" "DB_PORT: 5432\n" "DB_NAME: mydb\n"
         warnings = _detect_flat_prefix_scalar(content)
         codes = [w["code"] for w in warnings]
         assert "W_FLAT_PREFIX_SCALAR" in codes, (
-            "Block-form (KEY: value with space) siblings must also trigger "
-            "W_FLAT_PREFIX_SCALAR after regex fix."
+            "Block-form (KEY: value with space) siblings must also trigger " "W_FLAT_PREFIX_SCALAR after regex fix."
         )
 
     def test_no_false_positive_across_different_parent_blocks(self):
@@ -564,13 +507,7 @@ class TestFlatPrefixScalarTMGAdvisory:
         SECTION_A:\n  DB_HOST and SECTION_B:\n  DB_NAME are NOT siblings even if
         both are indented equally — they have different parents.
         """
-        content = (
-            "SECTION_A:\n"
-            "  DB_HOST::localhost\n"
-            "  DB_PORT::5432\n"
-            "SECTION_B:\n"
-            "  DB_NAME::mydb\n"
-        )
+        content = "SECTION_A:\n" "  DB_HOST::localhost\n" "  DB_PORT::5432\n" "SECTION_B:\n" "  DB_NAME::mydb\n"
         warnings = _detect_flat_prefix_scalar(content)
         hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
         # DB_HOST + DB_PORT = 2 (below threshold in SECTION_A group).
@@ -580,9 +517,7 @@ class TestFlatPrefixScalarTMGAdvisory:
             key_list = hit["keys"]
             has_section_a = any(k in ("DB_HOST", "DB_PORT") for k in key_list)
             has_section_b = any(k in ("DB_NAME",) for k in key_list)
-            assert not (has_section_a and has_section_b), (
-                f"Cross-parent-block grouping detected: {key_list}"
-            )
+            assert not (has_section_a and has_section_b), f"Cross-parent-block grouping detected: {key_list}"
 
 
 class TestInlineArrayRootCRSAdvisory:

--- a/tests/unit/test_structural_advisory_warnings.py
+++ b/tests/unit/test_structural_advisory_warnings.py
@@ -558,3 +558,68 @@ class TestFlatPrefixScalarTMGAdvisory:
             "Block-form (KEY: value with space) siblings must also trigger "
             "W_FLAT_PREFIX_SCALAR after regex fix."
         )
+
+    def test_no_false_positive_across_different_parent_blocks(self):
+        """CRS-1: Keys in different parent blocks must NOT be grouped as siblings.
+
+        SECTION_A:\n  DB_HOST and SECTION_B:\n  DB_NAME are NOT siblings even if
+        both are indented equally — they have different parents.
+        """
+        content = (
+            "SECTION_A:\n"
+            "  DB_HOST::localhost\n"
+            "  DB_PORT::5432\n"
+            "SECTION_B:\n"
+            "  DB_NAME::mydb\n"
+        )
+        warnings = _detect_flat_prefix_scalar(content)
+        hits = [w for w in warnings if w["code"] == "W_FLAT_PREFIX_SCALAR"]
+        # DB_HOST + DB_PORT = 2 (below threshold in SECTION_A group).
+        # DB_NAME = 1 (only key in SECTION_B group).
+        # No cross-block group of 3+ should form.
+        for hit in hits:
+            key_list = hit["keys"]
+            has_section_a = any(k in ("DB_HOST", "DB_PORT") for k in key_list)
+            has_section_b = any(k in ("DB_NAME",) for k in key_list)
+            assert not (has_section_a and has_section_b), (
+                f"Cross-parent-block grouping detected: {key_list}"
+            )
+
+
+class TestInlineArrayRootCRSAdvisory:
+    """CRS advisory follow-ups for W_INLINE_ARRAY_ROOT."""
+
+    def test_no_false_positive_when_double_colon_in_quoted_string(self):
+        """CRS-2: '::' appearing only inside a quoted string element must NOT trigger.
+
+        SECTION::[\"note, A::x\"] — the '::' is inside a quote, not a map entry.
+        """
+        # Only one quoted scalar element containing '::'; no unquoted K::V entries.
+        content = 'SECTION::["note with A::x embedded"]\n'
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_false_positive_mixed_scalar_map_below_threshold(self):
+        """CRS-3: Mixed array with 1 map entry and 2 scalars must NOT trigger.
+
+        Entry count threshold (>= 3 map entries) guards against firing when only
+        one element is a K::V pair and the rest are scalars.
+        """
+        # One map entry + two scalars = 1 map-entry, below threshold of 3.
+        content = "SECTION::[A::1, scalar_b, scalar_c]\n"
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        assert "W_INLINE_ARRAY_ROOT" not in codes
+
+    def test_no_false_positive_closing_bracket_in_quoted_value(self):
+        """CRS-2: A ']' inside a quoted string value must NOT close the array scan early.
+
+        Without quote-protection, SECTION::[A::'foo]', B::2, C::3] would close
+        prematurely on the ']' inside the first quoted value.
+        """
+        content = 'SECTION::[A::"foo]", B::2, C::3]\n'
+        warnings = _detect_inline_array_root(content)
+        codes = [w["code"] for w in warnings]
+        # The array has 3 unquoted map-entry elements after correct bracket tracking.
+        assert "W_INLINE_ARRAY_ROOT" in codes


### PR DESCRIPTION
## Summary
- Implement structural advisory warnings (W_INLINE_ARRAY_ROOT, W_FLAT_PREFIX_SCALAR) to detect problematic MCP patterns early
- Address TMG/CRS/CE review findings by fixing validation logic, error code naming, and guard conditions
- Add comprehensive test coverage for nested dict rejection in MERGE mode and structural advisory detection

## Changes
**Structural Advisory Warnings**
- New `write_detection.py` module implements W_INLINE_ARRAY_ROOT and W_FLAT_PREFIX_SCALAR pattern detection
- `validate.py` integrates advisory warnings into validation pipeline per TMG findings A1-A5

**Review Findings Fixes**
- Rename error code and simplify guard logic in write.py (TMG/CRS/CE)
- Fix backslash-parity quote scanning and remove dead-logic guard (CE findings)
- Correct W_INLINE_ARRAY_ROOT and W_FLAT_PREFIX_SCALAR validation per CRS findings

**Test Coverage**
- RED/GREEN tests for E_NESTED_DICT_IN_CHANGES_MODE guard in test_gh484_nested_dict_in_changes_mode.py
- 625-line structural advisory warning test suite covering edge cases and pattern detection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two structural advisory warnings and rejects nested dicts in MERGE payloads to prevent invalid inline-map emission. Resolves TMG/CRS/CE findings with safer scanning, clearer errors, and P2 follow-ups.

- **New Features**
  - `W_INLINE_ARRAY_ROOT` (detects map-as-inline-array; >=3 K::V elements or long arrays). Advisory only; surfaced in validate warnings and write corrections.
  - `W_FLAT_PREFIX_SCALAR` (>=3 sibling keys share a redundant underscore prefix). Advisory only; surfaced in validate warnings and write corrections.

- **Bug Fixes**
  - MERGE guard: reject any non-DELETE-sentinel dicts in payloads with `E_NESTED_DICT_IN_MERGE_PAYLOAD`; message lists offending keys and directs to content + format_style=preserve.
  - Detector hardening: shared backslash-parity quote handling; quote/comment-aware bracket scan with unclosed-array guard; correct sibling grouping by parent/indent; fixed key regex to `[:\s]` with end-anchor to match bare `KEY:` lines; count only true map-entry elements; plus cleanups and RED/GREEN tests (lint sorted).

<sup>Written for commit b815aaedd668951e8182d84abe7baf96143a54c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

