### PR TITLE
feat(#487)!: Phase 2 DocumentMutator — changes-mode value semantics (HARD BREAK v1.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚠️ BREAKING — `octave_write` `changes` mode value semantics (GH#487, v1.15.0)
+
+> **Migration in one line:** a **bare dict** at a `changes` KEY now **fully replaces** that key (unmentioned children are **dropped**). To merge into an existing block, you **MUST** now send an explicit `{"$op": "MERGE", "value": {…}}`.
+
+This is the STRATEGY_S3 `DocumentMutator` extraction implementing the operator-ratified, debate-hall-settled (`decision_hash a8837c80…`) + CDV CONDITIONAL-GO contract. Transition logic and structural AST synthesis are now owned by a single `DocumentMutator` layer (`src/octave_mcp/mcp/document_mutator.py`); the emitter remains the sole canonicalizer-to-bytes (R2: one mutation path, no serialization-policy split, no node indentation metadata added).
+
+- **Q1 — bare-dict at a top-level KEY = FULL REPLACE (#443a, HARD BREAK).** `changes={"PARENT": {"NEW_CHILD": "x"}}` against an existing `PARENT` block now **replaces** the block's children with the payload: **unmentioned children are DROPPED** (honours PROD::I3 — reflect only what's present). The previous silent implicit-MERGE (unmentioned children preserved + new child appended) is removed. **No** `$op:REPLACE` op is introduced — bare-dict carries replace semantics directly.
+  - **Key-wise reconciliation (CDV BLOCKING-1):** a key present in BOTH payload and target is **form-preserved** — routed through the #460 fence-preserving path, so a re-mentioned literal-zone (fenced ```` ``` ````) child keeps its fence FORM while unmentioned siblings are dropped (PROD::I1 intact).
+  - **Migration:** callers that relied on bare-dict merging **MUST** switch to `changes={"PARENT": {"$op": "MERGE", "value": {"NEW_CHILD": "x"}}}` to preserve unmentioned children. Blast radius is small at current usage; accepted by operator as a hard break.
+- **Q1 — bare-scalar over a nested BLOCK = FULL REPLACE (#443 Defect 2).** A bare scalar assigned to a KEY that holds a block now **replaces the block in place** with a single flat assignment (exactly one key emitted), curing the prior duplicate-keys footgun (block left in place AND a flat scalar of the same name appended at the same scope).
+- **Defect 2 — scalar-over-nested-BLOCK via `$op:MERGE` = REJECT (#443).** A `$op:MERGE` whose payload would replace an existing **child block** with a **scalar** is now **rejected with `E_OP_TARGET_MISMATCH`** (CDV firmed the scalar↔BLOCK transition to REJECT-only, never silently honour). To replace a block with a scalar, DELETE it first or send a bare-dict REPLACE at the parent. **Never emits duplicate keys.** Surfaced pre-apply by `octave_validate` and defended apply-side.
+- **Q2 — deferred canonicalization: nested dicts emit BLOCK form (#440).** A bare dict with a **nested** dict value is now synthesized as canonical **BLOCK** form (the sole canonical nested form) instead of the legacy `dict→InlineMap` coercion (which re-parsed to `E_NESTED_INLINE_MAP`). The `dict→InlineMap` coercion is **abolished** for nested dicts. Every such conversion is logged to the I4 audit channel as `TRANSFORM::INLINE_MAP_TO_BLOCK` (stable rule id `TN_INLINE_MAP_TO_BLOCK`) with the key as the stable structural id (PROD::I4). A **flat** dict (all scalar/list values) is unchanged — it still emits as a re-parseable inline map.
+- **#488 — APPEND/PREPEND of nested list/dict elements now re-parseable.** `$op:APPEND`/`$op:PREPEND` of a nested list (`[["PR::x"]]`) or dict (`[{"K": "v"}]`) element previously emitted a Python repr (`['PR::x']` single-quoted, or `{'K': 'v'}` with braces) that failed strict re-parse (E005) while reporting `status:success` — an I1 round-trip false-green. New list items are now normalized at the mutation seam so they emit as re-parseable OCTAVE (double-quoted strings; bare `k::v` pairs in multi-line lists).
+- **#484 guard retained.** The `E_NESTED_DICT_IN_MERGE_PAYLOAD` guard for nested dicts in `$op:MERGE` payloads is **unchanged** and continues to fire **only** under explicit `$op:MERGE`; the new bare-dict REPLACE path emits BLOCK form instead and is never blocked by the guard.
+
+`octave_validate` (read path) is unchanged: it continues to ACCEPT inline maps and report `W_INLINE_ARRAY_ROOT` without mutating the source (PROD::I5).
+
 ## [1.14.0] - 2026-05-30 - "octave_write changes-mode hybrid fix (anchored paths + literal-zone fidelity)"
 
 ### Added

--- a/src/octave_mcp/core/grammar/tier_normalize.py
+++ b/src/octave_mcp/core/grammar/tier_normalize.py
@@ -80,6 +80,14 @@ audit receipt covering blank-line stripping (until Sprint 3+ trivia
 population lands) and triple-quote collapse (until the new lexer W-code
 lands)."""
 
+RULE_INLINE_MAP_TO_BLOCK = "TN_INLINE_MAP_TO_BLOCK"
+"""GH#487 Q2 (#440) DEFERRED_CANONICALIZATION: changes-mode synthesised a
+canonical BLOCK node for a nested dict value instead of the legacy nested
+``InlineMap`` coercion (which re-parsed to E_NESTED_INLINE_MAP). Fires once per
+nested dict synthesised, recording the structural id of the key. BLOCK is the
+sole canonical nested form (Wall M1); the surfaced audit atom is
+``TRANSFORM::INLINE_MAP_TO_BLOCK`` (I4 TRANSFORM_AUDITABILITY)."""
+
 
 # ---------------------------------------------------------------------------
 # Active-log context (thread / async safe)
@@ -273,6 +281,7 @@ def reconcile_canonical_emission(
 
 __all__ = [
     "RULE_IDENTIFIER_DEQUOTE",
+    "RULE_INLINE_MAP_TO_BLOCK",
     "RULE_RECONCILE_CANONICAL",
     "active",
     "get_active_log",

--- a/src/octave_mcp/mcp/document_mutator.py
+++ b/src/octave_mcp/mcp/document_mutator.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from octave_mcp.core.grammar import tier_normalize
 from octave_mcp.core.grammar.cst import (
     Assignment,
     Block,
@@ -448,11 +449,73 @@ class DocumentMutator:
 
         # If not found and not deleting, add new field
         if not found:
-            # Create new assignment node with normalized value.
-            # PR-2 T6: new Assignment is born dirty (no source
-            # bytes to splice; its value MUST be re-emitted).
-            new_assignment = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
-            doc.sections.append(new_assignment)
+            # GH#487 Q2 (#440): a bare dict with NESTED dict values is synthesized
+            # as a canonical BLOCK (sole canonical nested form), not a nested
+            # InlineMap (which re-parses to E_NESTED_INLINE_MAP). The transform is
+            # I4-logged (TRANSFORM::INLINE_MAP_TO_BLOCK). A flat dict (all
+            # scalar/list values) stays an InlineMap — re-parseable inline OCTAVE.
+            if isinstance(new_value, dict) and not _is_op_descriptor(new_value) and self._has_nested_dict(new_value):
+                doc.sections.append(self._synthesize_block_from_dict(key, new_value))
+            else:
+                # Create new assignment node with normalized value.
+                # PR-2 T6: new Assignment is born dirty (no source
+                # bytes to splice; its value MUST be re-emitted).
+                new_assignment = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
+                doc.sections.append(new_assignment)
+
+    # ------------------------------------------------------------------
+    # Synthesis primitives (GH#487 B-4: Q2 dict -> BLOCK + I4 audit)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _synthesize_block_from_dict(key: str, payload: dict[str, Any]) -> Block:
+        """GH#487 Q2 (#440): synthesize a born-dirty canonical ``Block`` from a dict.
+
+        BLOCK is the sole canonical nested form (Wall M1); the legacy dict ->
+        ``InlineMap`` coercion (which re-parsed to E_NESTED_INLINE_MAP for nested
+        dicts) is abolished. Each value is built recursively:
+          - nested dict  -> nested ``Block`` (recurse)
+          - everything else -> normalized leaf via ``_normalize_value_for_ast``
+            (lists -> ListValue, scalars as-is) on a born-dirty ``Assignment``.
+
+        I4 (TRANSFORM_AUDITABILITY): a ``TRANSFORM::INLINE_MAP_TO_BLOCK`` receipt is
+        appended to the active TIER_NORMALIZATION log (the ContextVar set by
+        write.py during emit) with a stable structural id (the key path). Outside
+        an active audit context the log call is a no-op (today's behaviour for
+        callers that don't opt in).
+
+        The returned Block is ``dirty=True`` / ``body_dirty=True`` so the emitter
+        re-emits it canonically (depth-aware indentation by construction; no node
+        indentation metadata required — the seam holds).
+        """
+        children: list[Any] = []
+        for mk, mv in payload.items():
+            if isinstance(mv, dict) and not _is_op_descriptor(mv) and not _is_delete_sentinel(mv):
+                children.append(DocumentMutator._synthesize_block_from_dict(mk, mv))
+            else:
+                children.append(Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True))
+        # I4: stable structural id is the synthesised key (path-stable for the
+        # top-level synthesis; nested recursions log their own child key).
+        tier_normalize.log_repair_if_active(
+            tier_normalize.RULE_INLINE_MAP_TO_BLOCK,
+            before=f"{key}::[<inline-map>]",
+            after=f"{key}: (BLOCK)",
+        )
+        return Block(key=key, children=children, dirty=True, body_dirty=True)
+
+    @staticmethod
+    def _has_nested_dict(payload: dict[str, Any]) -> bool:
+        """True iff ``payload`` contains a non-op, non-DELETE nested dict value.
+
+        Used to decide whether a bare-dict assignment needs BLOCK synthesis (Q2)
+        vs. a flat single-level inline form. A flat dict (all scalar/list values)
+        stays an ``InlineMap`` — re-parseable inline OCTAVE — preserving today's
+        behaviour for the flat case; only nested dicts require BLOCK form.
+        """
+        return any(
+            isinstance(mv, dict) and not _is_op_descriptor(mv) and not _is_delete_sentinel(mv)
+            for mv in payload.values()
+        )
 
     # ------------------------------------------------------------------
     # Transition primitives (GH#487 B-3: Defect-2 reject)

--- a/src/octave_mcp/mcp/document_mutator.py
+++ b/src/octave_mcp/mcp/document_mutator.py
@@ -438,12 +438,34 @@ class DocumentMutator:
         # Legacy full-value replacement (or new Assignment if missing).
         # I1 (Syntactic Fidelity): Normalize Python values to AST types
         found = False
-        for section in doc.sections:
+        replace_nested = (
+            isinstance(new_value, dict) and not _is_op_descriptor(new_value) and self._has_nested_dict(new_value)
+        )
+        for idx, section in enumerate(doc.sections):
             if isinstance(section, Assignment) and section.key == key:
-                # #460 Case A: preserve literal-zone fence form in place.
-                section.value = _normalize_value_for_ast_preserving(new_value, section.value)
-                # PR-2 T6: paired-write on top-level Assignment.
-                _mark_dirty(section)
+                if replace_nested:
+                    # GH#487 Q2 (#440) — CE BLOCKING fix: a bare dict with NESTED
+                    # dict values REPLACING an existing scalar Assignment must
+                    # synthesize canonical BLOCK form (sole canonical nested form),
+                    # exactly as the new-key path does. The prior in-place value
+                    # swap routed through _normalize_value_for_ast_preserving ->
+                    # _normalize_value_for_ast, which coerced the dict to a nested
+                    # InlineMap (KEY::[OUTER::[INNER::v]]) failing strict re-parse
+                    # with E_NESTED_INLINE_MAP — an I1 round-trip violation. Swap
+                    # the Assignment node for a born-dirty Block (Q1 FULL REPLACE of
+                    # the scalar); the I4 TRANSFORM::INLINE_MAP_TO_BLOCK receipt is
+                    # logged by _synthesize_block_from_dict with stable structural
+                    # IDs, consistent with the new-key path.
+                    doc.sections[idx] = self._synthesize_block_from_dict(key, new_value)
+                    # The sections list shape changed (Assignment -> Block); mark
+                    # whole-doc dirty so the preserve-mode emitter re-emits rather
+                    # than splicing the now-stale scalar baseline bytes.
+                    doc.dirty = True
+                else:
+                    # #460 Case A: preserve literal-zone fence form in place.
+                    section.value = _normalize_value_for_ast_preserving(new_value, section.value)
+                    # PR-2 T6: paired-write on top-level Assignment.
+                    _mark_dirty(section)
                 found = True
                 break
 

--- a/src/octave_mcp/mcp/document_mutator.py
+++ b/src/octave_mcp/mcp/document_mutator.py
@@ -241,37 +241,20 @@ class DocumentMutator:
             return
 
         if isinstance(new_value, dict) and not _is_op_descriptor(new_value) and tool._find_block(doc, key) is not None:
-            # ADR-0006 SR2-T2 PR-2 (GH#377) T7: bare ``{KEY: {child:
-            # v2}}`` change against an EXISTING top-level Block.
-            # Without this branch, the dict would be normalised to
-            # an InlineMap and appended as a NEW top-level
-            # Assignment beside the Block (duplicate key, silent
-            # shape switch — I3 violation under format_style
-            # ``"preserve"``). With this branch, the dict is
-            # expanded into per-child Assignment mutations against
-            # the existing Block, keeping the Block shape and
-            # marking only the touched children dirty.
+            # GH#487 Q1 (#443a) FULL REPLACE [HARD BREAK v1.15]: a bare-dict at a
+            # top-level KEY that already holds a Block executes a FULL REPLACEMENT
+            # of that Block's children. Unmentioned children are DROPPED (honours
+            # PROD::I3 MIRROR_CONSTRAINT: reflect only what's present). To MERGE,
+            # callers MUST send an explicit {"$op":"MERGE","value":{...}}.
+            #
+            # This is the semantic inversion of the prior silent-merge behaviour:
+            # previously unmentioned children survived and the new child was
+            # appended. The #460 Case A fence-preserving path is REUSED for keys
+            # present in BOTH payload and target (CDV BLOCKING-1), so a re-mentioned
+            # literal-zone child keeps its fence FORM while unmentioned siblings drop.
             t7_block = tool._find_block(doc, key)
             assert t7_block is not None  # narrowed by branch guard
-            for mk, mv in new_value.items():
-                if _is_delete_sentinel(mv):
-                    t7_block.children = [
-                        c for c in t7_block.children if not (isinstance(c, Assignment) and c.key == mk)
-                    ]
-                    _mark_dirty(t7_block, body=True)
-                    continue
-                found_child = False
-                for child in t7_block.children:
-                    if isinstance(child, Assignment) and child.key == mk:
-                        # #460 Case A: preserve literal-zone fence form in place.
-                        child.value = _normalize_value_for_ast_preserving(mv, child.value)
-                        _mark_dirty(child)
-                        found_child = True
-                        break
-                if not found_child:
-                    new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
-                    t7_block.children.append(new_child)
-                _mark_dirty(t7_block, body=True)
+            self._full_replace_block(t7_block, new_value)
             return
 
         if tool._is_anchored_change(doc, key):
@@ -425,6 +408,24 @@ class DocumentMutator:
                 )
             return
 
+        # GH#487 Defect-2 (#443) bare-scalar-over-Block / Q1 FULL REPLACE:
+        # a bare value (no $op) assigned to a top-level KEY that currently holds
+        # a Block is a scalar<->BLOCK transition. Under Q1 FULL REPLACE it
+        # replaces the Block with a single flat Assignment IN PLACE (drop the
+        # Block's children, exactly one key emitted) — never the prior bug of
+        # leaving the Block AND appending a flat scalar of the same name
+        # (duplicate keys at the same scope). The replacement Assignment is born
+        # dirty (no baseline span) so the emitter re-emits it canonically and the
+        # dropped Block carries no stale span into the tree the emitter walks.
+        for idx, section in enumerate(doc.sections):
+            if isinstance(section, Block) and section.key == key:
+                doc.sections[idx] = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
+                # The sections list shape (a node was swapped) differs from the
+                # baseline; mark whole-doc dirty so the preserve-mode emitter does
+                # not splice the now-stale Block bytes for this key.
+                doc.dirty = True
+                return
+
         # Legacy full-value replacement (or new Assignment if missing).
         # I1 (Syntactic Fidelity): Normalize Python values to AST types
         found = False
@@ -444,3 +445,60 @@ class DocumentMutator:
             # bytes to splice; its value MUST be re-emitted).
             new_assignment = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
             doc.sections.append(new_assignment)
+
+    # ------------------------------------------------------------------
+    # Transition primitives (GH#487 B-2: Q1 FULL REPLACE)
+    # ------------------------------------------------------------------
+
+    def _full_replace_block(self, block: Block, payload: dict[str, Any]) -> None:
+        """GH#487 Q1 (#443a) key-wise reconciliation FULL REPLACE of a Block.
+
+        The Block's children are REBUILT from ``payload`` (a bare dict, no $op):
+          - key present in BOTH payload and block  -> FORM-PRESERVE: the existing
+            child node is kept and its value routed through
+            ``_normalize_value_for_ast_preserving`` (the #460 Case A fence-
+            preserving path, CDV BLOCKING-1), so a re-mentioned literal-zone child
+            keeps its fence FORM. The child is marked dirty.
+          - key in payload only                    -> SYNTHESIZE a born-dirty
+            Assignment child.
+          - key in block only (UNMENTIONED)         -> DROPPED (Q1, honours I3).
+          - payload value is the DELETE sentinel    -> the key is simply omitted
+            from the rebuilt children (idempotent drop).
+
+        Span hygiene (CDV flag): ``block.children`` is REPLACED with a fresh list.
+        Dropped children's nodes are discarded, not retained with stale spans, so
+        no stale baseline span survives; ``_mark_dirty(block, body=True)`` forces
+        the children region to re-emit canonically while the header still slices
+        from baseline. New/re-mentioned children carry/are-marked dirty so they
+        re-emit; synthesized children carry no spans.
+        """
+        existing: dict[str, Assignment] = {c.key: c for c in block.children if isinstance(c, Assignment)}
+        # Existing Block children (nested blocks) keyed for reconciliation too:
+        existing_blocks: dict[str, Block] = {c.key: c for c in block.children if isinstance(c, Block)}
+
+        new_children: list[Any] = []
+        for mk, mv in payload.items():
+            if _is_delete_sentinel(mv):
+                # Explicit DELETE of a (possibly absent) child: omit it.
+                continue
+            if mk in existing:
+                child = existing[mk]
+                # #460 Case A / BLOCKING-1: form-preserve a mentioned child.
+                child.value = _normalize_value_for_ast_preserving(mv, child.value)
+                _mark_dirty(child)
+                new_children.append(child)
+            elif mk in existing_blocks and isinstance(mv, dict) and not _is_op_descriptor(mv):
+                # Mentioned child is itself a nested Block and the replacement is a
+                # bare dict: recurse the FULL REPLACE into it (preserve the nested
+                # Block shape, reconcile its children key-wise).
+                nested = existing_blocks[mk]
+                self._full_replace_block(nested, mv)
+                new_children.append(nested)
+            else:
+                # New (unmentioned-in-target) key: synthesize a born-dirty child.
+                new_children.append(Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True))
+
+        # Replace the children list wholesale: unmentioned children are simply not
+        # carried over -> dropped (Q1, I3). No stale spans survive.
+        block.children = new_children
+        _mark_dirty(block, body=True)

--- a/src/octave_mcp/mcp/document_mutator.py
+++ b/src/octave_mcp/mcp/document_mutator.py
@@ -333,6 +333,14 @@ class DocumentMutator:
                         ]
                         _mark_dirty(target_block, body=True)
                         continue
+                    # GH#487 Defect-2 (#443): scalar-over-nested-BLOCK via MERGE is
+                    # a scalar<->BLOCK transition. CDV CONDITIONAL-GO firmed this to
+                    # REJECT-only (never silently honour): replacing a child Block
+                    # with a scalar would either destroy structure silently or emit
+                    # duplicate keys. Reject with E_OP_TARGET_MISMATCH (I3: no silent
+                    # structural destruction). This is the apply-side defensive net;
+                    # the validator surfaces the same error pre-apply.
+                    self._reject_scalar_over_child_block(target_block, mk, mv, key)
                     found_child = False
                     for child in target_block.children:
                         if isinstance(child, Assignment) and child.key == mk:
@@ -445,6 +453,44 @@ class DocumentMutator:
             # bytes to splice; its value MUST be re-emitted).
             new_assignment = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
             doc.sections.append(new_assignment)
+
+    # ------------------------------------------------------------------
+    # Transition primitives (GH#487 B-3: Defect-2 reject)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _reject_scalar_over_child_block(parent: Block, child_key: str, replacement: Any, target_key: str) -> None:
+        """GH#487 Defect-2 (#443): reject a scalar replacement of a child Block.
+
+        CDV CONDITIONAL-GO firmed the scalar<->BLOCK ruling to REJECT-only (not
+        honour). Under an explicit ``$op:MERGE`` on ``parent``, if a payload key
+        ``child_key`` names an existing child that is itself a ``Block`` and the
+        replacement is NOT a bare dict (i.e. a scalar / list — a non-block), the
+        MERGE would either destroy the nested Block silently or emit duplicate
+        keys. Raise ``E_OP_TARGET_MISMATCH`` (PROD::I3: no silent structural
+        destruction). To replace a Block with a scalar, the caller must DELETE
+        first or REPLACE at the parent (bare-dict FULL REPLACE).
+
+        No-op when the child is absent, is an Assignment, or the replacement is a
+        bare dict (the #484 guard already rejects nested-dict MERGE payloads, so a
+        dict reaching apply would be an op-descriptor handled elsewhere).
+        """
+        is_block_child = any(isinstance(c, Block) and c.key == child_key for c in parent.children)
+        if is_block_child and not (isinstance(replacement, dict)):
+            raise ValueError(
+                [
+                    {
+                        "code": "E_OP_TARGET_MISMATCH",
+                        "message": (
+                            f"$op MERGE on '{target_key}' cannot replace nested block "
+                            f"'{child_key}' with a scalar value (scalar<->BLOCK transition). "
+                            f"This is rejected to avoid silent structural destruction / "
+                            f"duplicate keys (PROD::I3). To replace the block, DELETE it first "
+                            f"or send a bare-dict REPLACE at '{target_key}'."
+                        ),
+                    }
+                ]
+            )
 
     # ------------------------------------------------------------------
     # Transition primitives (GH#487 B-2: Q1 FULL REPLACE)

--- a/src/octave_mcp/mcp/document_mutator.py
+++ b/src/octave_mcp/mcp/document_mutator.py
@@ -1,0 +1,446 @@
+"""DocumentMutator — the domain-mutation layer for changes-mode (GH#487 / STRATEGY_S3).
+
+The root architectural pattern this module closes is ``ABSENT_DOMAIN_MUTATION_LAYER``:
+STRATEGY_S1 split ``write.py`` into peer modules, but the *transition logic* (Q1 full
+replace, Defect-2 scalar<->BLOCK resolution, MERGE-vs-REPLACE discrimination) and the
+structural *AST synthesis* (constructing ``dirty=True`` Block / Assignment nodes) were
+still latent and scattered across ``write.py:_apply_changes`` and ``write_mutation.py``.
+
+The SEAM (CDV R2 anti-drift):
+  - ``DocumentMutator`` OWNS transition logic + structural AST synthesis. It produces a
+    mutated ``Document`` whose changed subtrees are born-/marked-``dirty`` AST nodes
+    carrying only semantic content (key, children, value) and the dirty flags. It NEVER
+    produces bytes and NEVER computes indentation.
+  - The emitter (``core/emitter.py``, driven by ``write_format.py`` Strategy A) remains the
+    SOLE canonicalizer-to-bytes. ``emit_block`` / ``emit_assignment`` derive indentation
+    purely from recursion depth, so a born-dirty synthetic ``Block`` emits with correct
+    indentation *by construction* — no node indentation metadata is required.
+
+B-1 (this commit) is a PURE RELOCATION: the per-key body of ``WriteTool._apply_changes``
+moved behind ``DocumentMutator.apply_change`` with ZERO behaviour change. The
+``DocumentMutator`` delegates back to the owning ``WriteTool`` for path-resolution helpers
+(``_find_block``, ``_apply_block_change``, ``_apply_section_change``, ``_is_anchored_change``,
+``_resolve_anchored_change``) that remain on the tool. Subsequent commits (B-2..B-6) flip the
+semantic behaviours behind this single API.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from octave_mcp.core.grammar.cst import (
+    Assignment,
+    Block,
+    Section,
+)
+from octave_mcp.mcp.write_mutation import (
+    _SECTION_PATH_RE,
+    _apply_array_op_inplace,
+    _extract_op_descriptor,
+    _is_delete_sentinel,
+    _is_op_descriptor,
+    _mark_dirty,
+    _normalize_value_for_ast,
+    _normalize_value_for_ast_preserving,
+)
+
+if TYPE_CHECKING:
+    from octave_mcp.mcp.write import WriteTool
+
+
+class DocumentMutator:
+    """Owns transition logic + structural AST synthesis for changes-mode.
+
+    Emits ``dirty=True`` nodes; never produces bytes (the emitter owns canon).
+    """
+
+    def __init__(self, tool: WriteTool) -> None:
+        # The owning WriteTool supplies path-resolution helpers that remain its
+        # responsibility (block/section finding, anchored-path resolution).
+        self._tool = tool
+
+    def apply_change(self, doc: Any, key: str, new_value: Any) -> None:
+        """Apply a single changes-mode key/value mutation to ``doc`` in place.
+
+        This is the per-key body relocated verbatim from ``WriteTool._apply_changes``
+        (B-1, no behaviour change). Path validation / fail-fast is still performed by
+        the caller (``WriteTool._apply_changes`` runs ``_validate_change_paths`` first).
+        """
+        tool = self._tool
+
+        # GH#353: Section-prefixed paths (§N.KEY or §N::NAME.KEY)
+        if key.startswith("§"):
+            match = _SECTION_PATH_RE.match(key)
+            if match:
+                section_id, section_name, child_key = match.groups()
+                tool._apply_section_change(doc, key, section_id, section_name, child_key, new_value)
+            # Invalid section paths already rejected by _validate_change_paths
+            return
+
+        # Check for dot-notation: META.FIELD
+        if key.startswith("META."):
+            # Extract the field name after "META."
+            field_name = key[5:]  # Remove "META." prefix
+
+            # GH #447: I3 (MIRROR_CONSTRAINT) + I1 (SYNTACTIC_FIDELITY)
+            # mutate-in-place contract. When a META envelope was parsed
+            # with FLAT-form atoms (no ``META:`` block prefix), the
+            # parser puts each atom in ``doc.sections`` as a top-level
+            # ``Assignment`` rather than into the ``doc.meta`` dict. The
+            # original ``META.<field>`` resolver wrote unconditionally
+            # to ``doc.meta`` which on emit produced a NEW canonical
+            # ``META:`` block alongside the surviving flat atom —
+            # duplicate-key, form switch, I3 violation. We must locate
+            # the existing flat atom FIRST and mutate it in place;
+            # only when no flat atom exists do we fall through to the
+            # ``doc.meta`` dict path (preserving today's behaviour for
+            # documents whose META is parsed into the dict).
+            #
+            # PR #449 CE REWORK BLOCKING #1: the flat-atom scan MUST be
+            # constrained to the ``===META===`` envelope shape only.
+            # ``META.<field>`` addresses the flat-atom inside an envelope
+            # whose name is "META", NOT any top-level atom with the
+            # matching key anywhere in the document. CE's repro showed
+            # that without this constraint a document like
+            # ``===DOC===\nSTATUS::content_status\n===END===`` would have
+            # its DOC envelope's ``STATUS`` atom silently mutated by
+            # ``changes={"META.STATUS": ...}`` -- a cross-envelope scope
+            # leak. We gate the scan on ``doc.name == "META"`` so that
+            # only true META envelopes participate in the flat-atom path.
+            flat_idx: int | None = None
+            if doc.name == "META":
+                for idx, section in enumerate(doc.sections):
+                    if isinstance(section, Assignment) and section.key == field_name:
+                        flat_idx = idx
+                        break
+
+            if flat_idx is not None:
+                if _is_delete_sentinel(new_value):
+                    # Remove the flat top-level Assignment in place.
+                    del doc.sections[flat_idx]
+                    # PR #449 CE REWORK observation #4: the deletion
+                    # mechanism is OMISSION -- removing the Assignment
+                    # node from ``doc.sections`` means the emitter
+                    # cannot re-emit what is no longer there. We also
+                    # mark ``doc.dirty=True`` so the preserve-mode
+                    # emitter cannot splice the now-stale baseline
+                    # bytes for this envelope; instead it re-emits
+                    # canonically, naturally skipping the deleted
+                    # atom. (No section-emission consults
+                    # ``doc.dirty`` directly; the flag fences the
+                    # baseline-slice path in ``emit()`` instead.)
+                    doc.dirty = True
+                else:
+                    # I1 (Syntactic Fidelity): normalise the value.
+                    target_assignment = doc.sections[flat_idx]
+                    assert isinstance(target_assignment, Assignment)
+                    # #460 Case A: preserve literal-zone fence form in place.
+                    target_assignment.value = _normalize_value_for_ast_preserving(new_value, target_assignment.value)
+                    # PR-2 T6: paired-write — mark only this leaf
+                    # dirty so the preserve-mode emitter re-emits
+                    # just this atom and splices the rest of the
+                    # envelope verbatim.
+                    _mark_dirty(target_assignment)
+            elif _is_delete_sentinel(new_value):
+                # No flat atom; fall through to doc.meta dict deletion.
+                if field_name in doc.meta:
+                    del doc.meta[field_name]
+                # PR-2 T6: per-key META dirty map captures the
+                # deletion event so PR-3's emitter knows this META
+                # key no longer exists in the AST.
+                doc.meta_dirty[field_name] = True
+            else:
+                # Update or add field in doc.meta
+                # I1 (Syntactic Fidelity): Normalize Python values to AST types
+                # Without this, Python lists emit as "['a', 'b']" instead of "[a,b]"
+                doc.meta[field_name] = _normalize_value_for_ast(new_value)
+                # PR-2 T6: paired-write — mark per-key dirty so PR-3
+                # emitter re-emits only this META key and splices
+                # the rest of META verbatim.
+                doc.meta_dirty[field_name] = True
+            return
+
+        if key == "META" and isinstance(new_value, dict):
+            if _is_delete_sentinel(new_value):
+                # DELETE sentinel on META clears the entire block
+                doc.meta = {}
+                # PR-2 T6: whole-META clear -> mark every existing
+                # key in meta_dirty so PR-3 emitter knows no key
+                # survives. Use a sentinel "*" to denote whole-meta
+                # dirty WITHOUT inventing a key shape that doesn't
+                # match observable data. We instead mark
+                # ``doc.dirty=True`` for whole-doc re-emit; the
+                # per-key map remains the precision instrument.
+                doc.dirty = True
+            else:
+                # GH#302: MERGE into existing META, not replace.
+                # Previous behavior replaced the entire META dict, silently
+                # dropping fields like CONTRACT::HOLOGRAPHIC that were not
+                # included in the changes dict.  Merge preserves unmentioned
+                # fields (I3 Mirror Constraint: reflect only present, create
+                # nothing -- and do not destroy what is already present).
+                #
+                # GH#373: An explicit {"$op": "MERGE", "value": {...}} descriptor
+                # has the same semantics as the bare-dict legacy form; payload
+                # is the inner dict.
+                op_meta, payload_meta, _ = _extract_op_descriptor(new_value)
+                merge_dict = payload_meta if op_meta == "MERGE" else new_value
+                for mk, mv in merge_dict.items():
+                    if _is_delete_sentinel(mv):
+                        doc.meta.pop(mk, None)
+                        # PR-2 T6: per-key META dirty (deletion).
+                        doc.meta_dirty[mk] = True
+                    else:
+                        # I1 (Syntactic Fidelity): Normalize values for AST
+                        doc.meta[mk] = _normalize_value_for_ast(mv)
+                        # PR-2 T6: paired-write — only touched keys
+                        # are marked dirty; unmentioned META keys
+                        # stay clean per the sibling-clean invariant
+                        # (ADR §4 per-key dirty model).
+                        doc.meta_dirty[mk] = True
+            return
+
+        if (
+            "." in key
+            and key.count(".") == 1
+            and tool._find_block(doc, key.split(".", 1)[0]) is not None
+            and not any(isinstance(s, Assignment) and s.key == key for s in doc.sections)
+        ):
+            # GH#369: PARENT.CHILD where PARENT is a top-level Block and the
+            # literal dotted key does NOT already exist as a flat top-level
+            # Assignment. Route into the Block instead of falling through to
+            # the flat-assignment branch (which would silently append a
+            # duplicate assignment with a dotted key, violating I3).
+            #
+            # The "literal dotted key already exists at top level" check
+            # preserves the GH#347 edge case where a block named e.g. "P1"
+            # coexists with a flat assignment "P1.1::value": we still
+            # modify the flat assignment in that scenario.
+            parent_key, _, child_key = key.partition(".")
+            tool._apply_block_change(doc, key, parent_key, child_key, new_value)
+            return
+
+        if _is_delete_sentinel(new_value) and not tool._is_anchored_change(doc, key):
+            # I2: DELETE sentinel - remove field entirely from sections.
+            # #460 Case B (rework B2): the bare-DELETE branch matches by
+            # ``s.key == key`` and never matches an anchored path, so it
+            # must NOT consume a resolvable ANCHOR/KEY DELETE (which would
+            # otherwise silent-success no-op). Suppressing it for exactly
+            # the keys the anchored branch claims (_is_anchored_change)
+            # lets a resolvable anchored DELETE fall through to the
+            # anchored handler below; a literal ``A/B`` key (resolve-
+            # literal-first) is still handled here.
+            doc.sections = [s for s in doc.sections if not (isinstance(s, Assignment) and s.key == key)]
+            # PR-2 T6: doc.sections list changed (deletion). The
+            # Document does not carry body_dirty; mark whole-doc
+            # dirty so PR-3 emitter knows the sections list shape
+            # differs from baseline. The other clean sections
+            # still slice individually via their own dirty=False
+            # spans.
+            doc.dirty = True
+            return
+
+        if isinstance(new_value, dict) and not _is_op_descriptor(new_value) and tool._find_block(doc, key) is not None:
+            # ADR-0006 SR2-T2 PR-2 (GH#377) T7: bare ``{KEY: {child:
+            # v2}}`` change against an EXISTING top-level Block.
+            # Without this branch, the dict would be normalised to
+            # an InlineMap and appended as a NEW top-level
+            # Assignment beside the Block (duplicate key, silent
+            # shape switch — I3 violation under format_style
+            # ``"preserve"``). With this branch, the dict is
+            # expanded into per-child Assignment mutations against
+            # the existing Block, keeping the Block shape and
+            # marking only the touched children dirty.
+            t7_block = tool._find_block(doc, key)
+            assert t7_block is not None  # narrowed by branch guard
+            for mk, mv in new_value.items():
+                if _is_delete_sentinel(mv):
+                    t7_block.children = [
+                        c for c in t7_block.children if not (isinstance(c, Assignment) and c.key == mk)
+                    ]
+                    _mark_dirty(t7_block, body=True)
+                    continue
+                found_child = False
+                for child in t7_block.children:
+                    if isinstance(child, Assignment) and child.key == mk:
+                        # #460 Case A: preserve literal-zone fence form in place.
+                        child.value = _normalize_value_for_ast_preserving(mv, child.value)
+                        _mark_dirty(child)
+                        found_child = True
+                        break
+                if not found_child:
+                    new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
+                    t7_block.children.append(new_child)
+                _mark_dirty(t7_block, body=True)
+            return
+
+        if tool._is_anchored_change(doc, key):
+            # #460 Case B: ANCHOR/KEY anchored-path. Resolve-literal-first —
+            # _is_anchored_change is True only when no literal top-level
+            # Assignment matches the raw key verbatim (that case is handled
+            # by the legacy branch, preserving backward-compat for real keys
+            # containing '/'). The same predicate gates the bare-DELETE
+            # suppression above, keeping the two branches in lock-step.
+            resolved = tool._resolve_anchored_change(doc, key)
+            assert resolved is not None  # narrowed by _is_anchored_change
+            target_assignment, parent = resolved
+            # #460 (cubic P1): the anchored target is an Assignment, so it
+            # MUST go through the SAME op machinery as a bare top-level key.
+            # Otherwise a $op descriptor is normalized and written as literal
+            # data (PROD::I3 violation: control descriptors as content).
+            op, payload, _ = _extract_op_descriptor(new_value)
+            if op == "DELETE" or _is_delete_sentinel(new_value):
+                # Remove the resolved sibling from its parent's child list.
+                if parent is None:
+                    doc.sections = [s for s in doc.sections if s is not target_assignment]
+                    doc.dirty = True
+                elif isinstance(parent, (Block, Section)):
+                    parent.children = [c for c in parent.children if c is not target_assignment]
+                    _mark_dirty(parent, body=True)
+            elif op in ("APPEND", "PREPEND"):
+                # Array op on the resolved Assignment. _validate_change_paths
+                # has already verified the target is array-typed via
+                # _resolve_target_type (which resolves anchored paths), so a
+                # type mismatch surfaces as E_OP_TARGET_MISMATCH before apply.
+                _apply_array_op_inplace(target_assignment, op, payload)
+                if isinstance(parent, (Block, Section)):
+                    _mark_dirty(parent, body=True)
+            elif op == "MERGE":
+                # An anchored path resolves only to an Assignment, never a
+                # Block/Section/META, so MERGE has no valid anchored target.
+                # The validator rejects this upstream (E_OP_TARGET_MISMATCH);
+                # this is a defensive loud failure so a MERGE descriptor can
+                # NEVER be written as literal data if it ever reaches apply.
+                raise ValueError(
+                    [
+                        {
+                            "code": "E_OP_TARGET_MISMATCH",
+                            "message": (
+                                f"$op MERGE is not supported on anchored path '{key}': "
+                                f"it resolves to an assignment (scalar/array), not a "
+                                f"Block/Section/META target. MERGE only applies to "
+                                f"top-level Blocks, Sections, or META."
+                            ),
+                        }
+                    ]
+                )
+            else:
+                # Bare value: full replacement.
+                # #460 Case A interplay: preserve literal-zone fence form.
+                target_assignment.value = _normalize_value_for_ast_preserving(new_value, target_assignment.value)
+                _mark_dirty(target_assignment)
+                if isinstance(parent, (Block, Section)):
+                    _mark_dirty(parent, body=True)
+            return
+
+        # GH#373: Op-aware dispatch on top-level keys.
+        # MERGE on a top-level Block; APPEND/PREPEND on a top-level
+        # array Assignment. Bare values fall through to legacy
+        # full-replacement.
+        op, payload, _ = _extract_op_descriptor(new_value)
+
+        if op == "MERGE":
+            # Validator restricts MERGE to block/section/meta targets.
+            target_block: Block | None = tool._find_block(doc, key)
+            if target_block is not None:
+                for mk, mv in payload.items():
+                    if _is_delete_sentinel(mv):
+                        target_block.children = [
+                            c for c in target_block.children if not (isinstance(c, Assignment) and c.key == mk)
+                        ]
+                        _mark_dirty(target_block, body=True)
+                        continue
+                    found_child = False
+                    for child in target_block.children:
+                        if isinstance(child, Assignment) and child.key == mk:
+                            # #460 Case A: preserve literal-zone fence form
+                            # when MERGE replaces an existing fenced child.
+                            child.value = _normalize_value_for_ast_preserving(mv, child.value)
+                            # PR-2 T6: paired-write per leaf.
+                            _mark_dirty(child)
+                            found_child = True
+                            break
+                    if not found_child:
+                        # New child: nothing to preserve, plain normalize.
+                        new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
+                        target_block.children.append(new_child)
+                    # PR-2 T6: in every MERGE-on-Block branch
+                    # (existing-child mutate or new-child
+                    # append), the block's body region changed.
+                    _mark_dirty(target_block, body=True)
+                return
+
+            # MERGE on a Section -- search and merge children.
+            target_section: Section | None = None
+            for node in doc.sections:
+                if isinstance(node, Section) and node.key == key:
+                    target_section = node
+                    break
+            if target_section is not None:
+                for mk, mv in payload.items():
+                    if _is_delete_sentinel(mv):
+                        target_section.children = [
+                            c for c in target_section.children if not (isinstance(c, Assignment) and c.key == mk)
+                        ]
+                        _mark_dirty(target_section, body=True)
+                        continue
+                    found_child = False
+                    for child in target_section.children:
+                        if isinstance(child, Assignment) and child.key == mk:
+                            # #460 Case A: preserve literal-zone fence form
+                            # when MERGE replaces an existing fenced child.
+                            child.value = _normalize_value_for_ast_preserving(mv, child.value)
+                            _mark_dirty(child)
+                            found_child = True
+                            break
+                    if not found_child:
+                        # New child: nothing to preserve, plain normalize.
+                        new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
+                        target_section.children.append(new_child)
+                    _mark_dirty(target_section, body=True)
+                return
+            # Validator should have caught missing target; safety net.
+            raise ValueError(
+                [
+                    {
+                        "code": "E_UNRESOLVABLE_PATH",
+                        "message": (f"$op MERGE target '{key}' not found as a Block " f"or Section."),
+                    }
+                ]
+            )
+
+        if op in ("APPEND", "PREPEND"):
+            for section in doc.sections:
+                if isinstance(section, Assignment) and section.key == key:
+                    _apply_array_op_inplace(section, op, payload)
+                    break
+            else:
+                raise ValueError(
+                    [
+                        {
+                            "code": "E_UNRESOLVABLE_PATH",
+                            "message": (f"$op {op} target '{key}' not found as a " f"top-level Assignment."),
+                        }
+                    ]
+                )
+            return
+
+        # Legacy full-value replacement (or new Assignment if missing).
+        # I1 (Syntactic Fidelity): Normalize Python values to AST types
+        found = False
+        for section in doc.sections:
+            if isinstance(section, Assignment) and section.key == key:
+                # #460 Case A: preserve literal-zone fence form in place.
+                section.value = _normalize_value_for_ast_preserving(new_value, section.value)
+                # PR-2 T6: paired-write on top-level Assignment.
+                _mark_dirty(section)
+                found = True
+                break
+
+        # If not found and not deleting, add new field
+        if not found:
+            # Create new assignment node with normalized value.
+            # PR-2 T6: new Assignment is born dirty (no source
+            # bytes to splice; its value MUST be re-emitted).
+            new_assignment = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
+            doc.sections.append(new_assignment)

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -41,6 +41,7 @@ from octave_mcp.core.schema_extractor import SchemaDefinition
 from octave_mcp.core.validator import Validator, _count_literal_zones
 from octave_mcp.mcp.base_tool import BaseTool, SchemaBuilder
 from octave_mcp.mcp.compile_grammar import USAGE_HINTS
+from octave_mcp.mcp.document_mutator import DocumentMutator
 from octave_mcp.mcp.write_detection import (
     _auto_quote_section_refs_in_values,
     _detect_annotation_too_long,
@@ -59,6 +60,7 @@ from octave_mcp.mcp.write_format import (
 )
 from octave_mcp.mcp.write_metrics import StructuralMetrics, extract_structural_metrics
 from octave_mcp.mcp.write_mutation import (
+    _SECTION_PATH_RE,
     _apply_array_op_inplace,
     _extract_op_descriptor,
     _is_delete_sentinel,
@@ -138,11 +140,9 @@ _ARRAY_INDEX_RE = re.compile(r"\[\d+\]")
 # NOTE: The child key pattern excludes dots to prevent matching deep paths like §1.A.B.C.
 # The section name in ::NAME allows dots (for names like v2.0) but the child key does NOT,
 # since dots in the child position indicate hierarchical path traversal which is unsupported.
-_SECTION_PATH_RE = re.compile(
-    r"^§([0-9]+[a-zA-Z]?(?:\.[0-9]+)?)"  # §<id>: digits + optional letter suffix + optional .N
-    r"(?:::([A-Za-z_][A-Za-z0-9_/\-]*))?"  # optional ::NAME (no dots in name)
-    r"\.([A-Za-z_][A-Za-z0-9_/\-]*)$"  # .KEY (required child key, no dots)
-)
+# GH#487 (STRATEGY_S3): the canonical definition now lives in write_mutation.py so the
+# WriteTool and the DocumentMutator share ONE source (R2). Re-exported here under the same
+# name to preserve every existing in-module reference.
 
 
 class WriteTool(BaseTool):
@@ -150,6 +150,21 @@ class WriteTool(BaseTool):
 
     # Security: allowed file extensions
     ALLOWED_EXTENSIONS = {".oct.md", ".octave", ".md"}
+
+    @property
+    def _mutator(self) -> "DocumentMutator":
+        """GH#487 (STRATEGY_S3): the changes-mode domain-mutation layer.
+
+        Lazily constructed (no custom ``__init__`` on BaseTool/WriteTool to
+        disturb) and cached on the instance. The mutator owns transition logic +
+        AST synthesis; it delegates back to this tool for path-resolution
+        helpers, so it holds a back-reference to ``self``.
+        """
+        mutator = getattr(self, "_mutator_cache", None)
+        if mutator is None:
+            mutator = DocumentMutator(self)
+            self._mutator_cache = mutator
+        return mutator
 
     def _repair_curly_brace_annotations(self, content: str) -> tuple[str, list[dict[str, Any]]]:
         """GH#263: Pre-process content to repair NAME{qualifier} -> NAME<qualifier>.
@@ -1939,380 +1954,12 @@ class WriteTool(BaseTool):
         if path_errors:
             raise ValueError(path_errors)
 
+        # GH#487 (STRATEGY_S3): the per-key transition logic + AST synthesis is
+        # owned by the DocumentMutator (one mutation path, R2 anti-drift). This
+        # loop is a thin dispatcher; the mutator delegates back to this tool for
+        # path-resolution helpers (_find_block, _apply_block_change, etc.).
         for key, new_value in changes.items():
-            # GH#353: Section-prefixed paths (§N.KEY or §N::NAME.KEY)
-            if key.startswith("§"):
-                match = _SECTION_PATH_RE.match(key)
-                if match:
-                    section_id, section_name, child_key = match.groups()
-                    self._apply_section_change(doc, key, section_id, section_name, child_key, new_value)
-                # Invalid section paths already rejected by _validate_change_paths
-                continue
-
-            # Check for dot-notation: META.FIELD
-            if key.startswith("META."):
-                # Extract the field name after "META."
-                field_name = key[5:]  # Remove "META." prefix
-
-                # GH #447: I3 (MIRROR_CONSTRAINT) + I1 (SYNTACTIC_FIDELITY)
-                # mutate-in-place contract. When a META envelope was parsed
-                # with FLAT-form atoms (no ``META:`` block prefix), the
-                # parser puts each atom in ``doc.sections`` as a top-level
-                # ``Assignment`` rather than into the ``doc.meta`` dict. The
-                # original ``META.<field>`` resolver wrote unconditionally
-                # to ``doc.meta`` which on emit produced a NEW canonical
-                # ``META:`` block alongside the surviving flat atom —
-                # duplicate-key, form switch, I3 violation. We must locate
-                # the existing flat atom FIRST and mutate it in place;
-                # only when no flat atom exists do we fall through to the
-                # ``doc.meta`` dict path (preserving today's behaviour for
-                # documents whose META is parsed into the dict).
-                #
-                # PR #449 CE REWORK BLOCKING #1: the flat-atom scan MUST be
-                # constrained to the ``===META===`` envelope shape only.
-                # ``META.<field>`` addresses the flat-atom inside an envelope
-                # whose name is "META", NOT any top-level atom with the
-                # matching key anywhere in the document. CE's repro showed
-                # that without this constraint a document like
-                # ``===DOC===\nSTATUS::content_status\n===END===`` would have
-                # its DOC envelope's ``STATUS`` atom silently mutated by
-                # ``changes={"META.STATUS": ...}`` -- a cross-envelope scope
-                # leak. We gate the scan on ``doc.name == "META"`` so that
-                # only true META envelopes participate in the flat-atom path.
-                flat_idx: int | None = None
-                if doc.name == "META":
-                    for idx, section in enumerate(doc.sections):
-                        if isinstance(section, Assignment) and section.key == field_name:
-                            flat_idx = idx
-                            break
-
-                if flat_idx is not None:
-                    if _is_delete_sentinel(new_value):
-                        # Remove the flat top-level Assignment in place.
-                        del doc.sections[flat_idx]
-                        # PR #449 CE REWORK observation #4: the deletion
-                        # mechanism is OMISSION -- removing the Assignment
-                        # node from ``doc.sections`` means the emitter
-                        # cannot re-emit what is no longer there. We also
-                        # mark ``doc.dirty=True`` so the preserve-mode
-                        # emitter cannot splice the now-stale baseline
-                        # bytes for this envelope; instead it re-emits
-                        # canonically, naturally skipping the deleted
-                        # atom. (No section-emission consults
-                        # ``doc.dirty`` directly; the flag fences the
-                        # baseline-slice path in ``emit()`` instead.)
-                        doc.dirty = True
-                    else:
-                        # I1 (Syntactic Fidelity): normalise the value.
-                        target_assignment = doc.sections[flat_idx]
-                        assert isinstance(target_assignment, Assignment)
-                        # #460 Case A: preserve literal-zone fence form in place.
-                        target_assignment.value = _normalize_value_for_ast_preserving(
-                            new_value, target_assignment.value
-                        )
-                        # PR-2 T6: paired-write — mark only this leaf
-                        # dirty so the preserve-mode emitter re-emits
-                        # just this atom and splices the rest of the
-                        # envelope verbatim.
-                        _mark_dirty(target_assignment)
-                elif _is_delete_sentinel(new_value):
-                    # No flat atom; fall through to doc.meta dict deletion.
-                    if field_name in doc.meta:
-                        del doc.meta[field_name]
-                    # PR-2 T6: per-key META dirty map captures the
-                    # deletion event so PR-3's emitter knows this META
-                    # key no longer exists in the AST.
-                    doc.meta_dirty[field_name] = True
-                else:
-                    # Update or add field in doc.meta
-                    # I1 (Syntactic Fidelity): Normalize Python values to AST types
-                    # Without this, Python lists emit as "['a', 'b']" instead of "[a,b]"
-                    doc.meta[field_name] = _normalize_value_for_ast(new_value)
-                    # PR-2 T6: paired-write — mark per-key dirty so PR-3
-                    # emitter re-emits only this META key and splices
-                    # the rest of META verbatim.
-                    doc.meta_dirty[field_name] = True
-            elif key == "META" and isinstance(new_value, dict):
-                if _is_delete_sentinel(new_value):
-                    # DELETE sentinel on META clears the entire block
-                    doc.meta = {}
-                    # PR-2 T6: whole-META clear -> mark every existing
-                    # key in meta_dirty so PR-3 emitter knows no key
-                    # survives. Use a sentinel "*" to denote whole-meta
-                    # dirty WITHOUT inventing a key shape that doesn't
-                    # match observable data. We instead mark
-                    # ``doc.dirty=True`` for whole-doc re-emit; the
-                    # per-key map remains the precision instrument.
-                    doc.dirty = True
-                else:
-                    # GH#302: MERGE into existing META, not replace.
-                    # Previous behavior replaced the entire META dict, silently
-                    # dropping fields like CONTRACT::HOLOGRAPHIC that were not
-                    # included in the changes dict.  Merge preserves unmentioned
-                    # fields (I3 Mirror Constraint: reflect only present, create
-                    # nothing -- and do not destroy what is already present).
-                    #
-                    # GH#373: An explicit {"$op": "MERGE", "value": {...}} descriptor
-                    # has the same semantics as the bare-dict legacy form; payload
-                    # is the inner dict.
-                    op_meta, payload_meta, _ = _extract_op_descriptor(new_value)
-                    merge_dict = payload_meta if op_meta == "MERGE" else new_value
-                    for mk, mv in merge_dict.items():
-                        if _is_delete_sentinel(mv):
-                            doc.meta.pop(mk, None)
-                            # PR-2 T6: per-key META dirty (deletion).
-                            doc.meta_dirty[mk] = True
-                        else:
-                            # I1 (Syntactic Fidelity): Normalize values for AST
-                            doc.meta[mk] = _normalize_value_for_ast(mv)
-                            # PR-2 T6: paired-write — only touched keys
-                            # are marked dirty; unmentioned META keys
-                            # stay clean per the sibling-clean invariant
-                            # (ADR §4 per-key dirty model).
-                            doc.meta_dirty[mk] = True
-            elif (
-                "." in key
-                and key.count(".") == 1
-                and self._find_block(doc, key.split(".", 1)[0]) is not None
-                and not any(isinstance(s, Assignment) and s.key == key for s in doc.sections)
-            ):
-                # GH#369: PARENT.CHILD where PARENT is a top-level Block and the
-                # literal dotted key does NOT already exist as a flat top-level
-                # Assignment. Route into the Block instead of falling through to
-                # the flat-assignment branch (which would silently append a
-                # duplicate assignment with a dotted key, violating I3).
-                #
-                # The "literal dotted key already exists at top level" check
-                # preserves the GH#347 edge case where a block named e.g. "P1"
-                # coexists with a flat assignment "P1.1::value": we still
-                # modify the flat assignment in that scenario.
-                parent_key, _, child_key = key.partition(".")
-                self._apply_block_change(doc, key, parent_key, child_key, new_value)
-            elif _is_delete_sentinel(new_value) and not self._is_anchored_change(doc, key):
-                # I2: DELETE sentinel - remove field entirely from sections.
-                # #460 Case B (rework B2): the bare-DELETE branch matches by
-                # ``s.key == key`` and never matches an anchored path, so it
-                # must NOT consume a resolvable ANCHOR/KEY DELETE (which would
-                # otherwise silent-success no-op). Suppressing it for exactly
-                # the keys the anchored branch claims (_is_anchored_change)
-                # lets a resolvable anchored DELETE fall through to the
-                # anchored handler below; a literal ``A/B`` key (resolve-
-                # literal-first) is still handled here.
-                doc.sections = [s for s in doc.sections if not (isinstance(s, Assignment) and s.key == key)]
-                # PR-2 T6: doc.sections list changed (deletion). The
-                # Document does not carry body_dirty; mark whole-doc
-                # dirty so PR-3 emitter knows the sections list shape
-                # differs from baseline. The other clean sections
-                # still slice individually via their own dirty=False
-                # spans.
-                doc.dirty = True
-            elif (
-                isinstance(new_value, dict)
-                and not _is_op_descriptor(new_value)
-                and self._find_block(doc, key) is not None
-            ):
-                # ADR-0006 SR2-T2 PR-2 (GH#377) T7: bare ``{KEY: {child:
-                # v2}}`` change against an EXISTING top-level Block.
-                # Without this branch, the dict would be normalised to
-                # an InlineMap and appended as a NEW top-level
-                # Assignment beside the Block (duplicate key, silent
-                # shape switch — I3 violation under format_style
-                # ``"preserve"``). With this branch, the dict is
-                # expanded into per-child Assignment mutations against
-                # the existing Block, keeping the Block shape and
-                # marking only the touched children dirty.
-                t7_block = self._find_block(doc, key)
-                assert t7_block is not None  # narrowed by branch guard
-                for mk, mv in new_value.items():
-                    if _is_delete_sentinel(mv):
-                        t7_block.children = [
-                            c for c in t7_block.children if not (isinstance(c, Assignment) and c.key == mk)
-                        ]
-                        _mark_dirty(t7_block, body=True)
-                        continue
-                    found_child = False
-                    for child in t7_block.children:
-                        if isinstance(child, Assignment) and child.key == mk:
-                            # #460 Case A: preserve literal-zone fence form in place.
-                            child.value = _normalize_value_for_ast_preserving(mv, child.value)
-                            _mark_dirty(child)
-                            found_child = True
-                            break
-                    if not found_child:
-                        new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
-                        t7_block.children.append(new_child)
-                    _mark_dirty(t7_block, body=True)
-            elif self._is_anchored_change(doc, key):
-                # #460 Case B: ANCHOR/KEY anchored-path. Resolve-literal-first —
-                # _is_anchored_change is True only when no literal top-level
-                # Assignment matches the raw key verbatim (that case is handled
-                # by the legacy branch, preserving backward-compat for real keys
-                # containing '/'). The same predicate gates the bare-DELETE
-                # suppression above, keeping the two branches in lock-step.
-                resolved = self._resolve_anchored_change(doc, key)
-                assert resolved is not None  # narrowed by _is_anchored_change
-                target_assignment, parent = resolved
-                # #460 (cubic P1): the anchored target is an Assignment, so it
-                # MUST go through the SAME op machinery as a bare top-level key.
-                # Otherwise a $op descriptor is normalized and written as literal
-                # data (PROD::I3 violation: control descriptors as content).
-                op, payload, _ = _extract_op_descriptor(new_value)
-                if op == "DELETE" or _is_delete_sentinel(new_value):
-                    # Remove the resolved sibling from its parent's child list.
-                    if parent is None:
-                        doc.sections = [s for s in doc.sections if s is not target_assignment]
-                        doc.dirty = True
-                    elif isinstance(parent, (Block, Section)):
-                        parent.children = [c for c in parent.children if c is not target_assignment]
-                        _mark_dirty(parent, body=True)
-                elif op in ("APPEND", "PREPEND"):
-                    # Array op on the resolved Assignment. _validate_change_paths
-                    # has already verified the target is array-typed via
-                    # _resolve_target_type (which resolves anchored paths), so a
-                    # type mismatch surfaces as E_OP_TARGET_MISMATCH before apply.
-                    _apply_array_op_inplace(target_assignment, op, payload)
-                    if isinstance(parent, (Block, Section)):
-                        _mark_dirty(parent, body=True)
-                elif op == "MERGE":
-                    # An anchored path resolves only to an Assignment, never a
-                    # Block/Section/META, so MERGE has no valid anchored target.
-                    # The validator rejects this upstream (E_OP_TARGET_MISMATCH);
-                    # this is a defensive loud failure so a MERGE descriptor can
-                    # NEVER be written as literal data if it ever reaches apply.
-                    raise ValueError(
-                        [
-                            {
-                                "code": "E_OP_TARGET_MISMATCH",
-                                "message": (
-                                    f"$op MERGE is not supported on anchored path '{key}': "
-                                    f"it resolves to an assignment (scalar/array), not a "
-                                    f"Block/Section/META target. MERGE only applies to "
-                                    f"top-level Blocks, Sections, or META."
-                                ),
-                            }
-                        ]
-                    )
-                else:
-                    # Bare value: full replacement.
-                    # #460 Case A interplay: preserve literal-zone fence form.
-                    target_assignment.value = _normalize_value_for_ast_preserving(new_value, target_assignment.value)
-                    _mark_dirty(target_assignment)
-                    if isinstance(parent, (Block, Section)):
-                        _mark_dirty(parent, body=True)
-            else:
-                # GH#373: Op-aware dispatch on top-level keys.
-                # MERGE on a top-level Block; APPEND/PREPEND on a top-level
-                # array Assignment. Bare values fall through to legacy
-                # full-replacement.
-                op, payload, _ = _extract_op_descriptor(new_value)
-
-                if op == "MERGE":
-                    # Validator restricts MERGE to block/section/meta targets.
-                    target_block: Block | None = self._find_block(doc, key)
-                    if target_block is not None:
-                        for mk, mv in payload.items():
-                            if _is_delete_sentinel(mv):
-                                target_block.children = [
-                                    c for c in target_block.children if not (isinstance(c, Assignment) and c.key == mk)
-                                ]
-                                _mark_dirty(target_block, body=True)
-                                continue
-                            found_child = False
-                            for child in target_block.children:
-                                if isinstance(child, Assignment) and child.key == mk:
-                                    # #460 Case A: preserve literal-zone fence form
-                                    # when MERGE replaces an existing fenced child.
-                                    child.value = _normalize_value_for_ast_preserving(mv, child.value)
-                                    # PR-2 T6: paired-write per leaf.
-                                    _mark_dirty(child)
-                                    found_child = True
-                                    break
-                            if not found_child:
-                                # New child: nothing to preserve, plain normalize.
-                                new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
-                                target_block.children.append(new_child)
-                            # PR-2 T6: in every MERGE-on-Block branch
-                            # (existing-child mutate or new-child
-                            # append), the block's body region changed.
-                            _mark_dirty(target_block, body=True)
-                        continue
-
-                    # MERGE on a Section -- search and merge children.
-                    target_section: Section | None = None
-                    for node in doc.sections:
-                        if isinstance(node, Section) and node.key == key:
-                            target_section = node
-                            break
-                    if target_section is not None:
-                        for mk, mv in payload.items():
-                            if _is_delete_sentinel(mv):
-                                target_section.children = [
-                                    c
-                                    for c in target_section.children
-                                    if not (isinstance(c, Assignment) and c.key == mk)
-                                ]
-                                _mark_dirty(target_section, body=True)
-                                continue
-                            found_child = False
-                            for child in target_section.children:
-                                if isinstance(child, Assignment) and child.key == mk:
-                                    # #460 Case A: preserve literal-zone fence form
-                                    # when MERGE replaces an existing fenced child.
-                                    child.value = _normalize_value_for_ast_preserving(mv, child.value)
-                                    _mark_dirty(child)
-                                    found_child = True
-                                    break
-                            if not found_child:
-                                # New child: nothing to preserve, plain normalize.
-                                new_child = Assignment(key=mk, value=_normalize_value_for_ast(mv), dirty=True)
-                                target_section.children.append(new_child)
-                            _mark_dirty(target_section, body=True)
-                        continue
-                    # Validator should have caught missing target; safety net.
-                    raise ValueError(
-                        [
-                            {
-                                "code": "E_UNRESOLVABLE_PATH",
-                                "message": (f"$op MERGE target '{key}' not found as a Block " f"or Section."),
-                            }
-                        ]
-                    )
-
-                if op in ("APPEND", "PREPEND"):
-                    for section in doc.sections:
-                        if isinstance(section, Assignment) and section.key == key:
-                            _apply_array_op_inplace(section, op, payload)
-                            break
-                    else:
-                        raise ValueError(
-                            [
-                                {
-                                    "code": "E_UNRESOLVABLE_PATH",
-                                    "message": (f"$op {op} target '{key}' not found as a " f"top-level Assignment."),
-                                }
-                            ]
-                        )
-                    continue
-
-                # Legacy full-value replacement (or new Assignment if missing).
-                # I1 (Syntactic Fidelity): Normalize Python values to AST types
-                found = False
-                for section in doc.sections:
-                    if isinstance(section, Assignment) and section.key == key:
-                        # #460 Case A: preserve literal-zone fence form in place.
-                        section.value = _normalize_value_for_ast_preserving(new_value, section.value)
-                        # PR-2 T6: paired-write on top-level Assignment.
-                        _mark_dirty(section)
-                        found = True
-                        break
-
-                # If not found and not deleting, add new field
-                if not found:
-                    # Create new assignment node with normalized value.
-                    # PR-2 T6: new Assignment is born dirty (no source
-                    # bytes to splice; its value MUST be re-emitted).
-                    new_assignment = Assignment(key=key, value=_normalize_value_for_ast(new_value), dirty=True)
-                    doc.sections.append(new_assignment)
+            self._mutator.apply_change(doc, key, new_value)
 
         return doc
 

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -2337,7 +2337,16 @@ class WriteTool(BaseTool):
             # corrections argument so deprecation warnings remain visible even
             # when validation fails the request.
             try:
-                doc = self._apply_changes(doc, changes, change_warnings=change_warnings)
+                # GH#487 Q2 (#440) / CE rework: the DocumentMutator synthesizes
+                # canonical BLOCK nodes for nested dicts during _apply_changes and
+                # records a TRANSFORM::INLINE_MAP_TO_BLOCK receipt via the
+                # tier_normalize active-context channel (I4). Synthesis happens here
+                # (apply time), BEFORE the emit-phase active() context opens, so the
+                # log must be active across _apply_changes too — otherwise the
+                # receipt is silently dropped. One channel (R2): the same
+                # tier_normalize_log is drained into corrections after emit.
+                with tier_normalize.active(tier_normalize_log):
+                    doc = self._apply_changes(doc, changes, change_warnings=change_warnings)
             except ValueError as e:
                 # GH#335: _validate_change_paths raises ValueError with
                 # structured error list for unresolvable paths.

--- a/src/octave_mcp/mcp/write.py
+++ b/src/octave_mcp/mcp/write.py
@@ -1480,6 +1480,31 @@ class WriteTool(BaseTool):
                                 ),
                             }
                         )
+                    elif target_kind in ("block", "section") and isinstance(target_node, (Block, Section)):
+                        # GH#487 Defect-2 (#443): a MERGE payload key that names an
+                        # existing CHILD Block but supplies a scalar (non-dict)
+                        # replacement is a scalar<->BLOCK transition. CDV firmed
+                        # this to REJECT-only (E_OP_TARGET_MISMATCH) — surfaced here
+                        # pre-apply (PROD::I3 / I5: visible, no silent destruction).
+                        child_blocks = {c.key for c in target_node.children if isinstance(c, Block)}
+                        bad = [
+                            mk
+                            for mk, mv in _payload.items()
+                            if mk in child_blocks and not _is_delete_sentinel(mv) and not isinstance(mv, dict)
+                        ]
+                        if bad:
+                            errors.append(
+                                {
+                                    "code": "E_OP_TARGET_MISMATCH",
+                                    "message": (
+                                        f"$op MERGE on '{key}' cannot replace nested block(s) "
+                                        f"{bad} with a scalar value (scalar<->BLOCK transition). "
+                                        f"Rejected to avoid silent structural destruction / "
+                                        f"duplicate keys (PROD::I3). To replace a block, DELETE "
+                                        f"it first or send a bare-dict REPLACE at '{key}'."
+                                    ),
+                                }
+                            )
 
         return errors
 

--- a/src/octave_mcp/mcp/write_mutation.py
+++ b/src/octave_mcp/mcp/write_mutation.py
@@ -155,8 +155,17 @@ def _apply_array_op_inplace(assignment: Assignment, op: str, payload: Any) -> No
       - payload as a single element: push/unshift one element.
       - payload as a list: bulk push/unshift in caller order.
     Existing items keep their original tokens (where present); new items are
-    appended as Python values, mirroring how _normalize_value_for_ast produces
-    list contents.
+    normalized via ``_normalize_value_for_ast`` so nested lists become
+    ``ListValue`` and nested dicts become ``InlineMap`` — both of which the
+    emitter renders as re-parseable OCTAVE.
+
+    GH#487 #488: previously raw Python ``list`` / ``dict`` items were pushed
+    verbatim and hit the emitter's ``str(value)`` fallback, producing a Python
+    repr (``['PR_485::x']`` single-quoted, or ``{'NESTED': 'v'}`` with braces)
+    that failed strict re-parse (E005) while ``octave_write`` reported success —
+    an I1 round-trip violation (false-green). Normalizing the new items at the
+    mutation seam closes the false-green; the emitter (sole canonicalizer) then
+    renders them depth-aware and re-parseable.
 
     ADR-0006 SR2-T2 PR-2 (GH#377): the Assignment whose value was
     mutated is marked ``dirty=True`` via ``_mark_dirty`` so Strategy
@@ -168,7 +177,11 @@ def _apply_array_op_inplace(assignment: Assignment, op: str, payload: Any) -> No
         op: "APPEND" or "PREPEND".
         payload: Element or list of elements to push.
     """
-    new_items = list(payload) if isinstance(payload, list) else [payload]
+    raw_items = list(payload) if isinstance(payload, list) else [payload]
+    # GH#487 #488: normalize each new item so nested structures emit re-parseably
+    # (list -> ListValue, dict -> InlineMap) instead of falling through to the
+    # emitter's Python-repr str(value) fallback.
+    new_items = [_normalize_value_for_ast(item) for item in raw_items]
 
     current = assignment.value
     if isinstance(current, ListValue):

--- a/src/octave_mcp/mcp/write_mutation.py
+++ b/src/octave_mcp/mcp/write_mutation.py
@@ -1,5 +1,6 @@
 """Op-dispatch and AST mutation primitives extracted from write.py as part of STRATEGY_S1 (#459/#466). Home of the v1.14.0 literal-zone form preservation fix (#460 Case A) when that work lands."""
 
+import re
 from typing import Any
 
 from octave_mcp.core.grammar.cst import (
@@ -10,6 +11,17 @@ from octave_mcp.core.grammar.cst import (
     ListValue,
     LiteralZoneValue,
     Section,
+)
+
+# GH#353 section-path regex. Relocated here from write.py as part of GH#487
+# (STRATEGY_S3) so both the WriteTool and the DocumentMutator share ONE
+# canonical definition (R2: no parallel/duplicate logic). ``§<id>::NAME.KEY``
+# where id = digits + optional letter suffix + optional ".N", NAME has no dots,
+# and KEY (required child key) has no dots.
+_SECTION_PATH_RE = re.compile(
+    r"^§([0-9]+[a-zA-Z]?(?:\.[0-9]+)?)"  # §<id>: digits + optional letter suffix + optional .N
+    r"(?:::([A-Za-z_][A-Za-z0-9_/\-]*))?"  # optional ::NAME (no dots in name)
+    r"\.([A-Za-z_][A-Za-z0-9_/\-]*)$"  # .KEY (required child key, no dots)
 )
 
 

--- a/tests/unit/test_changes_mode_roundtrip_characterization.py
+++ b/tests/unit/test_changes_mode_roundtrip_characterization.py
@@ -309,45 +309,42 @@ class TestCharacterizationKnownDefects:
     """
 
     @pytest.mark.asyncio
-    async def test_append_list_of_lists_false_green_single_quote_gh488(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#488)
+    async def test_append_list_of_lists_reparseable_gh488(self) -> None:
+        """INVERTED (GH#487 B-5, #488 list-element synthesis landed): clean round-trip.
 
-        APPEND onto a list-of-lists emits a single-quoted inline element (``['VALUE']``) which the
-        strict lexer rejects (E005). ``octave_write`` reports ``status: success`` — a FALSE GREEN
-        (I1 round-trip violation): the write claims success but the file no longer parses.
+        Formerly a characterization pin documenting the single-quote false-green (APPEND onto a
+        list-of-lists emitted ``['VALUE']`` failing strict re-parse with E005 while reporting
+        success). GH#487 B-5 normalizes new list items at the mutation seam so nested lists emit
+        as double-quoted re-parseable OCTAVE. Retained as the negative-history regression guard.
         """
         result, emitted = await _roundtrip(_DOC_LIST_OF_LISTS, {"RECENT": {"$op": "APPEND", "value": [["PR_485::x"]]}})
-        assert result.get("status") == "success", "current: write reports success (false-green)"
-        exc = _reparse_error(emitted)
-        assert exc is not None, f"current bug: emitted output should FAIL strict re-parse; got:\n{emitted}"
-        assert isinstance(exc, LexerError), f"current bug: E005 lexer rejection expected, got {exc!r}"
-        assert "'" in emitted, "current bug: element emitted with single quotes"
+        assert result.get("status") == "success"
+        assert _strict_reparses(emitted), f"GH#487 #488: emitted output must round-trip; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    async def test_prepend_list_of_lists_false_green_single_quote_gh488(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#488)
+    async def test_prepend_list_of_lists_reparseable_gh488(self) -> None:
+        """INVERTED (GH#487 B-5, #488 PREPEND list-element synthesis landed): clean round-trip.
 
-        PREPEND variant of the #488 single-quote false-green on a list-of-lists target.
+        PREPEND variant of the formerly-false-green #488 list-of-lists case; now re-parseable.
+        Retained as the negative-history regression guard.
         """
         result, emitted = await _roundtrip(_DOC_LIST_OF_LISTS, {"RECENT": {"$op": "PREPEND", "value": [["PR_485::x"]]}})
-        assert result.get("status") == "success", "current: write reports success (false-green)"
-        exc = _reparse_error(emitted)
-        assert exc is not None, f"current bug: emitted output should FAIL strict re-parse; got:\n{emitted}"
-        assert isinstance(exc, LexerError), f"current bug: E005 lexer rejection expected, got {exc!r}"
-        assert "'" in emitted, "current bug: element emitted with single quotes"
+        assert result.get("status") == "success"
+        assert _strict_reparses(emitted), f"GH#487 #488: emitted output must round-trip; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    async def test_append_nested_dict_element_false_green_gh488(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#488)
+    async def test_append_nested_dict_element_reparseable_gh488(self) -> None:
+        """INVERTED (GH#487 B-5, #488 dict-element synthesis landed): clean round-trip.
 
-        APPEND a dict element onto a list emits a Python-repr ``{'NESTED': 'v'}`` which the strict
-        lexer rejects (E005, unexpected ``{``). Same emitter/serialization family as #488/#484.
-        ``status: success`` — false-green.
+        Formerly a characterization pin documenting the Python-repr false-green (APPEND a dict
+        element emitted ``{'NESTED': 'v'}`` failing strict re-parse). GH#487 B-5 normalizes the
+        dict item to an InlineMap, emitting a re-parseable bare ``NESTED::v`` pair. Retained as
+        the negative-history regression guard.
         """
         result, emitted = await _roundtrip(_DOC_FLAT_ARRAY, {"ITEMS": {"$op": "APPEND", "value": [{"NESTED": "v"}]}})
-        assert result.get("status") == "success", "current: write reports success (false-green)"
-        assert not _strict_reparses(emitted), f"current bug: emitted output should FAIL re-parse:\n{emitted}"
-        assert "{" in emitted, "current bug: dict element emitted as Python repr with braces"
+        assert result.get("status") == "success"
+        assert _strict_reparses(emitted), f"GH#487 #488: emitted output must round-trip; got:\n{emitted}"
+        assert "{" not in emitted, f"GH#487 #488: no Python-repr braces; got:\n{emitted}"
 
     @pytest.mark.asyncio
     async def test_bare_dict_new_top_key_nested_value_emits_block_gh440(self) -> None:
@@ -480,21 +477,19 @@ class TestCharacterizationKnownDefects:
         assert "SIBLING" not in emitted, f"GH#487 Q1: unmentioned SIBLING must be dropped; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    async def test_prepend_nested_dict_element_false_green_gh488(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#488)
+    async def test_prepend_nested_dict_element_reparseable_gh488(self) -> None:
+        """INVERTED (GH#487 B-5, #488 PREPEND dict-element synthesis landed): clean round-trip.
 
-        CDV PREPEND-DICT-ONTO-ARRAY cell — mirror of the APPEND-dict case. PREPEND a dict element
-        onto a list-of-lists emits a Python-repr ``{'NESTED': 'v'}`` which the strict lexer rejects
-        (E005, unexpected ``{``). ``status: success`` — false-green, same emitter family as #488.
+        CDV PREPEND-DICT-ONTO-ARRAY cell — mirror of the APPEND-dict case. Formerly a
+        characterization pin documenting the Python-repr false-green; GH#487 B-5 normalizes the
+        dict item so it emits re-parseably. Retained as the negative-history regression guard.
         """
         result, emitted = await _roundtrip(
             _DOC_LIST_OF_LISTS, {"RECENT": {"$op": "PREPEND", "value": [{"NESTED": "v"}]}}
         )
-        assert result.get("status") == "success", "current: write reports success (false-green)"
-        exc = _reparse_error(emitted)
-        assert exc is not None, f"current bug: emitted output should FAIL strict re-parse; got:\n{emitted}"
-        assert isinstance(exc, LexerError), f"current bug: E005 lexer rejection expected, got {exc!r}"
-        assert "{" in emitted, "current bug: dict element emitted as Python repr with braces"
+        assert result.get("status") == "success"
+        assert _strict_reparses(emitted), f"GH#487 #488: emitted output must round-trip; got:\n{emitted}"
+        assert "{" not in emitted, f"GH#487 #488: no Python-repr braces; got:\n{emitted}"
 
 
 # ===========================================================================
@@ -510,45 +505,24 @@ class TestDesiredContractGH488:
     """#488: APPEND/PREPEND onto a list-of-lists must emit strict-re-parseable output."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#488 + GH#487 contract (#488 clause): APPEND onto list-of-lists must NOT emit "
-        "single-quoted inline strings; emitted output MUST strict-re-parse (I1 round-trip).",
-        strict=True,
-    )
     async def test_append_list_of_lists_emits_reparseable(self) -> None:
         result, emitted = await _roundtrip(_DOC_LIST_OF_LISTS, {"RECENT": {"$op": "APPEND", "value": [["PR_485::x"]]}})
         assert result.get("status") == "success"
         assert _strict_reparses(emitted), f"DESIRED: emitted output must round-trip; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#488 + GH#487 contract (#488 clause): PREPEND onto list-of-lists must emit "
-        "strict-re-parseable output (no single-quoted inline strings).",
-        strict=True,
-    )
     async def test_prepend_list_of_lists_emits_reparseable(self) -> None:
         result, emitted = await _roundtrip(_DOC_LIST_OF_LISTS, {"RECENT": {"$op": "PREPEND", "value": [["PR_485::x"]]}})
         assert result.get("status") == "success"
         assert _strict_reparses(emitted), f"DESIRED: emitted output must round-trip; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#488 + GH#487 contract (#488/serialization family): APPEND of a dict element must "
-        "emit re-parseable form (block/double-quoted), never a Python repr with braces.",
-        strict=True,
-    )
     async def test_append_nested_dict_element_emits_reparseable(self) -> None:
         result, emitted = await _roundtrip(_DOC_FLAT_ARRAY, {"ITEMS": {"$op": "APPEND", "value": [{"NESTED": "v"}]}})
         assert result.get("status") == "success"
         assert _strict_reparses(emitted), f"DESIRED: emitted output must round-trip; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#488 + GH#487 contract (#488 clause, PREPEND-DICT-ONTO-ARRAY, CDV blind cell): "
-        "PREPEND of a dict element onto a list-of-lists must emit re-parseable form "
-        "(block/double-quoted), never a Python repr with braces.",
-        strict=True,
-    )
     async def test_prepend_nested_dict_element_emits_reparseable(self) -> None:
         result, emitted = await _roundtrip(
             _DOC_LIST_OF_LISTS, {"RECENT": {"$op": "PREPEND", "value": [{"NESTED": "v"}]}}

--- a/tests/unit/test_changes_mode_roundtrip_characterization.py
+++ b/tests/unit/test_changes_mode_roundtrip_characterization.py
@@ -384,13 +384,14 @@ class TestCharacterizationKnownDefects:
         assert "NEW_CHILD" in emitted
 
     @pytest.mark.asyncio
-    async def test_merge_scalar_over_block_duplicate_keys_gh443_defect2(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#443 Defect 2)
+    async def test_merge_scalar_over_block_rejected_gh443_defect2(self) -> None:
+        """INVERTED (GH#487 B-3, Defect-2 REJECT landed): MERGE scalar-over-block is now rejected.
 
-        ``{"$op":"MERGE"}`` of a SCALAR over an existing nested BLOCK child leaves the BLOCK in
-        place AND appends a flat scalar of the same name → DUPLICATE KEYS at the same scope.
-        ``status: success``; the lenient parser even re-parses it. The contract requires explicit
-        resolution (replace the BLOCK or E_OP_TARGET_MISMATCH) — NEVER duplicate keys.
+        Formerly a characterization pin documenting the duplicate-keys bug (the BLOCK left in
+        place AND a flat scalar of the same name appended, status:success). GH#487 firmed the
+        scalar<->BLOCK transition to REJECT-only: the MERGE now fails with E_OP_TARGET_MISMATCH
+        and NO duplicate keys are emitted. Retained as the negative-history regression guard
+        (converse of ``test_merge_scalar_over_block_rejected_op_target_mismatch``).
         """
         doc = (
             "===EXAMPLE===\n"
@@ -403,12 +404,10 @@ class TestCharacterizationKnownDefects:
             "  PKG::y\n"
             "===END===\n"
         )
-        result, emitted = await _roundtrip(doc, {"PARENT": {"$op": "MERGE", "value": {"CHEVRON": "migrated"}}})
-        assert result.get("status") == "success", "current: write reports success (false-green)"
-        # Current bug: CHEVRON appears twice (BLOCK header + flat scalar) in the same scope.
-        assert (
-            _count_key_occurrences(emitted, "CHEVRON") >= 2
-        ), f"current bug: duplicate CHEVRON keys expected; got:\n{emitted}"
+        result, _ = await _roundtrip(doc, {"PARENT": {"$op": "MERGE", "value": {"CHEVRON": "migrated"}}})
+        codes = [e.get("code") for e in result.get("errors", [])]
+        assert "E_OP_TARGET_MISMATCH" in codes, f"GH#487 Defect-2: expected E_OP_TARGET_MISMATCH; got: {codes}"
+        assert result.get("status") != "success", "GH#487 Defect-2: scalar-over-BLOCK MERGE must not succeed"
 
     @pytest.mark.asyncio
     async def test_bare_scalar_over_block_full_replace_gh443_defect2(self) -> None:
@@ -607,13 +606,6 @@ class TestDesiredContractGH443Defect2:
     """#443 Defect 2: scalar<->BLOCK transition resolved explicitly — NEVER duplicate keys."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#443 Defect 2 + GH#487 contract REFINEMENT (CDV CONDITIONAL-GO firmed the "
-        "scalar<->BLOCK ruling to REJECT-only, not honour): a MERGE of a scalar over an existing "
-        "nested BLOCK MUST be REJECTED with E_OP_TARGET_MISMATCH (not honoured) — NEVER emit "
-        "duplicate keys, NEVER status:success. Cite I3 + GH#487 contract refinement.",
-        strict=True,
-    )
     async def test_merge_scalar_over_block_rejected_op_target_mismatch(self) -> None:
         doc = (
             "===EXAMPLE===\n"

--- a/tests/unit/test_changes_mode_roundtrip_characterization.py
+++ b/tests/unit/test_changes_mode_roundtrip_characterization.py
@@ -542,6 +542,38 @@ class TestDesiredContractGH440:
         # Desired canonical nested form is BLOCK, not an inline map.
         assert "[OUTER::" not in emitted, f"DESIRED: no inline nested map; got:\n{emitted}"
 
+    @pytest.mark.asyncio
+    async def test_existing_scalar_replaced_by_nested_dict_emits_block(self) -> None:
+        """GH#487 CE BLOCKING regression: existing FLAT SCALAR replaced by a bare nested dict.
+
+        A bare nested-dict payload at a KEY that ALREADY holds a flat scalar must, per the Q1
+        (FULL REPLACE) + Q2 (BLOCK is the sole canonical nested form) contract, synthesize
+        canonical BLOCK form — NOT the legacy nested-InlineMap coercion (``KEY::[OUTER::[INNER::v]]``)
+        which failed strict re-parse with E_NESTED_INLINE_MAP (an I1 round-trip violation, reported
+        ``status:success`` — a false-green). The existing-Block and new-key paths already synthesized
+        BLOCK; this existing-scalar->nested-dict branch was missed (document_mutator.py legacy
+        full-value replacement). Asserts: (a) success, (b) BLOCK form (no inline map), (c) strict
+        re-parse, (d) the I4 TRANSFORM::INLINE_MAP_TO_BLOCK (TN_INLINE_MAP_TO_BLOCK) receipt is
+        logged with the key as the stable structural id.
+        """
+        result, emitted = await _roundtrip(_DOC_SCALAR_KEY, {"KEY": {"OUTER": {"INNER": "v"}}})
+        # (a) success
+        assert result.get("status") == "success", f"expected success; got: {result.get('errors')}"
+        # (b) BLOCK form — no inline nested map for the replaced scalar
+        assert "[OUTER::" not in emitted, f"DESIRED: no inline nested map; got:\n{emitted}"
+        assert "KEY:" in emitted, f"DESIRED: KEY emits as a BLOCK header; got:\n{emitted}"
+        # (c) strict re-parse (no E_NESTED_INLINE_MAP)
+        exc = _reparse_error(emitted)
+        assert exc is None, f"DESIRED: BLOCK-form emit must round-trip; got reparse error {exc!r}:\n{emitted}"
+        # (d) I4 transform logged with a stable structural id (the key)
+        corrections = result.get("corrections") or []
+        transform_codes = [c for c in corrections if c.get("code") == "TN_INLINE_MAP_TO_BLOCK"]
+        assert transform_codes, (
+            "DESIRED: I4 TRANSFORM::INLINE_MAP_TO_BLOCK must be logged; " f"corrections={corrections}"
+        )
+        keys_logged = {str(c.get("before", "")).split("::", 1)[0] for c in transform_codes}
+        assert "KEY" in keys_logged, f"DESIRED: I4 receipt for 'KEY' (stable id); got: {keys_logged}"
+
 
 class TestDesiredContractGH443aFullReplace:
     """#443a / Q1: bare-dict at a top-level KEY = FULL REPLACE (drop unmentioned children, I3)."""

--- a/tests/unit/test_changes_mode_roundtrip_characterization.py
+++ b/tests/unit/test_changes_mode_roundtrip_characterization.py
@@ -350,20 +350,20 @@ class TestCharacterizationKnownDefects:
         assert "{" in emitted, "current bug: dict element emitted as Python repr with braces"
 
     @pytest.mark.asyncio
-    async def test_bare_dict_new_top_key_nested_value_false_green_gh440(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#440)
+    async def test_bare_dict_new_top_key_nested_value_emits_block_gh440(self) -> None:
+        """INVERTED (GH#487 B-4, Q2 dict->BLOCK landed): nested dict now emits BLOCK form.
 
-        A bare-dict at a NEW top-level KEY whose value is itself a nested dict is coerced into a
-        nested InlineMap (``NEWKEY::[OUTER::[INNER::v]]``). ``status: success`` but the strict
-        parser rejects it with ``E_NESTED_INLINE_MAP``. This is the Q2 (#440) ``dict->InlineMap``
-        coercion that the ratified contract abolishes in favour of BLOCK form at emit.
+        Formerly a characterization pin documenting the dict->InlineMap coercion bug (nested
+        ``NEWKEY::[OUTER::[INNER::v]]`` failing strict re-parse with E_NESTED_INLINE_MAP). GH#487
+        Q2 (#440) DEFERRED_CANONICALIZATION abolishes the coercion: a bare-dict at a NEW top-level
+        KEY whose value is a nested dict is synthesized as BLOCK form (sole canonical nested form),
+        which strict-re-parses cleanly. Retained as the negative-history regression guard
+        (converse of ``test_bare_dict_new_top_key_nested_value_emits_block``).
         """
         result, emitted = await _roundtrip(_DOC_SCALAR_KEY, {"NEWKEY": {"OUTER": {"INNER": "v"}}})
-        assert result.get("status") == "success", "current: write reports success (false-green)"
-        exc = _reparse_error(emitted)
-        assert exc is not None, f"current bug: nested inline map should FAIL re-parse:\n{emitted}"
-        assert isinstance(exc, ParserError), f"current bug: E_NESTED_INLINE_MAP expected, got {exc!r}"
-        assert "E_NESTED_INLINE_MAP" in str(exc), f"current bug: expected E_NESTED_INLINE_MAP; got {exc}"
+        assert result.get("status") == "success"
+        assert _strict_reparses(emitted), f"GH#487 Q2: BLOCK-form emit must round-trip; got:\n{emitted}"
+        assert "[OUTER::" not in emitted, f"GH#487 Q2: no inline nested map; got:\n{emitted}"
 
     @pytest.mark.asyncio
     async def test_bare_dict_top_key_over_block_full_replace_gh443a(self) -> None:
@@ -561,13 +561,6 @@ class TestDesiredContractGH440:
     """#440 / Q2: nested dict values serialize as BLOCK at emit (dict->InlineMap abolished)."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#440 + GH#487 contract Q2 (DEFERRED_CANONICALIZATION): a bare-dict at a top-level "
-        "KEY with a nested dict value MUST emit BLOCK form (sole canonical nested form) and "
-        "strict-re-parse; dict->InlineMap coercion is abolished. Transform logged TRANSFORM::"
-        "INLINE_MAP_TO_BLOCK (I4).",
-        strict=True,
-    )
     async def test_bare_dict_new_top_key_nested_value_emits_block(self) -> None:
         result, emitted = await _roundtrip(_DOC_SCALAR_KEY, {"NEWKEY": {"OUTER": {"INNER": "v"}}})
         assert result.get("status") == "success"

--- a/tests/unit/test_changes_mode_roundtrip_characterization.py
+++ b/tests/unit/test_changes_mode_roundtrip_characterization.py
@@ -366,20 +366,21 @@ class TestCharacterizationKnownDefects:
         assert "E_NESTED_INLINE_MAP" in str(exc), f"current bug: expected E_NESTED_INLINE_MAP; got {exc}"
 
     @pytest.mark.asyncio
-    async def test_bare_dict_top_key_over_block_silent_merge_gh443a(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#443a)
+    async def test_bare_dict_top_key_over_block_full_replace_gh443a(self) -> None:
+        """INVERTED (GH#487 B-2, Q1 FULL REPLACE landed): bare-dict over a Block now full-replaces.
 
-        A bare-dict at a top-level KEY that already holds a nested BLOCK performs a SILENT MERGE:
-        unmentioned children (CHILD_A, CHILD_B) are PRESERVED and the new child is appended.
-        The ratified Q1 contract makes this a FULL REPLACE (drop unmentioned children, honour I3).
-        ``status: success``, output reparses — the corruption is semantic, not syntactic.
+        Formerly a characterization pin documenting the silent-MERGE bug (unmentioned children
+        CHILD_A/CHILD_B preserved + new child appended). GH#487 Q1 inverts this to a FULL REPLACE
+        (HARD BREAK v1.15): unmentioned children are DROPPED (honours I3). Retained as the
+        negative-history regression guard for the fixed behaviour; the converse of the
+        desired-contract cell ``test_bare_dict_top_key_over_block_full_replace``.
         """
         result, emitted = await _roundtrip(_DOC_NESTED_BLOCK, {"PARENT": {"NEW_CHILD": "added"}})
         assert result.get("status") == "success"
-        assert _strict_reparses(emitted), "current: output is syntactically valid (semantic-only defect)"
-        # Current silent-MERGE: unmentioned children survive.
-        assert "CHILD_A" in emitted, "current bug: unmentioned child CHILD_A preserved (silent merge)"
-        assert "CHILD_B" in emitted, "current bug: unmentioned child CHILD_B preserved (silent merge)"
+        assert _strict_reparses(emitted), f"output must round-trip; got:\n{emitted}"
+        # GH#487 Q1 FULL REPLACE: unmentioned children are now DROPPED.
+        assert "CHILD_A" not in emitted, f"GH#487 Q1: unmentioned CHILD_A must be dropped; got:\n{emitted}"
+        assert "CHILD_B" not in emitted, f"GH#487 Q1: unmentioned CHILD_B must be dropped; got:\n{emitted}"
         assert "NEW_CHILD" in emitted
 
     @pytest.mark.asyncio
@@ -410,18 +411,20 @@ class TestCharacterizationKnownDefects:
         ), f"current bug: duplicate CHEVRON keys expected; got:\n{emitted}"
 
     @pytest.mark.asyncio
-    async def test_bare_scalar_over_block_duplicate_keys_gh443_defect2(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#443 Defect 2)
+    async def test_bare_scalar_over_block_full_replace_gh443_defect2(self) -> None:
+        """INVERTED (GH#487 B-2, Q1 FULL REPLACE landed): bare-scalar over a Block now replaces it.
 
-        A bare SCALAR (no ``$op``) assigned to a top-level KEY that holds a nested BLOCK leaves the
-        BLOCK in place AND appends a flat scalar of the same name → DUPLICATE KEYS at the same scope.
-        ``status: success``. Non-MERGE variant of the scalar<->BLOCK transition footgun.
+        Formerly a characterization pin documenting the duplicate-keys bug (Block left in place
+        AND a flat scalar of the same name appended). GH#487 Q1 FULL REPLACE (scalar<->BLOCK
+        transition) replaces the Block with a single flat Assignment IN PLACE — exactly one key.
+        Retained as the negative-history regression guard for the fixed behaviour.
         """
         result, emitted = await _roundtrip(_DOC_NESTED_BLOCK, {"PARENT": "flat_now"})
-        assert result.get("status") == "success", "current: write reports success (false-green)"
+        assert result.get("status") == "success"
         assert (
-            _count_key_occurrences(emitted, "PARENT") >= 2
-        ), f"current bug: duplicate PARENT keys expected; got:\n{emitted}"
+            _count_key_occurrences(emitted, "PARENT") == 1
+        ), f"GH#487 Q1: exactly one PARENT key after scalar-over-block replace; got:\n{emitted}"
+        assert _strict_reparses(emitted), f"output must round-trip; got:\n{emitted}"
 
     @pytest.mark.asyncio
     async def test_validate_block_vs_flat_collision_detected_gh443(self) -> None:
@@ -454,28 +457,28 @@ class TestCharacterizationKnownDefects:
         ), f"GH#487: BLOCK-vs-flat collision must now be DETECTED; repair_log={result.get('repair_log')}"
 
     @pytest.mark.asyncio
-    async def test_literal_zone_replace_silent_merge_keeps_sibling_gh460a(self) -> None:
-        """CHARACTERIZATION: documents current buggy behavior, will flip when #487 lands. (#460 Case A / #443a)
+    async def test_literal_zone_replace_preserves_fence_and_drops_sibling_gh460a(self) -> None:
+        """INVERTED (GH#487 B-2, CDV BLOCKING-1 landed): fence preserved AND sibling dropped.
 
         CDV BLOCKING-1 cell. A bare-dict FULL REPLACE at a top-level Block (``PARENT``) whose
         payload re-mentions the fenced child (``CODE``) with a plain str value:
-          - CURRENT: the fence FORM of the mentioned child IS preserved (the #460 Case A path,
+          - The fence FORM of the mentioned child is PRESERVED (the #460 Case A path,
             ``_normalize_value_for_ast_preserving``, re-wraps the plain str as a LiteralZoneValue —
-            so it emits ``CODE::`` + a ``\\`\\`\\``` fence, not ``CODE::\"...\"``). I1 form-preservation
-            already works for the mentioned child.
-          - CURRENT BUG: the operation is still a SILENT MERGE — the UNMENTIONED ``SIBLING`` child
-            is PRESERVED. Under the ratified Q1 FULL-REPLACE contract it must be dropped.
-        ``status: success``, output reparses (semantic-only defect on the sibling).
+            so it emits ``CODE::`` + a fence, not ``CODE::\"...\"``). I1 form-preservation holds.
+          - GH#487 Q1 FULL REPLACE: the UNMENTIONED ``SIBLING`` child is now DROPPED.
+        Formerly a characterization pin documenting the silent-MERGE sibling-survives bug; now the
+        negative-history regression guard for the fixed behaviour (converse of
+        ``test_literal_zone_replace_preserves_fence_and_drops_sibling``).
         """
         result, emitted = await _roundtrip(_DOC_LITERAL_ZONE_BLOCK, {"PARENT": {"CODE": "new plain content"}})
         assert result.get("status") == "success"
-        assert _strict_reparses(emitted), f"current: output is syntactically valid; got:\n{emitted}"
-        # Fence form preserved for the mentioned child (already-correct #460 Case A behaviour).
-        assert "```" in emitted, f"current: fence form preserved for mentioned child; got:\n{emitted}"
-        assert 'CODE::"' not in emitted, f"current: must NOT downgrade fence to quoted scalar; got:\n{emitted}"
-        assert "new plain content" in emitted, "current: content was swapped into the fence"
-        # Silent-merge defect: the unmentioned sibling survives.
-        assert "SIBLING" in emitted, f"current bug: unmentioned SIBLING preserved (silent merge); got:\n{emitted}"
+        assert _strict_reparses(emitted), f"output must round-trip; got:\n{emitted}"
+        # Fence form preserved for the mentioned child (#460 Case A / BLOCKING-1).
+        assert "```" in emitted, f"fence form preserved for mentioned child; got:\n{emitted}"
+        assert 'CODE::"' not in emitted, f"fence must NOT downgrade to quoted scalar; got:\n{emitted}"
+        assert "new plain content" in emitted, "content was swapped into the fence"
+        # GH#487 Q1 FULL REPLACE: the unmentioned sibling is now dropped.
+        assert "SIBLING" not in emitted, f"GH#487 Q1: unmentioned SIBLING must be dropped; got:\n{emitted}"
 
     @pytest.mark.asyncio
     async def test_prepend_nested_dict_element_false_green_gh488(self) -> None:
@@ -578,12 +581,6 @@ class TestDesiredContractGH443aFullReplace:
     """#443a / Q1: bare-dict at a top-level KEY = FULL REPLACE (drop unmentioned children, I3)."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#443a + GH#487 contract Q1 (HARD BREAK v1.15): a bare-dict at a top-level KEY "
-        "executes FULL REPLACE — unmentioned children are DROPPED (honours I3: reflect only "
-        "what's present). Explicit {'$op':'MERGE'} is required to merge.",
-        strict=True,
-    )
     async def test_bare_dict_top_key_over_block_full_replace(self) -> None:
         result, emitted = await _roundtrip(_DOC_NESTED_BLOCK, {"PARENT": {"NEW_CHILD": "added"}})
         assert result.get("status") == "success"
@@ -594,15 +591,6 @@ class TestDesiredContractGH443aFullReplace:
         assert "NEW_CHILD" in emitted, "DESIRED: the mentioned child must be present"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#487 BLOCKING-1 (CDV CONDITIONAL-GO) + GH#460 Case A + I1 (Syntactic Fidelity): a "
-        "bare-dict FULL REPLACE at a top-level Block that re-mentions a LITERAL-ZONE child with a "
-        "plain str MUST (a) form-preserve the mentioned child's fence (route via "
-        '_normalize_value_for_ast_preserving, write_mutation.py:243 — emit a fence, not KEY::"...") '
-        "AND (b) DROP unmentioned siblings (Q1 full replace). Currently the fence is preserved but "
-        "the unmentioned sibling survives (silent merge).",
-        strict=True,
-    )
     async def test_literal_zone_replace_preserves_fence_and_drops_sibling(self) -> None:
         result, emitted = await _roundtrip(_DOC_LITERAL_ZONE_BLOCK, {"PARENT": {"CODE": "new plain content"}})
         assert result.get("status") == "success"
@@ -646,11 +634,6 @@ class TestDesiredContractGH443Defect2:
         assert result.get("status") != "success", "DESIRED: scalar-over-BLOCK MERGE must not succeed"
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="GH#443 Defect 2 + GH#487 contract: a bare scalar assigned over an existing nested "
-        "BLOCK at a top-level KEY MUST full-replace the BLOCK (Q1) — NEVER emit duplicate keys.",
-        strict=True,
-    )
     async def test_bare_scalar_over_block_no_duplicate_keys(self) -> None:
         result, emitted = await _roundtrip(_DOC_NESTED_BLOCK, {"PARENT": "flat_now"})
         assert result.get("status") == "success"


### PR DESCRIPTION
## GH#487 Phase 2 — DocumentMutator build (T4, HARD BREAK v1.15)

Implements the operator-ratified, debate-hall-settled (`decision_hash a8837c80…`) + CDV CONDITIONAL-GO contract from the [Phase-1b blueprint](https://github.com/elevanaltd/octave-mcp/issues/487#issuecomment-4585386838). Extracts the absent domain-mutation layer (`STRATEGY_S3`) and flips all 9 `xfail(strict)` acceptance cells GREEN. RED→GREEN per cell with git evidence.

**Do not merge** — this is for the T4 review chain (TMG→CRS→CE→CIV→PE) + `/review`. Version bump + PyPI publish are Phase 3 (out of scope here).

### The seam (CDV R2 anti-drift) — held
- `DocumentMutator` (`src/octave_mcp/mcp/document_mutator.py`) **owns** transition logic (Q1 FULL-REPLACE, Defect-2 reject, MERGE-vs-REPLACE) + structural AST synthesis (born-dirty `Block`/`Assignment` nodes, key-wise reconciliation, drop-unmentioned, span hygiene).
- The emitter (`core/emitter.py` via `write_format.py` Strategy A) remains the **sole** canonicalizer-to-bytes. **No emitter change. No node indentation metadata added** — `emit_block`/`emit_assignment` compute indentation purely from recursion depth, so born-dirty synthetic Blocks emit correctly by construction (BLOCK-FROM-DICT resolved to LOW risk, confirmed live).
- R2: `_SECTION_PATH_RE` relocated to the leaf `write_mutation.py` so the WriteTool and the mutator share ONE definition.

### Commit-by-commit (blueprint §7)
1. **B-1** `d973227` — **pure relocation, zero behaviour change.** Per-key body of `_apply_changes` moved behind `DocumentMutator.apply_change`; `_apply_changes` becomes a thin loop. Full suite identical to baseline (3724 passed / 12 xfailed).
2. **B-2** `e1a7111` — **Q1 FULL REPLACE (HARD BREAK).** `_full_replace_block` key-wise reconciliation; bare-scalar-over-block in-place replace. Flips cells 6, 7, 9.
3. **B-3** `27868db` — **Defect-2 reject.** `E_OP_TARGET_MISMATCH` on scalar-over-child-block under `$op:MERGE`, surfaced pre-apply (validator) + apply-side net. Flips cell 8.
4. **B-4** `883dfb9` — **Q2 dict→BLOCK + I4.** `_synthesize_block_from_dict`; abolish nested `dict→InlineMap`; log `TRANSFORM::INLINE_MAP_TO_BLOCK` (`TN_INLINE_MAP_TO_BLOCK`). Flips cell 5.
5. **B-5** `d158c71` — **#488 list-element synthesis.** Normalize new APPEND/PREPEND list items so nested list/dict elements emit re-parseably. Flips cells 1–4.
6. **CHANGELOG** `55a31df` — v1.15 breaking-change migration note (no version bump).

B-6 (#484 guard relaxation for REPLACE) required **no code change**: the guard was always scoped to `$op == "MERGE"`; routing bare-dict through FULL REPLACE/BLOCK synthesis (B-2/B-4) is the "relaxation," and the guard correctly still fires under MERGE (verified live).

### §6 traceability — all 9 cells flipped GREEN
| # | xfail cell | flipped by |
|---|---|---|
| 1 | `GH488::test_append_list_of_lists_emits_reparseable` | B-5 |
| 2 | `GH488::test_prepend_list_of_lists_emits_reparseable` | B-5 |
| 3 | `GH488::test_append_nested_dict_element_emits_reparseable` | B-5 |
| 4 | `GH488::test_prepend_nested_dict_element_emits_reparseable` | B-5 |
| 5 | `GH440::test_bare_dict_new_top_key_nested_value_emits_block` | B-4 |
| 6 | `GH443a::test_bare_dict_top_key_over_block_full_replace` | B-2 |
| 7 | `GH443a::test_literal_zone_replace_preserves_fence_and_drops_sibling` | B-2 |
| 8 | `GH443Defect2::test_merge_scalar_over_block_rejected_op_target_mismatch` | B-3 |
| 9 | `GH443Defect2::test_bare_scalar_over_block_no_duplicate_keys` | B-2 |

The 9 corresponding characterization pins are inverted to guard the fixed behaviour (negative-history regression guards).

### Quality gates (T4)
- Characterization net: **27 passed / 0 xfailed** (was 18/9).
- Full suite: **3733 passed / 3 xfailed** (xfailed dropped by 9 — exactly the 9 targets). ruff / black / mypy clean.
- **2 pre-existing unrelated failures** remain and are NOT in scope: `test_agent_definition_schema.py::…[ideator.oct.md]` and `…[synthesizer.oct.md]` (#461-family). They fail identically on the base commit.
- The 3 remaining xfails are pre-existing and unrelated: decision-log schema, snake-case-blob v1 miss, parser comment span.

### Invariants
PROD::I1 (re-parseable round-trip on all emitted forms), I3 (drop-unmentioned = reflect-only-present; reject silent structural destruction), I4 (`TRANSFORM::INLINE_MAP_TO_BLOCK` logged with stable structural ids), I5 (validate read path untouched), R2 (one mutation path; emitter sole byte canon).

### Out of scope / follow-up
- v1.15.0 version bump + PyPI publish (Phase 3).
- The two optional TMG edge cases (flat-then-block ordering, 3-way same-scope collision) — these are validator-**detection** edge cases (Phase 1a's domain, already merged) and would materially expand this PR beyond the DocumentMutator; left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `DocumentMutator` to own changes‑mode mutations and completes GH#487 Phase 2 semantics. Adds full‑replace for bare dicts (hard break), nested dicts -> BLOCKs (including when replacing a scalar) with audit logging, rejects MERGE scalar‑over‑block, and normalizes list items for strict round‑trips.

- **New Features**
  - Added `DocumentMutator` to centralize transition logic and AST synthesis; `_SECTION_PATH_RE` moved to `write_mutation.py` for shared use; emitter unchanged.
  - Bare dict at a key now does FULL REPLACE of the existing block; unmentioned children are dropped.
  - Bare scalar over a block replaces it in place; `$op:"MERGE"` scalar‑over‑block is rejected with `E_OP_TARGET_MISMATCH`.
  - Nested dicts synthesize BLOCKs (audit rule `TN_INLINE_MAP_TO_BLOCK`); this also applies when replacing an existing scalar. Audit receipts now surface by wrapping `_apply_changes` in `tier_normalize.active(...)`.
  - `$op:APPEND`/`$op:PREPEND` normalize nested list/dict items so output strict‑re‑parses.

- **Migration**
  - If you relied on implicit merge with a bare dict, switch to `{"$op":"MERGE","value":{...}}` to preserve unmentioned children.
  - To replace a child block with a scalar, delete it first or send a bare‑dict replace at the parent; MERGE no longer allows this.

<sup>Written for commit 754704b5b5022e287663b6208a779466d5fa7654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

