### PR TITLE
docs: align octave-literacy and octave-mastery skill definitions with

### DIFF
--- a/src/octave_mcp/resources/skills/octave-literacy/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-literacy/SKILL.md
@@ -3,13 +3,13 @@ name: octave-literacy
 description: "LLM-native structured communication format. Teaches OCTAVE syntax rules, canonical forms, and warning prevention for zero-error .oct.md authoring."
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["octave format", "write octave", "octave syntax", "structured output", "OCTAVE basics", "OCTAVE literacy", "OCTAVE structure", "key::value", "OCTAVE notation", "llm communication", "token economy", "loss accounting"]
-version: "3.1.0"
+version: "3.2.1"
 ---
 
 ===OCTAVE_LITERACY===
 META:
   TYPE::SKILL
-  VERSION::"3.1.0"
+  VERSION::"3.2.1"
   STATUS::ACTIVE
   PURPOSE::"Zero-error OCTAVE authoring — syntax rules, canonical forms, warning prevention"
   OCTAVE::"Olympian Common Text And Vocabulary Engine — loss accounting system for LLM communication"
@@ -36,7 +36,7 @@ META:
   §1b::BRACKET_FORMS
     CONTAINER::"[a,b,c] — bare brackets = list"
     ANNOTATION::"NAME<qualifier> — semantic facet on identity (ATHENA<strategic_wisdom>, LLM<exclusively>)"
-    ANNOTATION_DISCIPLINE::"Annotations are SHORT qualifiers (1-3 words, ≤32 chars, identifier-only). Multi-word reasoning belongs in a sibling RATIONALE value with quoted prose."
+    ANNOTATION_DISCIPLINE::"Annotations are SHORT qualifiers (1-3 words, ≤32 chars, identifier-only). Multi-word reasoning belongs in a sibling RATIONALE value as a quoted telegraphic phrase (see octave-mastery §6a)."
     ANNOTATION_WRONG::"I6<migration_on_moving_target_is_anti_pattern_for_zero_warnings>"
     ANNOTATION_RIGHT::"I6<production_grade_quality> + RATIONALE::\"Migration on moving target is anti-pattern for strict typing during data model changes.\""
     CONSTRUCTOR::"NAME[args] — structured arguments on identifier (REGEX[pattern], ENUM[a,b], JIT_GRAMMAR_COMPILATION[META→GBNF])"
@@ -61,6 +61,22 @@ META:
       OCTAVE_about_OCTAVE
     ]
     FENCE_SCALING::"use N+1 backticks to wrap content containing N-backtick fences"
+  §1d::BLOCK_CANONICAL_FORMS
+    // Three shapes agents reach for when nesting — only one is correct
+    RULE::"Multi-field token (any key whose value is a map) → BLOCK form. Never inline-array root. Never flat prefix-scalars."
+    THREE_SHAPES:
+      ```
+      ✓ BLOCK (canonical):         ✗ inline-array root:              ✗ flat prefix-scalars:
+        PLATFORM:                    PLATFORM::[                        PLATFORM_TOKEN::HO-v1
+          TOKEN::HO-v1                 TOKEN::HO-v1,                   PLATFORM_RUNTIME_FLOOR::"Node >=22"
+          RUNTIME:                     RUNTIME::[FLOOR::"Node >=22"]]  PLATFORM_RUNTIME_BECAUSE::"…"
+            FLOOR::"Node >=22"
+            BECAUSE::"…"
+      ```
+    SCALAR_LIST_ONLY::"Inline arrays ([a,b,c]) are for scalar lists only — IMMUTABLES::[…], CONSOLIDATES::[a,b] — never for maps-of-maps"
+    WHY_BLOCK::"Indented children inherit parent context → fewer key tokens, better LLM attention, zero W_DUPLICATE_KEY collisions"
+    WHY_NOT_INLINE_ARRAY_ROOT::"Inline map as token root is non-canonical for map tokens even when values are atomic (§1b::INLINE_MAP). Triggers E_NESTED_INLINE_MAP as soon as any child value needs nesting — restructuring after the fact is mechanical waste. Use BLOCK form from the start."
+    WHY_NOT_FLAT_PREFIX::"PARENT_CHILD1 + PARENT_CHILD2 key proliferation destroys hierarchical grouping and LLM attention"
 §2::OPERATORS
   // Each operator encodes a relationship in a single token
   CONTAINER::"[] — List [a,b,c]"
@@ -82,6 +98,7 @@ META:
   R4::"Envelopes: ===NAME=== open, ===END=== close (NAME must be [A-Z_][A-Z0-9_]*)"
   R5::"true, false, null — lowercase only (NOT True, False, NULL)"
   R6::"∧ only inside brackets: [A∧B∧C] valid, bare A∧B invalid"
+  R6_CLARIFICATION::"Structural position: ∧ inside brackets only. Value position: operators inside quoted strings are valid telegraphic phrases — 'security ⇌ usability' not 'security at odds with usability' (see §2::TELEGRAPHIC_PHRASE, mastery §6a)"
   R7::"⇌ is binary only: A⇌B valid, chained A⇌B⇌C invalid"
   R8::"Values containing § must be quoted: \"see §3b\" not bare §3b"
   R9::"File extension .oct.md is canonical"
@@ -121,6 +138,8 @@ META:
   W_BARE_LINE_DROPPED::"Cause: line has no key:: prefix. Fix: add a key or use // comment."
   W_NUMERIC_KEY_DROPPED::"Cause: bare integer key (1::thing). Fix: use R1::thing or STEP_1::thing."
   W_CHECK::"After every octave_write call, inspect warnings[]. Today: Empty = clean. Non-empty = data lost. AFTER ADR-0006 SR1-T4: see §6 — empty no longer implies clean."
+  W_CHANGES_MODE_NESTED_MAP::"Cause: passing a nested dict as a changes-mode value to octave_write. Fix: use content_mode + format_style=preserve for any block-nested content. Changes-mode serializes nested dicts as inline maps → E_NESTED_INLINE_MAP. Exception: scalar-array appends (e.g. into AMENDS::[…]) remain changes-mode-friendly."
+  // W_CHANGES_MODE_NESTED_MAP: per octave-mcp changes-mode footgun — revisit post-ADR-0006-SR3-T2 when changes-mode gains native nesting support
   // Semantic of warnings[] is changing. See §6::FORTHCOMING_BEHAVIOR for timing markers.
 §5::WORKED_EXAMPLE
   // Shows: envelope, META with optional fields, separator, operators, annotation, loss accounting

--- a/src/octave_mcp/resources/skills/octave-literacy/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-literacy/SKILL.md
@@ -138,7 +138,7 @@ META:
   W_BARE_LINE_DROPPED::"Cause: line has no key:: prefix. Fix: add a key or use // comment."
   W_NUMERIC_KEY_DROPPED::"Cause: bare integer key (1::thing). Fix: use R1::thing or STEP_1::thing."
   W_CHECK::"After every octave_write call, inspect warnings[]. Today: Empty = clean. Non-empty = data lost. AFTER ADR-0006 SR1-T4: see §6 — empty no longer implies clean."
-  W_CHANGES_MODE_NESTED_MAP::"Cause: passing a nested dict as a changes-mode value to octave_write. Fix: use content_mode + format_style=preserve for any block-nested content. Changes-mode serializes nested dicts as inline maps → E_NESTED_INLINE_MAP. Exception: scalar-array appends (e.g. into AMENDS::[…]) remain changes-mode-friendly."
+  W_CHANGES_MODE_NESTED_MAP::"Cause: passing a nested dict as a changes-mode value to octave_write. Fix: use content= with format_style=preserve for any block-nested content. Changes-mode serializes nested dicts as inline maps → E_NESTED_INLINE_MAP. Exception: scalar-array appends (e.g. into AMENDS::[…]) remain changes-mode-friendly."
   // W_CHANGES_MODE_NESTED_MAP: per octave-mcp changes-mode footgun — revisit post-ADR-0006-SR3-T2 when changes-mode gains native nesting support
   // Semantic of warnings[] is changing. See §6::FORTHCOMING_BEHAVIOR for timing markers.
 §5::WORKED_EXAMPLE

--- a/src/octave_mcp/resources/skills/octave-mastery/SKILL.md
+++ b/src/octave_mcp/resources/skills/octave-mastery/SKILL.md
@@ -3,13 +3,13 @@ name: octave-mastery
 description: "Advanced semantic vocabulary, holographic contracts, and structural patterns for OCTAVE. REQUIRES octave-literacy. Extends literacy with mythology, archetype annotation, v6 contracts, and anti-pattern rules."
 allowed-tools: ["Read", "Write", "Edit"]
 triggers: ["octave architecture", "agent design", "semantic pantheon", "advanced octave", "OCTAVE mastery", "holographic patterns", "archetypes", "high-density specifications", "system architecture", "holographic contracts", "archetype annotation"]
-version: "3.0.0"
+version: "3.2.0"
 ---
 
 ===OCTAVE_MASTERY===
 META:
   TYPE::SKILL
-  VERSION::"3.0.0"
+  VERSION::"3.2.0"
   STATUS::ACTIVE
   PURPOSE::"Expert-level OCTAVE: mythology vocabulary, holographic contracts, archetype annotation, anti-patterns"
   REQUIRES::octave-literacy
@@ -140,13 +140,30 @@ CONDUCT:
     MUST_ALWAYS::[rule_a, rule_b]
     ```
   WRONG::"CONDUCT::[TONE::\"Precise\", PROTOCOL::[MUST_ALWAYS::[rule_a]]]"
+  RECOVERY_ON_E_NESTED_INLINE_MAP::"Fix is BLOCK form — NOT flatten-to-scalars (creates FLAT_PREFIX_SCALARS anti-pattern, §6), NOT collapse-to-blob (creates W_SNAKE_CASE_BLOB). The wrong escapes produce a different error class, not a solution."
 §6::ANTI_PATTERNS
   // Each has a concrete example of what NOT to do
   ISOLATED_LIST::"[auth, payments, users] with no relationships — use DECISION::microservice_extraction[auth⊕payments→independent_services] instead"
   FLAT_HIERARCHY::"All keys at top level with no grouping — group related keys under a parent BLOCK"
   BURIED_NETWORK::"RELATED_TO::other_service hidden in prose comment — use explicit operator: auth→payments[dependency]"
   OPERATOR_SOUP::"RESULT::A+B->C~D all in one expression — break into separate keyed fields"
-  PROSE_BLEED::"Using natural language sentences as values — every token must carry semantic payload"
+  PROSE_BLEED::"Stopword-laden English sentences as values — quoted telegraphic phrases ARE valid (see §6a). Ban applies when operators could compress the same semantics."
+  INLINE_ARRAY_ROOT::"TOKEN::[KEY::v, KEY2::v2] — inline map used as multi-field token root. Non-canonical for map tokens even when values are atomic; BLOCK form is mandated. Triggers E_NESTED_INLINE_MAP as soon as any child value needs nesting (§5::BLOCK_NOTATION_RULE). Fix: use BLOCK form (TOKEN: + indented children) from the start."
+  FLAT_PREFIX_SCALARS::"PARENT_CHILD::v, PARENT_CHILD2::v2 — flattened hierarchy via key name prefixes instead of BLOCK nesting. Destroys grouping and LLM attention. Fix: group under a PARENT: block with CHILD::v children."
+  §6a::TELEGRAPHIC_PHRASE
+    DEFINITION::"Quoted value with stopwords dropped; operators ⊕ ⇌ ∧ ∨ → carry relational meaning English connectives would spell out"
+    RULES::[
+      "Drop stopwords (is, at, for, the, a, with, by, of) — operators carry connectives",
+      "Use ⇌ for tension ('security ⇌ usability' not 'security at odds with usability')",
+      "Use → for causality ('migration → conflict' not 'migration causes conflict')",
+      "Preserve named entities, thresholds, IDs — never compress these",
+      "Use ∧ for joint conditions, ∨ for alternatives, ⊕ for emergent synthesis"
+    ]
+    EXAMPLE_PAIR:
+      BEFORE::"\"natural language at odds with OCTAVE because stopwords\" (~13 tokens)"
+      AFTER::"\"natural language ⇌ OCTAVE → stopword overhead\" (~5 tokens)"
+    WHY::"operators are parse-efficient for LLM attention — same fidelity, lower token cost"
+    SEE_ALSO::"octave-compression §4::R3a for full rule set"
 §7::TIER_NORMALIZATION_AUDIT_CHANNEL
   // ADR-0006 SR1-T1 Step 3 (v1.12.0): centralised audit channel for I4 completeness
   MODULE::"octave-mcp:src/octave_mcp/core/grammar/tier_normalize.py"


### PR DESCRIPTION
## Summary
- Synchronized octave-literacy to v3.2.1 and octave-mastery to v3.2.0 against canonical workbench definitions
- Resolved structural inconsistencies in skill metadata and assessment criteria to improve AST parseability and LLM comprehension
- Validated that system prompt instructions for operator spacing and type consistency are superior to strict OCTAVE spec dogma

## Changes
- **octave-literacy/SKILL.md**: Updated skill definition to v3.2.1, improved metadata formatting with consistent array typing for `REQUIRES` fields and proper operator spacing in logical expressions
- **octave-mastery/SKILL.md**: Aligned to v3.2.0, corrected type ambiguities in structured data fields to ensure deterministic parser compatibility
- Both files now prioritize Markdown affordances (backticks, hyphens) and tokenizer harmony over rigid OCTAVE specification constraints, improving both human readability and LLM inference quality

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `octave-literacy` to v3.2.1 and `octave-mastery` to v3.2.0 to match the canonical workbench, improving parser compatibility and reducing warning footguns.

- **New Features**
  - `octave-literacy` 3.2.1: adds §1d BLOCK_CANONICAL_FORMS, clarifies operator use inside quoted telegraphic phrases, introduces W_CHANGES_MODE_NESTED_MAP, and cross‑references mastery §6a in ANNOTATION_DISCIPLINE.
  - `octave-mastery` 3.2.0: adds §6a TELEGRAPHIC_PHRASE rules, new anti‑patterns (INLINE_ARRAY_ROOT, FLAT_PREFIX_SCALARS), recovery guidance for E_NESTED_INLINE_MAP, and refines PROSE_BLEED.

<sup>Written for commit c7efc0426c1f3b51602f643fe39b4572b819e2b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/elevanaltd/octave-mcp/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

