### PR TITLE
chore(release): v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-05-31 - "STRATEGY_S3 DocumentMutator — changes-mode value semantics (HARD BREAK)"
+
 ### ⚠️ BREAKING — `octave_write` `changes` mode value semantics (GH#487, v1.15.0)
 
 > **Migration in one line:** a **bare dict** at a `changes` KEY now **fully replaces** that key (unmentioned children are **dropped**). To merge into an existing block, you **MUST** now send an explicit `{"$op": "MERGE", "value": {…}}`.
@@ -1057,7 +1059,8 @@ the architectural separation of the OCTAVE language specification from implement
 - Non-reasoning document processing
 - Deterministic, idempotent transformations
 
-[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.14.0...HEAD
+[Unreleased]: https://github.com/elevanaltd/octave-mcp/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.14.0...v1.15.0
 [1.14.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.13.1...v1.14.0
 [1.13.1]: https://github.com/elevanaltd/octave-mcp/compare/v1.13.0...v1.13.1
 [1.13.0]: https://github.com/elevanaltd/octave-mcp/compare/v1.12.0...v1.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "octave-mcp"
-version = "1.14.0"
+version = "1.15.0"
 description = "OCTAVE MCP Server - Lenient-to-Canonical OCTAVE pipeline with schema validation and generative holographic contracts"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -607,7 +607,7 @@ wheels = [
 
 [[package]]
 name = "octave-mcp"
-version = "1.14.0"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## chore(release): v1.15.0

**Release-prep PR only.** No code changes, no logic — version bump + CHANGELOG date + lockfile pin. The git tag and GitHub Release (the publish trigger) are a **separate operator step** that follows merge; this PR does not tag, release, or publish to PyPI.

### What changed (3 files)
- **`pyproject.toml`** — `[project] version` `1.14.0` → `1.15.0` (the sole package-version source; `src/octave_mcp/__init__.py` resolves `__version__` dynamically via importlib metadata, so nothing else to bump).
- **`uv.lock`** — `octave-mcp` project pin `1.14.0` → `1.15.0`, regenerated via `uv lock`. Verified the project version line is the **only** change (no dependency churn).
- **`CHANGELOG.md`** — folded the reviewed `[Unreleased]` breaking-change block into a dated `## [1.15.0] - 2026-05-31 - "STRATEGY_S3 DocumentMutator — changes-mode value semantics (HARD BREAK)"` heading (empty `[Unreleased]` placeholder kept per repo convention); compare-links updated (`[Unreleased]` → `v1.15.0...HEAD`, added `[1.15.0]` → `v1.14.0...v1.15.0`). The migration note stays prominent at the top of the section.

### v1.15.0 contents
- **#487 STRATEGY_S3 `DocumentMutator` — changes-mode value semantics (HARD BREAK).** Operator-ratified as a **minor** (v1.15.0, not 2.0.0); the break is documented via the CHANGELOG migration note. Merged via PR #491 (full T4 chain: TMG/CRS/CIV APPROVED, CE rework landed).
  - **Q1** — bare-dict/scalar at a top-level KEY = **FULL REPLACE**; unmentioned children **dropped** (I3). To merge, callers **MUST** send explicit `{"$op":"MERGE","value":{…}}`. Key-wise reconciliation form-preserves re-mentioned literal-zone children (I1).
  - **Q2** — nested dicts canonicalize to **BLOCK** at emit (sole canonical nested form); `dict→InlineMap` coercion abolished; `TRANSFORM::INLINE_MAP_TO_BLOCK` logged (I4).
  - **Defect-2** — scalar-over-nested-BLOCK via `$op:MERGE` → **`E_OP_TARGET_MISMATCH`** (REJECT-only); never duplicate keys.
  - **#488** — APPEND/PREPEND of nested list/dict elements now emit re-parseable OCTAVE (closes the I1 round-trip false-green).
  - **#484** guard retained (fires only under explicit `$op:MERGE`).
- **#490 Phase 1a validator detection baseline** (BLOCK-vs-flat same-name collision) — already on main.

Closes the version/changelog portion of #487 Phase 3. See #487 for the full design + decision record.

### Verification
- `ruff` / `black --check` / `mypy` clean.
- `pytest`: **3734 passed / 11 skipped / 3 xfailed** (the 2 `test_agent_definition_schema.py` `[ideator]`/`[synthesizer]` failures are pre-existing and unrelated — #461-family).
- Distribution sanity (mirrors the publish workflow): `python -m build` + `twine check dist/*` **PASSED** for `octave_mcp-1.15.0.tar.gz` and `octave_mcp-1.15.0-py3-none-any.whl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare v1.15.0 release by bumping the package version, adding a dated 1.15.0 section and compare links to the CHANGELOG, and syncing `uv.lock` to pin `octave-mcp` 1.15.0. No code changes; tagging and publishing happen after merge.

<sup>Written for commit fcdc7791d2588151ea7cf3e2cc5f34088584205d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

