### PR TITLE
fix(#487): Phase 1a — detect nested BLOCK-vs-flat same-name collision in octave_validate

### DIFF
--- a/src/octave_mcp/core/parser.py
+++ b/src/octave_mcp/core/parser.py
@@ -1268,8 +1268,11 @@ class Parser:
                 pending_comments = []  # Reset after passing to child
                 pending_comments_start_byte = None
                 if child:
-                    # GH#294: Track duplicate keys in section children
-                    if isinstance(child, Assignment):
+                    # GH#294: Track duplicate keys in section children.
+                    # GH#487 (R2): also register Block children, not just Assignment,
+                    # so a BLOCK-key colliding with a flat-scalar of the same name in
+                    # the same scope is detected (e.g. ``CHEVRON:`` then ``CHEVRON::x``).
+                    if isinstance(child, (Assignment, Block)):
                         child_key = child.key
                         child_line = child.line
                         if child_key in section_key_positions:
@@ -1637,8 +1640,11 @@ class Parser:
                     pending_comments = []  # Reset after passing to child
                     pending_comments_start_byte = None
                     if child:
-                        # GH#294: Track duplicate keys in block children
-                        if isinstance(child, Assignment):
+                        # GH#294: Track duplicate keys in block children.
+                        # GH#487 (R2): also register Block children, not just Assignment,
+                        # so a BLOCK-key colliding with a flat-scalar of the same name in
+                        # the same scope is detected (e.g. ``CHEVRON:`` then ``CHEVRON::x``).
+                        if isinstance(child, (Assignment, Block)):
                             child_key = child.key
                             child_line = child.line
                             if child_key in block_key_positions:

--- a/tests/unit/test_changes_mode_roundtrip_characterization.py
+++ b/tests/unit/test_changes_mode_roundtrip_characterization.py
@@ -59,7 +59,8 @@ The ratified contract (debate-hall decision_hash a8837c80…, operator-ratified 
   bare-scalar over an existing nested BLOCK (no $op)    | success, DUPLICATE keys (BLOCK + | #443   | full replace BLOCK w/ scalar; NEVER duplicate
                                                         | flat scalar same scope)          |Defect2 | keys
   validate: flat-vs-flat top-level duplicate            | duplicate_key in repair_log      | (R2)   | invariant — stays detected (pin)
-  validate: BLOCK-key vs flat-scalar same name in block | NOT in repair_log (undetected)   | #443/R2| should be caught (duplicate_key or error)
+  validate: BLOCK-key vs flat-scalar same name in block | duplicate_key in repair_log      | #443/R2| caught (duplicate_key) — FIXED GH#487 Ph1a
+                                                        | (DETECTED — GH#487 Phase 1a)     |        | (parser detector registers Block children)
   --- CDV CONDITIONAL-GO blind cells (added Phase 0+, gemini critical-design-validator) ---------
   bare-dict FULL REPLACE re-mentioning a LITERAL-ZONE   | success, SILENT MERGE: fence form| #460-A | REPLACE: fence form of MENTIONED child still
     child (fenced ```...```) at a top-level Block        | of mentioned child IS preserved  | #487   | preserved (route via _normalize_value_for_ast_
@@ -423,14 +424,16 @@ class TestCharacterizationKnownDefects:
         ), f"current bug: duplicate PARENT keys expected; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    async def test_validate_block_vs_flat_collision_undetected_gh443(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#443 / R2)
+    async def test_validate_block_vs_flat_collision_detected_gh443(self) -> None:
+        """INVERTED (GH#487 Phase 1a, R2): BLOCK-vs-flat same-name collision IS now detected.
 
-        A hand-authored BLOCK-key (``CHEVRON:``) colliding with a flat-scalar of the same name
-        inside the same parent block is NOT detected by the validator: it validates clean
-        (``VALIDATED`` / ``valid: true``) with NO ``duplicate_key`` repair entry. This is the
-        validator-coverage gap the contract folds into Phase 0 — emit-time canonicalization alone
-        won't make ``validate`` see it; a validator-side fix is required.
+        Previously a characterization pin asserting the validator-coverage GAP: a hand-authored
+        BLOCK-key (``CHEVRON:``) colliding with a flat-scalar of the same name inside the same
+        parent block validated clean with NO ``duplicate_key`` repair entry. The GH#487 Phase 1a
+        parser fix (extend the single duplicate-key detector to register Block children, not just
+        Assignment) closes that gap. This cell is inverted to assert the collision is now caught;
+        it is the converse of the desired-contract cell ``test_validate_block_vs_flat_collision_caught``
+        and is retained as the negative-history pin documenting the fixed behaviour.
         """
         doc = (
             "===EXAMPLE===\n"
@@ -447,8 +450,8 @@ class TestCharacterizationKnownDefects:
         result = await _VALIDATE.execute(content=doc, schema="META", profile="STANDARD")
         subtypes = [e.get("subtype") for e in result.get("repair_log", [])]
         assert (
-            "duplicate_key" not in subtypes
-        ), f"current bug: BLOCK-vs-flat collision should be UNDETECTED; repair_log={result.get('repair_log')}"
+            "duplicate_key" in subtypes
+        ), f"GH#487: BLOCK-vs-flat collision must now be DETECTED; repair_log={result.get('repair_log')}"
 
     @pytest.mark.asyncio
     async def test_literal_zone_replace_silent_merge_keeps_sibling_gh460a(self) -> None:
@@ -661,13 +664,11 @@ class TestDesiredContractValidatorCoverage:
     """#443 / R2 validator-coverage: BLOCK-key vs flat-scalar collision must be caught."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#443 (validator gap) + GH#487 contract (R2 validator-coverage): a BLOCK-key "
-        "colliding with a flat-scalar of the same name inside a parent block MUST be caught by "
-        "octave_validate (duplicate_key repair entry or a hard error) — currently undetected.",
-        strict=True,
-    )
     async def test_validate_block_vs_flat_collision_caught(self) -> None:
+        # GH#487 Phase 1a (R2 validator-coverage): a BLOCK-key colliding with a
+        # flat-scalar of the same name inside a parent block is now caught by
+        # octave_validate (duplicate_key repair entry). xfail marker removed when
+        # the parser duplicate-key detector was extended to register Block children.
         doc = (
             "===EXAMPLE===\n"
             "META:\n"


### PR DESCRIPTION
## Summary

**GH#487 Phase 1a — standalone validator fix (ships FIRST, per the CDV CONDITIONAL-GO sequencing decision).**

`octave_validate` caught a pure flat-vs-flat top-level duplicate key, but did **not** catch a BLOCK-key colliding with a flat-scalar of the **same name inside a parent block**. The reproduction doc below validated clean (`valid:true`, no `duplicate_key` repair entry) — that was the bug (R2 validator-coverage gap; folds GH#443 Defect 2):

```
===EXAMPLE===
META:
  TYPE::TEST
  VERSION::"1.0"
PARENT:
  CHEVRON:
    deep::x
  PKG::y
  CHEVRON::migrated
===END===
```

`CHEVRON` appears twice inside `PARENT` (once as a BLOCK header, once as a flat scalar) and is now surfaced as a `duplicate_key` repair entry.

## Root cause & fix

The lenient duplicate-key detector in `src/octave_mcp/core/parser.py` registered only `Assignment` children in the same-scope key-position map, ignoring `Block` children. A `CHEVRON:` block header therefore never seeded the map, so the later `CHEVRON::migrated` scalar found no prior occurrence.

Fix: extend the **single existing detector** to register `Block` children as well (`isinstance(child, (Assignment, Block))`) at both the section-children and block-children tracking sites.

- **INTERNAL impact** — detector signature unchanged; no parallel validator introduced (honours North Star R2 `validator_drift`).
- **I5 schema sovereignty** — the collision is now visible in `octave_validate` output.
- **Scope fence held** — no `write.py` / `write_mutation.py` / emit / canonicalization / DocumentMutator changes. Phase 2 (Strategy S3 DocumentMutator extraction) remains deferred.

## TDD evidence (RED → GREEN)

- `test_validate_block_vs_flat_collision_caught` — `xfail(strict=True)` marker **removed**; now GREEN (collision caught).
- Coupled characterization pin inverted: `test_validate_block_vs_flat_collision_undetected_gh443` → `test_validate_block_vs_flat_collision_detected_gh443`, asserting detection instead of the old buggy non-detection; cell-roster table updated.
- Invariant `test_validate_flat_vs_flat_duplicate_is_detected` — unchanged, still passes (no regression).

## Quality gates

- `ruff check src tests` — clean
- `black --check src tests` — clean
- `mypy src` — clean
- `pytest` — **+1 passed / -1 xfailed** vs baseline (the block-vs-flat xfail flipped GREEN).

> Note: two **pre-existing, unrelated** failures in `tests/unit/test_agent_definition_schema.py` (`ideator.oct.md`, `synthesizer.oct.md` — external agent-file roster drift) are present on the clean baseline (commit 7a6359e) and are untouched by this change. Verified via `git stash`.

## Files changed
- `src/octave_mcp/core/parser.py` (+14/-6)
- `tests/unit/test_changes_mode_roundtrip_characterization.py` (coupled test cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects and reports nested BLOCK-vs-flat same-name collisions in `octave_validate`. Cases like a `CHEVRON:` block and `CHEVRON::migrated` scalar under the same parent now emit a `duplicate_key` repair entry.

- **Bug Fixes**
  - Extended the duplicate-key detector in `src/octave_mcp/core/parser.py` to register `Block` children alongside `Assignment` at both section and block scopes.
  - Updated tests: inverted the prior characterization test to assert detection and removed the xfail from the desired contract test; flat-vs-flat invariant unchanged.

<sup>Written for commit bed2cab1883e0688f8ccffebb04a782216d567c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

